### PR TITLE
Add cross-platform (macOS + Linux) support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,34 @@ Inside scripts, use a fallback so they work both as hooks and when run directly:
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 ```
 
+## Cross-Platform Compatibility
+
+All scripts must work on both macOS and Linux. Use these patterns:
+
+**Platform detection:**
+```bash
+if [ "$(uname)" = "Darwin" ]; then
+  # macOS
+else
+  # Linux
+fi
+```
+
+**`stat` — file modification time:**
+- macOS: `stat -f %m "$file"`
+- Linux: `stat -c %Y "$file"`
+
+**`date` — parsing ISO timestamps:**
+- macOS: `date -juf "%Y-%m-%dT%H:%M:%S" "$str" +%s`
+- Linux: `date -ud "$str" +%s`
+
+**OAuth credentials** (priority order):
+1. `$CLAUDE_CODE_OAUTH_TOKEN` env var (any platform)
+2. macOS Keychain: `security find-generic-password -s "Claude Code-credentials" -w`
+3. Linux credentials file: `~/.claude/.credentials.json`
+
+**Shared `/tmp` files:** Always append `-${UID}` to avoid collisions in multi-user environments.
+
 ## Plugin Cache Sync
 
 Claude Code has a bug where the plugin cache is not invalidated on auto-update ([#14061](https://github.com/anthropics/claude-code/issues/14061), [#15621](https://github.com/anthropics/claude-code/issues/15621), [#15642](https://github.com/anthropics/claude-code/issues/15642)).
@@ -178,4 +206,4 @@ Claude Code has a bug where the plugin cache is not invalidated on auto-update (
 ## Dependencies
 
 - plantuml: Python 3.x, git
-- statusline: jq, curl, macOS Keychain (for Anthropic OAuth token)
+- statusline: jq, curl, python3; macOS Keychain or ~/.claude/.credentials.json on Linux (for Anthropic OAuth token)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ plugins/<name>/
 ### statusline
 - `jq` — JSON processing
 - `curl` — API requests
-- macOS Keychain access (for Anthropic OAuth token)
+- `python3` — OAuth token parsing (macOS)
+- macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
 
 ## Plugin Cache Sync
 

--- a/plugins/statusline/commands/statusline-setup/SKILL.md
+++ b/plugins/statusline/commands/statusline-setup/SKILL.md
@@ -3,7 +3,7 @@ name: statusline-setup
 description: >
   Configure the Claude Code custom statusline showing API rate limits,
   context window usage, git branch, and model info.
-compatibility: Requires jq, curl, and macOS Keychain
+compatibility: Requires jq and curl. macOS and Linux supported.
 ---
 
 # Statusline Setup

--- a/plugins/statusline/scripts/statusline.sh
+++ b/plugins/statusline/scripts/statusline.sh
@@ -47,7 +47,8 @@ dirty_info=""
 if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
   branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
   if [ -n "$branch" ]; then
-    if ! git -C "$cwd" diff-index --quiet HEAD -- 2>/dev/null || [ -n "$(git -C "$cwd" ls-files --others --exclude-standard 2>/dev/null)" ]; then
+    git_status_output=$(git -C "$cwd" status --porcelain=v1 --untracked-files=normal 2>/dev/null)
+    if [ -n "$git_status_output" ]; then
       git_info="   🌿 $(printf '\033[38;5;178m')${branch}$(printf '\033[0m')"
       dirty_info=" ⚠️"
     else
@@ -105,7 +106,7 @@ if [ -n "$used_pct" ]; then
 fi
 
 # Fetch usage data from Anthropic API (cached for 60 seconds)
-cache_file="/tmp/claude-statusline-usage-cache"
+cache_file="/tmp/claude-statusline-usage-cache-${UID}"
 cache_max_age=60
 now=$(date +%s)
 use_cache=false
@@ -126,7 +127,15 @@ usage_json=""
 if [ "$use_cache" = true ]; then
   usage_json=$(cat "$cache_file" 2>/dev/null)
 else
-  token=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['claudeAiOauth']['accessToken'])" 2>/dev/null)
+  # Cross-platform OAuth token retrieval
+  token=""
+  if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+    token="$CLAUDE_CODE_OAUTH_TOKEN"
+  elif [ "$(uname)" = "Darwin" ]; then
+    token=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['claudeAiOauth']['accessToken'])" 2>/dev/null)
+  elif [ -f "${HOME}/.claude/.credentials.json" ]; then
+    token=$(jq -r '.claudeAiOauth.accessToken' "${HOME}/.claude/.credentials.json" 2>/dev/null)
+  fi
   if [ -n "$token" ]; then
     usage_json=$(curl -s --connect-timeout 2 --max-time 3 \
       -H "Authorization: Bearer $token" \
@@ -151,7 +160,13 @@ parse_reset_epoch() {
     echo ""
     return
   fi
-  date -juf "%Y-%m-%dT%H:%M:%S" "$(echo "$resets_at" | sed 's/\.[0-9]*+00:00$//' | sed 's/+00:00$//')" +%s 2>/dev/null
+  local normalized
+  normalized=$(echo "$resets_at" | sed 's/\.[0-9]*+00:00$//' | sed 's/+00:00$//')
+  if [ "$(uname)" = "Darwin" ]; then
+    date -juf "%Y-%m-%dT%H:%M:%S" "$normalized" +%s 2>/dev/null
+  else
+    date -ud "$normalized" +%s 2>/dev/null
+  fi
 }
 
 # Format time remaining as human-readable string

--- a/scripts/claude-sync
+++ b/scripts/claude-sync
@@ -60,7 +60,11 @@ done
 
 # --- Check freshness window ---
 if [ "$force" = false ] && [ -f "$FRESHNESS_FILE" ]; then
-    last_run=$(stat -f %m "$FRESHNESS_FILE" 2>/dev/null || echo 0)
+    if [ "$(uname)" = "Darwin" ]; then
+      last_run=$(stat -f %m "$FRESHNESS_FILE" 2>/dev/null || echo 0)
+    else
+      last_run=$(stat -c %Y "$FRESHNESS_FILE" 2>/dev/null || echo 0)
+    fi
     now=$(date +%s)
     age=$(( now - last_run ))
     if [ "$age" -lt "$FRESHNESS_WINDOW" ]; then


### PR DESCRIPTION
## Summary

- **statusline.sh**: use `git status --porcelain` (simpler, works on initial commits), append `$UID` to cache file (multi-user safety), add cross-platform OAuth token retrieval (env var → Keychain → `~/.claude/.credentials.json`), make `parse_reset_epoch()` work with both BSD and GNU `date`
- **claude-sync**: add Linux fallback for `stat` (BSD `-f %m` → GNU `-c %Y`)
- **CLAUDE.md**: add Cross-Platform Compatibility guidelines section, update dependencies
- **README.md / SKILL.md**: update requirements to reflect Linux support

Supersedes #20 — includes fixes 1, 2, 4 from that PR, skips fix 3 (removing `2>/dev/null` from curl was a regression that would leak error output into `$usage_json`).

Closes #20

## Test plan

- [ ] On macOS: run `statusline.sh` with test JSON input — verify all segments render
- [ ] Shellcheck passes on `statusline.sh` and `claude-sync` (no new warnings)
- [ ] `$UID` resolves correctly in bash (`echo $UID`)
- [ ] `parse_reset_epoch "2025-01-15T10:30:00.000+00:00"` returns correct epoch
- [ ] On Linux: verify `stat -c %Y`, `date -ud`, and `~/.claude/.credentials.json` paths work

🤖 Generated with [Claude Code](https://claude.com/claude-code)