### PR TITLE
Add proactive diagram directive and agentskills.io reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A marketplace of reusable Claude Code plugins (`Tribe Coding`). Each plugin lives under `plugins/<name>/` and follows the Claude Code plugin spec. The marketplace manifest is `.claude-plugin/marketplace.json`.
+
+## Plugins
+
+### plantuml-sync
+Keeps PlantUML diagram image URLs in sync with their source blocks in markdown files.
+
+Key components:
+- `scripts/plantuml-encode.py` — core encoder/validator. Modes: `--sync` (auto-fix), `--check` (CI validation), stdin (encode raw text). Uses zlib deflate + PlantUML's custom base64 alphabet.
+- `scripts/sync-plantuml.sh` — PostToolUse hook (runs after every Write/Edit on `.md` files), calls `plantuml-encode.py --sync`
+- `scripts/inject-base-rules.sh` — SessionStart hook, outputs ~200 tokens of formatting rules so Claude knows the two-part pattern (code block + image link)
+- `scripts/setup-project.sh` — SessionStart hook, installs git pre-commit hook in `.githooks/` and sets `core.hooksPath`
+- `templates/pre-commit` — blocks commits when PlantUML URLs are stale
+- `templates/plantuml-sync.yml` — GitHub Actions workflow for PR checks
+- `skills/plantuml-diagram-guide/` — on-demand skill with full diagram type catalog
+- `commands/plantuml-validate/` — user-invocable `/plantuml-validate` command
+
+### statusline
+Custom Claude Code statusline showing real-time session info.
+
+Key components:
+- `scripts/statusline.sh` — main script, reads JSON from stdin (piped by Claude Code), outputs ANSI-colored status line. Fetches Anthropic OAuth usage API (cached 60s in `/tmp/claude-statusline-usage-cache`), reads OAuth token from macOS Keychain
+- `scripts/setup-statusline.sh` — SessionStart hook, copies `statusline.sh` to `~/.claude/statusline.sh`
+- `commands/statusline-setup/` — user-invocable `/statusline-setup` command, configures `~/.claude/settings.json`
+
+## Plugin Structure Convention
+
+```
+plugins/<name>/
+├── .claude-plugin/plugin.json    # manifest (name, version, commands, skills, hooks)
+├── hooks/hooks.json              # hook definitions (PostToolUse, SessionStart)
+├── scripts/                      # shell/python scripts called by hooks
+├── commands/<cmd>/SKILL.md       # user-invocable slash commands
+├── skills/<skill>/SKILL.md       # on-demand context-efficient skills
+└── templates/                    # project templates (pre-commit, CI)
+```
+
+## Skills Standard
+
+All SKILL.md files must follow the [agentskills.io specification](https://agentskills.io/specification):
+- YAML frontmatter with `name` and `description` is required
+- Optional: `compatibility`, `license`, `metadata`
+- When creating or editing SKILL.md files, always include valid frontmatter
+
+## Adding a New Plugin
+
+1. Create `plugins/<name>/` with the structure above
+2. Add `.claude-plugin/plugin.json` manifest
+3. All SKILL.md files must include YAML frontmatter per the [agentskills.io spec](https://agentskills.io/specification)
+4. Register in `.claude-plugin/marketplace.json`
+
+## Dependencies
+
+- plantuml-sync: Python 3.x, git
+- statusline: jq, curl, macOS Keychain (for Anthropic OAuth token)

--- a/plugins/plantuml-sync/scripts/inject-base-rules.sh
+++ b/plugins/plantuml-sync/scripts/inject-base-rules.sh
@@ -20,11 +20,14 @@ Alice -> Bob: Hello
 
 ![Sequence Diagram](https://www.plantuml.com/plantuml/svg/<encoded>)
 
+Proactive usage:
+- When creating or updating `.md` documentation files, proactively add PlantUML diagrams to illustrate architecture, sequences, state machines, data flow, and component relationships.
+- When explaining architecture or flows in the terminal, render diagrams as ASCII art using box-drawing characters — do NOT paste raw PlantUML source.
+- Use the `plantuml-diagram-guide` skill to choose the right diagram type for the task.
+
 Rules:
 - Always keep both parts in sync. When you modify PlantUML source, the PostToolUse hook auto-updates the image URL.
 - Use SVG format (`/svg/` path) unless PNG is specifically requested.
 - The alt text in the image link should be a short description of the diagram.
 - Place a blank line between the closing ``` and the image link.
-- In terminal/TUI interactions, render diagrams as ASCII art using box-drawing characters — do NOT paste raw PlantUML source.
-- For the full diagram type catalog (sequence, activity, state, class, ER, etc.), invoke the `plantuml-diagram-guide` skill.
 RULES


### PR DESCRIPTION
## Summary

- **inject-base-rules.sh**: Add "Proactive usage" section — Claude now proactively suggests PlantUML diagrams when editing `.md` documentation, instead of waiting to be asked
- **CLAUDE.md**: Add "Skills Standard" section referencing [agentskills.io spec](https://agentskills.io/specification), update "Adding a New Plugin" with frontmatter requirement

Closes #3

## Changes

| File | Change |
|------|--------|
| `plugins/plantuml-sync/scripts/inject-base-rules.sh` | Add 3-line "Proactive usage" block before "Rules" |
| `CLAUDE.md` | Add "Skills Standard" section, add step 3 to "Adding a New Plugin" |

## Test plan

- [ ] Start new session with plantuml-sync installed — verify proactive directive is in context
- [ ] Edit a `.md` doc file — Claude should suggest adding diagrams
- [ ] Create a new SKILL.md — Claude should include YAML frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)