### PR TITLE
Fix session cost widget: use correct field total_cost_usd

### DIFF
--- a/plugins/statusline/.claude-plugin/plugin.json
+++ b/plugins/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Three-line Claude Code statusline with enhanced resolution: 5h (30 blocks/10m), 7d (28 blocks/6h), extra usage (N blocks/1d). Features improved alignment, dimmed separators, and wide character support.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/statusline/scripts/statusline.sh
+++ b/plugins/statusline/scripts/statusline.sh
@@ -555,7 +555,7 @@ else
 fi
 
 # Session cost widget: 💵･$X.XX  (from total_cost_usd in stdin JSON)
-session_cost_usd=$(echo "$input" | jq -r '.cost.session_cost_usd // empty')
+session_cost_usd=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
 session_cost_widget=""
 session_cost_visible_width=0
 if [ -n "$session_cost_usd" ] && [ "$session_cost_usd" != "null" ]; then


### PR DESCRIPTION
## Summary
- The session cost widget (💵) was never displayed because the script read `.cost.session_cost_usd`, but Claude Code actually sends `.cost.total_cost_usd` in the statusline JSON
- Fixed field name in `statusline.sh` line 558
- Bump version 1.3.0 → 1.3.1

## Root cause
Discovered by logging the real JSON from Claude Code stdin:
```json
{
  "cost": {
    "total_cost_usd": 0.5351633,
    "total_duration_ms": 156574,
    ...
  }
}
```

## Test plan
- [ ] After `claude-marketplace-sync`, verify line 3 shows `💵･$X.XXXX` in statusline

🤖 Generated with [Claude Code](https://claude.com/claude-code)