### PR TITLE
Optimize plantuml-diagram-guide skill description (Option B+D)

### DIFF
--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
+++ b/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: plantuml-diagram-guide
 description: >
-  Comprehensive catalog of PlantUML diagram types with selection guidance.
-  Use when choosing which diagram type fits a documentation task — covers
-  sequence, activity, state, class, ER, component, and 10 more types.
+  Invoked automatically before creating PlantUML diagrams to select the correct type.
+  Covers 17 types: sequence, activity, state, class, ER, component, deployment,
+  timing, mindmap, gantt, WBS, JSON, YAML, network, object, usecase, wireframe.
+  Do NOT create PlantUML without consulting this guide.
+  Keywords: diagram type, which diagram, best diagram, choose diagram, UML.
 ---
 
 # PlantUML Diagram Type Guide


### PR DESCRIPTION
Implements Option B+D from issue #29 to optimize the `plantuml-diagram-guide` skill description for better discoverability and automatic invocation.

## Changes

### SKILL.md frontmatter description

**Before (236 chars, ~60 tokens):**
```yaml
description: >
  Comprehensive catalog of PlantUML diagram types with selection guidance.
  Use when choosing which diagram type fits a documentation task — covers
  sequence, activity, state, class, ER, component, and 10 more types.
```

**After (350 chars, ~90 tokens):**
```yaml
description: >
  Invoked automatically before creating PlantUML diagrams to select the correct type.
  Covers 17 types: sequence, activity, state, class, ER, component, deployment,
  timing, mindmap, gantt, WBS, JSON, YAML, network, object, usecase, wireframe.
  Do NOT create PlantUML without consulting this guide.
  Keywords: diagram type, which diagram, best diagram, choose diagram, UML.
```

### plugin.json version

- **Before:** `1.1.0`
- **After:** `1.2.0` (MINOR version bump per CLAUDE.md requirements)

## Improvements

✅ **Leads with action state** — "Invoked automatically" signals when/how the skill activates (not passive "Catalog")

✅ **Lists all 17 types explicitly** — Better visibility in `/skills` output (was "and 10 more types")

✅ **Adds WHEN NOT clause** — "Do NOT create PlantUML without consulting this guide" follows [Scott Spence best practice](https://scottspence.com/posts/how-to-make-claude-code-skills-activate-reliably)

✅ **Includes keywords** — "diagram type, which diagram, best diagram, choose diagram, UML" improves natural language intent matching

## Token Cost Impact

- **Delta:** +30 tokens (+50%)
- **Cost per session:** ~$0.00009 (with Sonnet at $0.003/1K input tokens)
- **Annual cost for 1000 sessions:** $0.09 (9 cents)
- **Verdict:** Negligible cost for measurably better discoverability

## Expected Benefits

1. **Better natural language matching** — Keywords help Claude match user queries like "which diagram should I use?"
2. **Clearer invocation signal** — "Invoked automatically" emphasizes it's part of the workflow
3. **Explicit negative case** — WHEN NOT clause reduces false negatives (skill not invoking when it should)
4. **Full type visibility** — All 17 types listed improves skill selection in `/skills` output

## Testing Checklist

- [x] Description appears correctly in SKILL.md frontmatter
- [ ] Test in fresh Claude Code session: `/skills` shows updated description
- [ ] Test natural language query: "which diagram type for API flows?" triggers skill
- [ ] Test automatic invocation: "create docs/test.md with architecture" invokes skill before creating diagrams
- [ ] Verify SessionStart MANDATORY enforcement still works (should, no changes to inject-base-rules.sh)

## Version Bump Rationale

**Type:** MINOR (1.1.0 → 1.2.0)

**Reason:** Enhancement (improved skill description for better discoverability) with no breaking changes.

Per CLAUDE.md semantic versioning requirements:
> **MINOR version (x.Y.0)** — New features, backwards-compatible:
> - Enhanced functionality that doesn't break existing usage
> - Non-breaking behavior changes

This change enhances discoverability without changing skill functionality or breaking existing workflows.

## References

- Closes #29
- Related: #28 (SessionStart MANDATORY skill invocation testing)
- CLAUDE.md: [Skill description best practices](https://github.com/Tribe-Coding/claude-plugins/blob/main/CLAUDE.md#2-skill-description--trigger-based-suggestion) (section 2)
- [Scott Spence: How to Make Claude Code Skills Activate Reliably](https://scottspence.com/posts/how-to-make-claude-code-skills-activate-reliably)