### PR TITLE
Add workaround for plugin cache invalidation bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,19 @@ Inside scripts, use a fallback so they work both as hooks and when run directly:
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 ```
 
+## Plugin Cache Workaround
+
+Claude Code has a bug where the plugin cache (`~/.claude/plugins/cache/`) is not invalidated when the marketplace source (`~/.claude/plugins/marketplaces/`) is updated via auto-update. `CLAUDE_PLUGIN_ROOT` points to the stale cached version.
+
+Upstream issues:
+- [#14061](https://github.com/anthropics/claude-code/issues/14061) — `/plugin update` doesn't invalidate cache
+- [#15621](https://github.com/anthropics/claude-code/issues/15621) — old versions not removed, their hooks still run
+- [#15642](https://github.com/anthropics/claude-code/issues/15642) — `CLAUDE_PLUGIN_ROOT` points to stale version
+
+**Workaround:** Each plugin includes a `scripts/sync-plugin-cache.sh` SessionStart hook (first in the list) that copies the entire plugin directory from marketplace into the cache on every session start. This ensures scripts, skills, commands, and hook configs are always up to date.
+
+The script is intentionally simple and stable — since the cached copy runs first (bootstrapping), it must not require changes to function correctly.
+
 ## Adding a New Plugin
 
 1. Create `plugins/<name>/` with the structure above

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ A marketplace of reusable plugins for [Claude Code](https://docs.anthropic.com/e
 
 | Plugin | Type | Name | Invocation | Description |
 |--------|------|------|------------|-------------|
-| **plantuml** | hook | PostToolUse | *automatic* | Auto-sync PlantUML image URLs on `.md` edits |
+| **plantuml** | hook | SessionStart | *automatic* | **FIXME:** Sync plugin cache from marketplace source ([#13](https://github.com/Tribe-Coding/claude-plugins/issues/13)) |
+| | hook | PostToolUse | *automatic* | Auto-sync PlantUML image URLs on `.md` edits |
 | | hook | SessionStart | *automatic* | Inject base formatting rules + install pre-commit hook |
 | | command | [`plantuml-validate`](plugins/plantuml/commands/plantuml-validate/SKILL.md) | `/plantuml:plantuml-validate` | Check all diagram URLs are in sync |
 | | skill | [`plantuml-diagram-guide`](plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md) | *on-demand* | Full catalog of 16 diagram types with selection guide |
-| **statusline** | hook | SessionStart | *automatic* | Install statusline script to `~/.claude/` |
+| **statusline** | hook | SessionStart | *automatic* | **FIXME:** Sync plugin cache from marketplace source ([#13](https://github.com/Tribe-Coding/claude-plugins/issues/13)) |
+| | hook | SessionStart | *automatic* | Install statusline script to `~/.claude/` |
 | | command | [`statusline-setup`](plugins/statusline/commands/statusline-setup/SKILL.md) | `/statusline:statusline-setup` | Configure statusline in `~/.claude/settings.json` |
 
 > - **hook** — runs automatically in response to events (e.g. after every file edit or on session start). No user action needed.
@@ -100,6 +102,19 @@ plugins/<name>/
 - `jq` — JSON processing
 - `curl` — API requests
 - macOS Keychain access (for Anthropic OAuth token)
+
+## Known Issues
+
+### Plugin cache not invalidated on auto-update
+
+Claude Code has a bug where auto-updating a marketplace does not invalidate the plugin cache. `CLAUDE_PLUGIN_ROOT` continues to point at stale cached files, so updated scripts, skills, and commands are not picked up.
+
+**Upstream issues:**
+- [anthropics/claude-code#14061](https://github.com/anthropics/claude-code/issues/14061) — `/plugin update` doesn't invalidate cache
+- [anthropics/claude-code#15621](https://github.com/anthropics/claude-code/issues/15621) — old versions not removed, their hooks still run
+- [anthropics/claude-code#15642](https://github.com/anthropics/claude-code/issues/15642) — `CLAUDE_PLUGIN_ROOT` points to stale version
+
+**Workaround:** All plugins in this marketplace include a `sync-plugin-cache.sh` SessionStart hook that copies fresh content from the marketplace source into the cache on every session start. No user action is needed — the workaround is automatic and will be removed once the upstream bugs are fixed.
 
 ## Contributing
 

--- a/plugins/plantuml/hooks/hooks.json
+++ b/plugins/plantuml/hooks/hooks.json
@@ -17,6 +17,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/sync-plugin-cache.sh\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/inject-base-rules.sh\"",
             "timeout": 10
           },

--- a/plugins/plantuml/scripts/sync-plugin-cache.sh
+++ b/plugins/plantuml/scripts/sync-plugin-cache.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Workaround for Claude Code plugin cache bug.
+# Copies plugin content from marketplace source into the stale cache directory.
+#
+# Upstream issues:
+#   https://github.com/anthropics/claude-code/issues/14061
+#   https://github.com/anthropics/claude-code/issues/15621
+#   https://github.com/anthropics/claude-code/issues/15642
+#
+# This script must remain simple and stable — it bootstraps itself
+# (the cached copy runs first, then overwrites itself with the new version).
+
+set -euo pipefail
+
+CACHE_DIR="${CLAUDE_PLUGIN_ROOT:-}"
+[ -z "$CACHE_DIR" ] && exit 0
+
+# Extract marketplace and plugin names from cache path:
+#   ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/
+PLUGINS_BASE="${HOME}/.claude/plugins"
+# Strip the common prefix to get: <marketplace>/<plugin>/<version>
+relative="${CACHE_DIR#"${PLUGINS_BASE}/cache/"}"
+# If stripping failed (path doesn't match), bail out silently
+[ "$relative" = "$CACHE_DIR" ] && exit 0
+
+marketplace="${relative%%/*}"
+rest="${relative#*/}"
+plugin="${rest%%/*}"
+
+MARKETPLACE_DIR="${PLUGINS_BASE}/marketplaces/${marketplace}/plugins/${plugin}"
+
+# If marketplace source doesn't exist, nothing to sync
+[ -d "$MARKETPLACE_DIR" ] || exit 0
+
+# Copy marketplace content into cache, overwriting stale files
+cp -rf "$MARKETPLACE_DIR"/ "$CACHE_DIR"/ 2>/dev/null || {
+    echo "warning: sync-plugin-cache: failed to sync ${plugin} from marketplace to cache" >&2
+}

--- a/plugins/statusline/hooks/hooks.json
+++ b/plugins/statusline/hooks/hooks.json
@@ -5,6 +5,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/sync-plugin-cache.sh\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-statusline.sh\"",
             "timeout": 10
           }

--- a/plugins/statusline/scripts/sync-plugin-cache.sh
+++ b/plugins/statusline/scripts/sync-plugin-cache.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Workaround for Claude Code plugin cache bug.
+# Copies plugin content from marketplace source into the stale cache directory.
+#
+# Upstream issues:
+#   https://github.com/anthropics/claude-code/issues/14061
+#   https://github.com/anthropics/claude-code/issues/15621
+#   https://github.com/anthropics/claude-code/issues/15642
+#
+# This script must remain simple and stable — it bootstraps itself
+# (the cached copy runs first, then overwrites itself with the new version).
+
+set -euo pipefail
+
+CACHE_DIR="${CLAUDE_PLUGIN_ROOT:-}"
+[ -z "$CACHE_DIR" ] && exit 0
+
+# Extract marketplace and plugin names from cache path:
+#   ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/
+PLUGINS_BASE="${HOME}/.claude/plugins"
+# Strip the common prefix to get: <marketplace>/<plugin>/<version>
+relative="${CACHE_DIR#"${PLUGINS_BASE}/cache/"}"
+# If stripping failed (path doesn't match), bail out silently
+[ "$relative" = "$CACHE_DIR" ] && exit 0
+
+marketplace="${relative%%/*}"
+rest="${relative#*/}"
+plugin="${rest%%/*}"
+
+MARKETPLACE_DIR="${PLUGINS_BASE}/marketplaces/${marketplace}/plugins/${plugin}"
+
+# If marketplace source doesn't exist, nothing to sync
+[ -d "$MARKETPLACE_DIR" ] || exit 0
+
+# Copy marketplace content into cache, overwriting stale files
+cp -rf "$MARKETPLACE_DIR"/ "$CACHE_DIR"/ 2>/dev/null || {
+    echo "warning: sync-plugin-cache: failed to sync ${plugin} from marketplace to cache" >&2
+}


### PR DESCRIPTION
## Summary

- Add `sync-plugin-cache.sh` SessionStart hook to both plugins that copies marketplace source into the cache on every session start, working around Claude Code's stale cache bug
- Document the workaround in CLAUDE.md and README.md (Known Issues section)
- Link to upstream issues: anthropics/claude-code#14061, #15621, #15642

Closes #13

## Test plan

- [ ] Remove plugin cache: `rm -rf ~/.claude/plugins/cache/tribe-coding/statusline/`
- [ ] Reinstall plugin (creates cache with old SHA)
- [ ] Push a change to a script in the marketplace
- [ ] Restart Claude Code — verify cache is updated with fresh content
- [ ] Verify skills and commands also reflect the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)