### PR TITLE
Fix claude-marketplace-sync: remove duplicate startup log line

### DIFF
--- a/scripts/claude-marketplace-sync
+++ b/scripts/claude-marketplace-sync
@@ -106,8 +106,6 @@ fi
 # --- Pull marketplaces ---
 marketplace_names=$(jq -r 'keys[]' "$MARKETPLACES_JSON")
 
-echo "claude-marketplace-sync: syncing marketplaces..." >&2
-
 for name in $marketplace_names; do
     auto_update=$(jq -r --arg n "$name" '.[$n].autoUpdate // false' "$MARKETPLACES_JSON")
     install_location=$(jq -r --arg n "$name" '.[$n].installLocation' "$MARKETPLACES_JSON")


### PR DESCRIPTION
## Summary

- Removes redundant `echo "claude-marketplace-sync: syncing marketplaces..."` that duplicated the already-present `log_always "🔄 Syncing Claude plugins..."` message on startup

**Before:**
```
[claude-marketplace-sync] 🔄 Syncing Claude plugins..
claude-marketplace-sync: syncing marketplaces...
```

**After:**
```
[claude-marketplace-sync] 🔄 Syncing Claude plugins..
```

## Test plan
- [ ] Run `claude-marketplace-sync` і перевірити, що виводиться лише один рядок на початку

🤖 Generated with [Claude Code](https://claude.com/claude-code)