### PR TITLE
Make PlantUML skill invocation mandatory in SessionStart rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,13 @@ Example (plantuml `inject-base-rules.sh`):
 ```
 Proactive usage:
 - When creating or updating `.md` documentation files, proactively add PlantUML diagrams…
-- Use the `plantuml-diagram-guide` skill to choose the right diagram type.
+- **ALWAYS invoke the `plantuml-diagram-guide` skill BEFORE creating any PlantUML diagram**.
+  This is MANDATORY — do not skip this step even if you think you know which type to use.
 ```
 
 **Budget:** Keep injected text minimal. Every token costs context in every session, even when the plugin is irrelevant. Rules only — no catalogs, no examples.
+
+**Language:** Use imperative, unambiguous language for critical behavior. Words like "ALWAYS", "MUST", "MANDATORY" enforce strict compliance. Avoid soft language like "consider", "you may", "it's recommended".
 
 ### 2. Skill description — trigger-based suggestion
 

--- a/plugins/plantuml/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/plantuml/docs/ACCEPTANCE_TESTS.md
@@ -808,11 +808,12 @@ bash plugins/plantuml/scripts/inject-base-rules.sh | grep -A 5 "Proactive usage"
 Proactive usage:
 - When creating or updating `.md` documentation files, proactively add PlantUML diagrams...
 - When explaining architecture or flows in the terminal, render diagrams as ASCII art...
-- Use the `plantuml-diagram-guide` skill to choose the right diagram type for the task.
+- **ALWAYS invoke the `plantuml-diagram-guide` skill BEFORE creating any PlantUML diagram** to choose the correct diagram type. This is MANDATORY — do not skip this step even if you think you know which type to use.
 ```
 
 **Acceptance criteria:**
-- ✅ Contains explicit instruction: "Use the `plantuml-diagram-guide` skill"
+- ✅ Contains **MANDATORY** instruction: "ALWAYS invoke the `plantuml-diagram-guide` skill BEFORE creating any PlantUML diagram"
+- ✅ Uses imperative language: "ALWAYS", "MANDATORY", "do not skip"
 - ✅ Trigger: "When creating or updating `.md`" (automatic context)
 - ✅ No conditional phrasing like "if the user asks"
 

--- a/plugins/plantuml/scripts/inject-base-rules.sh
+++ b/plugins/plantuml/scripts/inject-base-rules.sh
@@ -23,7 +23,7 @@ Alice -> Bob: Hello
 Proactive usage:
 - When creating or updating `.md` documentation files, proactively add PlantUML diagrams to illustrate architecture, sequences, state machines, data flow, and component relationships.
 - When explaining architecture or flows in the terminal, render diagrams as ASCII art using box-drawing characters — do NOT paste raw PlantUML source.
-- Use the `plantuml-diagram-guide` skill to choose the right diagram type for the task.
+- **ALWAYS invoke the `plantuml-diagram-guide` skill BEFORE creating any PlantUML diagram** to choose the correct diagram type. This is MANDATORY — do not skip this step even if you think you know which type to use.
 
 Rules:
 - Always keep both parts in sync. When you modify PlantUML source, the PostToolUse hook auto-updates the image URL.


### PR DESCRIPTION
## Problem

Manual verification of test 8.4 (issue #26) revealed that Claude does **NOT** invoke the `plantuml-diagram-guide` skill before creating diagrams, even though SessionStart rules instruct to "Use the skill".

### Test 8.4 Result: ⚠️ Partial Pass

| Criterion | Result |
|-----------|--------|
| Step 2: Rules present | ✅ PASS |
| Step 3: Proactive diagrams | ✅ PASS |
| Step 4: PostToolUse hook | ✅ PASS |
| **Step 5: Skill invocation** | **❌ FAIL** |

**Root cause:** SessionStart rules use soft language ("Use") instead of imperative commands, allowing Claude to skip skill invocation if it thinks it knows the answer.

## Solution

Strengthen SessionStart rules to make skill invocation **MANDATORY** using unambiguous imperative language.

### Changes

**Before:**
```
- Use the `plantuml-diagram-guide` skill to choose the right diagram type for the task.
```

**After:**
```
- **ALWAYS invoke the `plantuml-diagram-guide` skill BEFORE creating any PlantUML diagram**
  to choose the correct diagram type. This is MANDATORY — do not skip this step even if
  you think you know which type to use.
```

## Files Changed

### 1. `plugins/plantuml/scripts/inject-base-rules.sh`
- Changed from "Use the skill" → "ALWAYS invoke the skill BEFORE"
- Added "This is MANDATORY — do not skip"
- Made language unambiguous and imperative

### 2. `plugins/plantuml/docs/ACCEPTANCE_TESTS.md`
- Updated expected output in test 8.4 static verification
- Updated acceptance criteria to check for "ALWAYS", "MANDATORY", "do not skip"
- Reflects new stricter requirements

### 3. `CLAUDE.md`
- Updated example in "Proactive Plugin Behavior" section
- Added guideline: **"Use ALWAYS, MUST, MANDATORY for critical behavior"**
- Added note: "Avoid soft language like 'consider', 'you may', 'it's recommended'"

## Expected Impact

After this change, Claude will:
1. ✅ **ALWAYS invoke** the skill before creating diagrams (no exceptions)
2. ✅ Follow a **consistent decision-making process** (documented in skill invocation)
3. ✅ Provide **visibility** into diagram type selection (test 8.5 requirement)

This ensures test 8.4 Step 5 will pass:
```
Expected: Shows `plantuml-diagram-guide` skill was invoked
```

## Verification Steps

To verify this fix works, repeat test 8.4 in a fresh session:

1. Start fresh Claude Code session
2. Ask: "Create a README.md file documenting a simple authentication system"
3. Ask: "Show me your conversation history specifying what skills were called"
4. **Expected:** Claude reports invoking `plantuml-diagram-guide` skill

## Related

- Issue #26 - Manual verification needed: PlantUML SessionStart injection (test 8.4)
- PR #25 - Add comprehensive acceptance test documentation (merged)

## Checklist

- [x] Updated inject-base-rules.sh with imperative language
- [x] Updated ACCEPTANCE_TESTS.md expected output
- [x] Updated CLAUDE.md guidelines for SessionStart rules
- [x] Tested changes locally (script output verified)
- [ ] Manual verification in fresh session (pending)