### PR TITLE
Fix claude-marketplace-sync: skip rsync when SHA unchanged

### DIFF
--- a/scripts/claude-marketplace-sync
+++ b/scripts/claude-marketplace-sync
@@ -173,31 +173,47 @@ for key in $plugin_keys; do
     old_version=$(jq -r --arg k "$key" '.plugins[$k][0].version // ""' "$INSTALLED_JSON" 2>/dev/null || echo "")
     old_sha=$(jq -r --arg k "$key" '.plugins[$k][0].gitCommitSha // ""' "$INSTALLED_JSON" 2>/dev/null || echo "")
 
+    # Determine if sync is needed before running rsync
+    if [ -z "$old_version" ]; then
+        needs_sync=true
+        sync_reason="first install"
+    elif [ "$old_version" != "$new_version" ]; then
+        needs_sync=true
+        sync_reason="version changed: ${old_version} → ${new_version}"
+    elif [ -n "$current_sha" ] && [ "$old_sha" != "$current_sha" ]; then
+        needs_sync=true
+        sync_reason="new commits"
+    elif [ "$force" = true ]; then
+        needs_sync=true
+        sync_reason="--force"
+    elif [ ! -d "$cache_dir" ]; then
+        needs_sync=true
+        sync_reason="cache dir missing"
+    else
+        needs_sync=false
+    fi
+
+    if [ "$needs_sync" = false ]; then
+        log "Skipping ${key} (up to date, SHA=${current_sha:0:7})"
+        continue
+    fi
+
     if [ ! -d "$cache_dir" ]; then
         mkdir -p "$cache_dir"
     fi
 
-    log "Syncing ${key} → ${cache_dir}"
+    log "Syncing ${key} → ${cache_dir} (${sync_reason})"
     if rsync -a --delete "${source_dir}/" "${cache_dir}/" 2>/dev/null; then
-        # Determine if content changed: new version, new git SHA, first install, or --force
         if [ -z "$old_version" ]; then
             log_always "✅ Installed: ${key} version ${new_version}"
-            version_changed=true
         elif [ "$old_version" != "$new_version" ]; then
             log_always "✅ Updated: ${key} version ${new_version}"
-            version_changed=true
-        elif [ -n "$current_sha" ] && [ "$old_sha" != "$current_sha" ]; then
-            log_always "✅ Updated: ${key} version ${new_version} (new commits)"
-            version_changed=true
-        elif [ "$force" = true ]; then
-            # --force: run hooks even if nothing changed
-            version_changed=true
         else
-            version_changed=false
+            log_always "✅ Updated: ${key} version ${new_version} (${sync_reason})"
         fi
 
         # Update gitCommitSha in installed_plugins.json so next run can compare
-        if [ -n "$current_sha" ] && [ "$version_changed" = true ]; then
+        if [ -n "$current_sha" ]; then
             jq --arg k "$key" --arg sha "$current_sha" \
                '.plugins[$k][0].gitCommitSha = $sha' \
                "$INSTALLED_JSON" > "${INSTALLED_JSON}.tmp" \
@@ -205,8 +221,8 @@ for key in $plugin_keys; do
         fi
         log "  synced OK"
 
-        # Run SessionStart hooks if version changed (to update installed files)
-        if [ "$version_changed" = true ]; then
+        # Run SessionStart hooks after sync (to update installed files)
+        if true; then
             hooks_json="${cache_dir}/hooks/hooks.json"
             if [ -f "$hooks_json" ]; then
                 session_start_hooks=$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.type == "command") | .command' "$hooks_json" 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Move change detection **before** `rsync` instead of after
- Skip rsync entirely when version and SHA both match cached values
- rsync now only runs for: first install, version change, new commits, missing cache dir, or `--force`
- In verbose mode, shows reason for skip: `Skipping plantuml@tribe-coding (up to date, SHA=45c1e04)`

## Root cause

Previously the script always ran `rsync`, then decided whether to run SessionStart hooks. This meant file I/O on every sync cycle even when nothing changed.

## Test plan

- [ ] Run `claude-marketplace-sync --verbose` twice in a row (remove freshness file between runs) — second run should show "Skipping ... (up to date)"  
- [ ] Run `claude-marketplace-sync --verbose --force` — should rsync and run hooks regardless  
- [ ] Make a real change to a plugin, run sync — should detect new SHA and rsync

🤖 Generated with [Claude Code](https://claude.com/claude-code)