### PR TITLE
Add SKILL.md links and type glossary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ A marketplace of reusable plugins for [Claude Code](https://docs.anthropic.com/e
 | **statusline** | hook | SessionStart | *automatic* | Install statusline script to `~/.claude/` |
 | | command | [`statusline-setup`](plugins/statusline/commands/statusline-setup/SKILL.md) | `/statusline:statusline-setup` | Configure statusline in `~/.claude/settings.json` |
 
-> **hook** — runs automatically in response to events (e.g. after every file edit or on session start). No user action needed.
-> **command** — a `/slash-command` that the user invokes explicitly when needed.
-> **skill** — reference material that Claude loads on-demand when it decides the context is relevant.
+> - **hook** — runs automatically in response to events (e.g. after every file edit or on session start). No user action needed.
+> - **command** — a `/slash-command` that the user invokes explicitly when needed.
+> - **skill** — reference material that Claude loads on-demand when it decides the context is relevant.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Link command/skill names in the quick reference table to their SKILL.md files for easy navigation
- Add hook/command/skill type glossary right after the table explaining the difference
- Note that plugin auto-updates are applied on the next Claude Code restart

## Test plan
- [ ] Verify SKILL.md links resolve correctly on GitHub
- [ ] Verify blockquote glossary renders properly in markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)