### PR TITLE
Fix broken script paths in plantuml plugin

### DIFF
--- a/plugins/plantuml/commands/plantuml-validate/SKILL.md
+++ b/plugins/plantuml/commands/plantuml-validate/SKILL.md
@@ -19,9 +19,9 @@ Validate that all PlantUML diagram URLs in markdown files are in sync with their
 
 2. Run the validation check on all found files:
    ```bash
-   python3 "$(dirname "$0")/../../scripts/plantuml-encode.py" --check <files>
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/plantuml-encode.py" --check <files>
    ```
-   If `plantuml-encode.py` is not found at the plugin path, look for it at `$CLAUDE_PROJECT_DIR/scripts/plantuml-encode.py`.
+   `CLAUDE_PLUGIN_ROOT` is set automatically by Claude Code when running plugin commands.
 
 3. Report results to the user:
    - If all diagrams are in sync: confirm success with file count
@@ -30,5 +30,5 @@ Validate that all PlantUML diagram URLs in markdown files are in sync with their
 
 4. If the user confirms auto-fix, run:
    ```bash
-   python3 plantuml-encode.py --sync <affected-files>
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/plantuml-encode.py" --sync <affected-files>
    ```

--- a/plugins/plantuml/templates/pre-commit
+++ b/plugins/plantuml/templates/pre-commit
@@ -8,7 +8,7 @@ if [ -n "$STAGED_MD" ]; then
     # Find the encoder script: check plugin cache locations, then project fallback
     ENCODER=""
     for candidate in \
-        "$HOME/.claude/plugins/plantuml/scripts/plantuml-encode.py" \
+        "$HOME/.claude/plugins/marketplaces/tribe-coding/plugins/plantuml/scripts/plantuml-encode.py" \
         "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/plantuml-encode.py"; do
         if [ -f "$candidate" ]; then
             ENCODER="$candidate"


### PR DESCRIPTION
## Summary

- **plantuml-validate/SKILL.md**: Replace `$(dirname "$0")` (resolves to shell binary, not plugin dir) with `${CLAUDE_PLUGIN_ROOT}` for both `--check` and `--sync` commands
- **templates/pre-commit**: Replace non-existent cache path (`~/.claude/plugins/plantuml/`) with marketplace source path (`~/.claude/plugins/marketplaces/tribe-coding/plugins/plantuml/`) — stable, no version number, always current after auto-update

## Test plan

- [ ] Run `/plantuml-validate` in a project with PlantUML diagrams — verify it finds and executes `plantuml-encode.py`
- [ ] Install the pre-commit hook via `setup-project.sh`, stage a `.md` file with PlantUML, and verify the hook finds the encoder

🤖 Generated with [Claude Code](https://claude.com/claude-code)