### PR TITLE
Add agentskills.io YAML frontmatter to SKILL.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ To add a new plugin:
 
 1. Create `plugins/<name>/` with the standard structure
 2. Add a `.claude-plugin/plugin.json` manifest
-3. Register it in `.claude-plugin/marketplace.json`
-4. Submit a PR
+3. All SKILL.md files must include YAML frontmatter per the [agentskills.io spec](https://agentskills.io/specification)
+4. Register it in `.claude-plugin/marketplace.json`
+5. Submit a PR
 
 ## License
 

--- a/plugins/plantuml-sync/commands/plantuml-validate/SKILL.md
+++ b/plugins/plantuml-sync/commands/plantuml-validate/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: plantuml-validate
+description: >
+  Validate that all PlantUML diagram URLs in markdown files match their
+  source blocks. Reports missing or stale URLs and offers auto-fix.
+compatibility: Requires Python 3.x
+---
+
 # PlantUML Validate
 
 Validate that all PlantUML diagram URLs in markdown files are in sync with their source blocks.

--- a/plugins/plantuml-sync/skills/plantuml-diagram-guide/SKILL.md
+++ b/plugins/plantuml-sync/skills/plantuml-diagram-guide/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: plantuml-diagram-guide
+description: >
+  Comprehensive catalog of PlantUML diagram types with selection guidance.
+  Use when choosing which diagram type fits a documentation task — covers
+  sequence, activity, state, class, ER, component, and 10 more types.
+---
+
 # PlantUML Diagram Type Guide
 
 Use this guide to choose the right PlantUML diagram type for documentation. When creating or updating `.md` files, proactively suggest and use the appropriate diagram type.

--- a/plugins/statusline/commands/statusline-setup/SKILL.md
+++ b/plugins/statusline/commands/statusline-setup/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: statusline-setup
+description: >
+  Configure the Claude Code custom statusline showing API rate limits,
+  context window usage, git branch, and model info.
+compatibility: Requires jq, curl, and macOS Keychain
+---
+
 # Statusline Setup
 
 Configure the Claude Code custom statusline with API rate limits, context window usage, git branch, and model info.


### PR DESCRIPTION
## Summary

- Add YAML frontmatter to all 3 SKILL.md files following the [agentskills.io specification](https://agentskills.io/specification)
- Enables cross-agent discoverability (Claude Code, Cursor, Gemini CLI, VS Code, OpenAI Codex, etc.)

Closes #1

## Changes

| File | Frontmatter added |
|------|-------------------|
| `plantuml-sync/skills/plantuml-diagram-guide/SKILL.md` | `name`, `description` |
| `plantuml-sync/commands/plantuml-validate/SKILL.md` | `name`, `description`, `compatibility` |
| `statusline/commands/statusline-setup/SKILL.md` | `name`, `description`, `compatibility` |

## Credit

Inspired by @kintecus's agentskills.io migration work in Tribe-Coding/stone-scriber#60.

## Test plan

- [ ] Skills are discovered by Claude Code from the new frontmatter
- [ ] Frontmatter validates against agentskills.io spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)