### PR TITLE
Pull latest marketplace content before syncing to cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ Upstream issues:
 - [#15621](https://github.com/anthropics/claude-code/issues/15621) — old versions not removed, their hooks still run
 - [#15642](https://github.com/anthropics/claude-code/issues/15642) — `CLAUDE_PLUGIN_ROOT` points to stale version
 
-**Workaround:** Each plugin includes a `scripts/sync-plugin-cache.sh` SessionStart hook (first in the list) that copies the entire plugin directory from marketplace into the cache on every session start. This ensures scripts, skills, commands, and hook configs are always up to date.
+**Workaround:** Each plugin includes a `scripts/sync-plugin-cache.sh` SessionStart hook (first in the list) that pulls the latest marketplace content from remote (`git pull --depth=1`, 3s timeout) and then copies it into the cache on every session start. A flag file (`/tmp/claude-marketplace-pull-<name>`) prevents duplicate pulls when multiple plugins from the same marketplace start in the same session. This ensures scripts, skills, commands, and hook configs are always up to date.
 
 The script is intentionally simple and stable — since the cached copy runs first (bootstrapping), it must not require changes to function correctly.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Claude Code has a bug where auto-updating a marketplace does not invalidate the 
 - [anthropics/claude-code#15621](https://github.com/anthropics/claude-code/issues/15621) — old versions not removed, their hooks still run
 - [anthropics/claude-code#15642](https://github.com/anthropics/claude-code/issues/15642) — `CLAUDE_PLUGIN_ROOT` points to stale version
 
-**Workaround:** All plugins in this marketplace include a `sync-plugin-cache.sh` SessionStart hook that copies fresh content from the marketplace source into the cache on every session start. No user action is needed — the workaround is automatic and will be removed once the upstream bugs are fixed.
+**Workaround:** All plugins in this marketplace include a `sync-plugin-cache.sh` SessionStart hook that pulls the latest marketplace content from remote (`git pull --depth=1`, 3s timeout) and then copies it into the cache on every session start. A flag file (`/tmp/claude-marketplace-pull-<name>`) prevents duplicate pulls when multiple plugins from the same marketplace start in the same session. No user action is needed — the workaround is automatic and will be removed once the upstream bugs are fixed.
 
 ## Contributing
 

--- a/plugins/plantuml/scripts/sync-plugin-cache.sh
+++ b/plugins/plantuml/scripts/sync-plugin-cache.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Workaround for Claude Code plugin cache bug.
-# Copies plugin content from marketplace source into the stale cache directory.
+# Pulls latest marketplace content via git, then copies into stale cache directory.
 #
 # Upstream issues:
 #   https://github.com/anthropics/claude-code/issues/14061
@@ -28,11 +28,35 @@ rest="${relative#*/}"
 plugin="${rest%%/*}"
 
 MARKETPLACE_DIR="${PLUGINS_BASE}/marketplaces/${marketplace}/plugins/${plugin}"
+REPO_DIR="${PLUGINS_BASE}/marketplaces/${marketplace}"
 
 # If marketplace source doesn't exist, nothing to sync
 [ -d "$MARKETPLACE_DIR" ] || exit 0
 
-# Sync marketplace content into cache, removing deleted files
+# --- Pull latest from remote (once per session) ---
+# Flag file prevents duplicate pulls when multiple plugins from the same marketplace
+# each run their own copy of this script within the same session start.
+PULL_FLAG="/tmp/claude-marketplace-pull-${marketplace}"
+pull_needed=true
+
+if [ -f "$PULL_FLAG" ]; then
+    flag_age=$(( $(date +%s) - $(stat -f %m "$PULL_FLAG" 2>/dev/null || echo 0) ))
+    [ "$flag_age" -lt 60 ] && pull_needed=false
+fi
+
+if [ "$pull_needed" = true ] && [ -d "$REPO_DIR/.git" ]; then
+    TIMEOUT_CMD=""
+    if command -v timeout &>/dev/null; then
+        TIMEOUT_CMD="timeout 3"
+    elif command -v gtimeout &>/dev/null; then
+        TIMEOUT_CMD="gtimeout 3"
+    fi
+
+    $TIMEOUT_CMD git -C "$REPO_DIR" pull --depth=1 origin main &>/dev/null || true
+    touch "$PULL_FLAG" 2>/dev/null || true
+fi
+
+# --- Sync marketplace content into cache ---
 rsync -a --delete "$MARKETPLACE_DIR"/ "$CACHE_DIR"/ 2>/dev/null || {
     echo "warning: sync-plugin-cache: failed to sync ${plugin} from marketplace to cache" >&2
 }

--- a/plugins/statusline/scripts/sync-plugin-cache.sh
+++ b/plugins/statusline/scripts/sync-plugin-cache.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Workaround for Claude Code plugin cache bug.
-# Copies plugin content from marketplace source into the stale cache directory.
+# Pulls latest marketplace content via git, then copies into stale cache directory.
 #
 # Upstream issues:
 #   https://github.com/anthropics/claude-code/issues/14061
@@ -28,11 +28,35 @@ rest="${relative#*/}"
 plugin="${rest%%/*}"
 
 MARKETPLACE_DIR="${PLUGINS_BASE}/marketplaces/${marketplace}/plugins/${plugin}"
+REPO_DIR="${PLUGINS_BASE}/marketplaces/${marketplace}"
 
 # If marketplace source doesn't exist, nothing to sync
 [ -d "$MARKETPLACE_DIR" ] || exit 0
 
-# Sync marketplace content into cache, removing deleted files
+# --- Pull latest from remote (once per session) ---
+# Flag file prevents duplicate pulls when multiple plugins from the same marketplace
+# each run their own copy of this script within the same session start.
+PULL_FLAG="/tmp/claude-marketplace-pull-${marketplace}"
+pull_needed=true
+
+if [ -f "$PULL_FLAG" ]; then
+    flag_age=$(( $(date +%s) - $(stat -f %m "$PULL_FLAG" 2>/dev/null || echo 0) ))
+    [ "$flag_age" -lt 60 ] && pull_needed=false
+fi
+
+if [ "$pull_needed" = true ] && [ -d "$REPO_DIR/.git" ]; then
+    TIMEOUT_CMD=""
+    if command -v timeout &>/dev/null; then
+        TIMEOUT_CMD="timeout 3"
+    elif command -v gtimeout &>/dev/null; then
+        TIMEOUT_CMD="gtimeout 3"
+    fi
+
+    $TIMEOUT_CMD git -C "$REPO_DIR" pull --depth=1 origin main &>/dev/null || true
+    touch "$PULL_FLAG" 2>/dev/null || true
+fi
+
+# --- Sync marketplace content into cache ---
 rsync -a --delete "$MARKETPLACE_DIR"/ "$CACHE_DIR"/ 2>/dev/null || {
     echo "warning: sync-plugin-cache: failed to sync ${plugin} from marketplace to cache" >&2
 }


### PR DESCRIPTION
## Summary

- `sync-plugin-cache.sh` now runs `git pull --depth=1 origin main` (3s timeout) on the marketplace repo **before** copying into the cache
- Fixes a race condition where Claude Code updates the marketplace AFTER SessionStart hooks run, causing the cache to be one session behind
- A flag file (`/tmp/claude-marketplace-pull-<name>`) prevents duplicate pulls when multiple plugins from the same marketplace start in the same session
- Updated workaround description in CLAUDE.md and README.md

Related: #13

## Test plan

- [ ] Remove flag file: `rm -f /tmp/claude-marketplace-pull-tribe-coding`
- [ ] Run manually: `CLAUDE_PLUGIN_ROOT=~/.claude/plugins/cache/tribe-coding/plantuml/1.0.0 bash plugins/plantuml/scripts/sync-plugin-cache.sh`
- [ ] Verify flag file created at `/tmp/claude-marketplace-pull-tribe-coding`
- [ ] Verify cache matches marketplace: `diff -r ~/.claude/plugins/cache/tribe-coding/plantuml/1.0.0/scripts/ ~/.claude/plugins/marketplaces/tribe-coding/plugins/plantuml/scripts/`
- [ ] Run second plugin within 60s — verify git pull is skipped (fast execution)
- [ ] Test with no network — script completes without error, rsync still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)