### PR TITLE
Use rsync --delete to remove stale files from plugin cache

### DIFF
--- a/plugins/plantuml/scripts/sync-plugin-cache.sh
+++ b/plugins/plantuml/scripts/sync-plugin-cache.sh
@@ -32,7 +32,7 @@ MARKETPLACE_DIR="${PLUGINS_BASE}/marketplaces/${marketplace}/plugins/${plugin}"
 # If marketplace source doesn't exist, nothing to sync
 [ -d "$MARKETPLACE_DIR" ] || exit 0
 
-# Copy marketplace content into cache, overwriting stale files
-cp -rf "$MARKETPLACE_DIR"/ "$CACHE_DIR"/ 2>/dev/null || {
+# Sync marketplace content into cache, removing deleted files
+rsync -a --delete "$MARKETPLACE_DIR"/ "$CACHE_DIR"/ 2>/dev/null || {
     echo "warning: sync-plugin-cache: failed to sync ${plugin} from marketplace to cache" >&2
 }

--- a/plugins/statusline/scripts/sync-plugin-cache.sh
+++ b/plugins/statusline/scripts/sync-plugin-cache.sh
@@ -32,7 +32,7 @@ MARKETPLACE_DIR="${PLUGINS_BASE}/marketplaces/${marketplace}/plugins/${plugin}"
 # If marketplace source doesn't exist, nothing to sync
 [ -d "$MARKETPLACE_DIR" ] || exit 0
 
-# Copy marketplace content into cache, overwriting stale files
-cp -rf "$MARKETPLACE_DIR"/ "$CACHE_DIR"/ 2>/dev/null || {
+# Sync marketplace content into cache, removing deleted files
+rsync -a --delete "$MARKETPLACE_DIR"/ "$CACHE_DIR"/ 2>/dev/null || {
     echo "warning: sync-plugin-cache: failed to sync ${plugin} from marketplace to cache" >&2
 }


### PR DESCRIPTION
## Summary

- Switch `sync-plugin-cache.sh` from `cp -rf` to `rsync -a --delete` so that files removed in new versions are also cleaned up from the cache

## Test plan

- [ ] Add a dummy file to the cache, verify it gets removed after session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)