### PR TITLE
Fix marketplace-sync: run hooks on content change, use symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ A standalone script that runs *before* Claude Code starts. It pulls marketplace 
 ./scripts/install-sync.sh
 ```
 
-This copies `claude-marketplace-sync` to `~/.local/bin/`, adds it to `PATH`, and configures a shell alias so that `claude` automatically syncs before starting.
+This creates a symlink from `~/.local/bin/claude-marketplace-sync` to the script in the repo, adds it to `PATH`, and configures a shell alias so that `claude` automatically syncs before starting. Because it's a symlink, changes to the script in the repo are picked up immediately — no reinstall needed.
 
 **Usage:**
 
 ```bash
 claude-marketplace-sync              # Sync (skips if ran in last 5 min)
-claude-marketplace-sync --force      # Ignore freshness window
+claude-marketplace-sync --force      # Ignore freshness window; also re-runs SessionStart hooks
 claude-marketplace-sync --all        # Sync all marketplaces, not just autoUpdate ones
 claude-marketplace-sync --verbose    # Print detailed progress
 ```

--- a/scripts/claude-marketplace-sync
+++ b/scripts/claude-marketplace-sync
@@ -168,29 +168,42 @@ for key in $plugin_keys; do
     cache_base="${PLUGINS_DIR}/cache/${marketplace}/${plugin}"
     cache_dir="${cache_base}/${new_version}"
 
-    # Get old version from existing cache (if any)
-    old_version=""
-    if [ -d "$cache_dir" ]; then
-        old_plugin_json="${cache_dir}/.claude-plugin/plugin.json"
-        if [ -f "$old_plugin_json" ]; then
-            old_version=$(jq -r '.version // ""' "$old_plugin_json" 2>/dev/null || echo "")
-        fi
-    else
-        # Directory doesn't exist yet, create it
+    # Get current git SHA of the marketplace repo
+    current_sha=$(git -C "$marketplace_location" rev-parse HEAD 2>/dev/null || echo "")
+
+    # Get previously synced SHA and version from installed_plugins.json
+    old_version=$(jq -r --arg k "$key" '.plugins[$k][0].version // ""' "$INSTALLED_JSON" 2>/dev/null || echo "")
+    old_sha=$(jq -r --arg k "$key" '.plugins[$k][0].gitCommitSha // ""' "$INSTALLED_JSON" 2>/dev/null || echo "")
+
+    if [ ! -d "$cache_dir" ]; then
         mkdir -p "$cache_dir"
     fi
 
     log "Syncing ${key} → ${cache_dir}"
     if rsync -a --delete "${source_dir}/" "${cache_dir}/" 2>/dev/null; then
-        # Show update message only if version changed
-        if [ -n "$old_version" ] && [ "$old_version" != "$new_version" ]; then
+        # Determine if content changed: new version, new git SHA, first install, or --force
+        if [ -z "$old_version" ]; then
+            log_always "✅ Installed: ${key} version ${new_version}"
+            version_changed=true
+        elif [ "$old_version" != "$new_version" ]; then
             log_always "✅ Updated: ${key} version ${new_version}"
             version_changed=true
-        elif [ -z "$old_version" ]; then
-            log_always "✅ Installed: ${key} version ${new_version}"
+        elif [ -n "$current_sha" ] && [ "$old_sha" != "$current_sha" ]; then
+            log_always "✅ Updated: ${key} version ${new_version} (new commits)"
+            version_changed=true
+        elif [ "$force" = true ]; then
+            # --force: run hooks even if nothing changed
             version_changed=true
         else
             version_changed=false
+        fi
+
+        # Update gitCommitSha in installed_plugins.json so next run can compare
+        if [ -n "$current_sha" ] && [ "$version_changed" = true ]; then
+            jq --arg k "$key" --arg sha "$current_sha" \
+               '.plugins[$k][0].gitCommitSha = $sha' \
+               "$INSTALLED_JSON" > "${INSTALLED_JSON}.tmp" \
+            && mv "${INSTALLED_JSON}.tmp" "$INSTALLED_JSON"
         fi
         log "  synced OK"
 

--- a/scripts/install-sync.sh
+++ b/scripts/install-sync.sh
@@ -14,9 +14,8 @@ if [ ! -f "$SOURCE" ]; then
 fi
 
 mkdir -p "$DEST_DIR"
-cp "$SOURCE" "$DEST"
-chmod +x "$DEST"
-echo "Installed claude-marketplace-sync → ${DEST}"
+ln -sf "$SOURCE" "$DEST"
+echo "Installed claude-marketplace-sync → ${DEST} (symlink)"
 
 # --- Detect shell profile ---
 SHELL_NAME="$(basename "${SHELL:-/bin/bash}")"


### PR DESCRIPTION
## Summary

- **Bug fix**: `claude-marketplace-sync` now runs SessionStart hooks whenever plugin content changes, not just on version bump. Tracks `gitCommitSha` in `installed_plugins.json` — if SHA changed since last sync, hooks are executed even if version number is unchanged. This fixes the real-world case where `statusline.sh` (or other installed files) aren't updated after a push without a version bump.
- **Bug fix**: `--force` flag now always runs SessionStart hooks, regardless of SHA or version (previously only ran on version change).
- **Improvement**: `install-sync.sh` now creates a **symlink** instead of copying the script to `~/.local/bin/`. Changes to the script in the repo are picked up immediately — no reinstall needed.

## How it works now

| Scenario | Hooks run? |
|----------|-----------|
| New version (e.g. 1.2.0 → 1.3.0) | ✅ Yes |
| Same version, new git commits | ✅ Yes |
| First install | ✅ Yes |
| `--force` flag | ✅ Yes (always) |
| Nothing changed | ❌ No |

## Test plan

- [x] `claude-marketplace-sync --force --verbose` — runs hooks for all plugins
- [x] Second run without `--force` and no new commits — hooks not re-run
- [x] `install-sync.sh` creates symlink, verified with `ls -la ~/.local/bin/claude-marketplace-sync`
- [ ] Push a commit without version bump → run `claude-marketplace-sync` → verify hooks run and installed files update

🤖 Generated with [Claude Code](https://claude.com/claude-code)