### PR TITLE
Fix session cost display: reduce to 2 decimal places (v1.3.2)

### DIFF
--- a/plugins/statusline/.claude-plugin/plugin.json
+++ b/plugins/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Three-line Claude Code statusline with enhanced resolution: 5h (30 blocks/10m), 7d (28 blocks/6h), extra usage (N blocks/1d). Features improved alignment, dimmed separators, and wide character support.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/statusline/scripts/statusline.sh
+++ b/plugins/statusline/scripts/statusline.sh
@@ -562,7 +562,7 @@ if [ -n "$session_cost_usd" ] && [ "$session_cost_usd" != "null" ]; then
   # Convert JSON dot-decimal to locale decimal separator, then format with awk
   dec_sep=$(printf "%.1f" 1 | tr -d '01')
   cost_locale=$(echo "$session_cost_usd" | sed "s/\./${dec_sep}/")
-  cost_fmt=$(echo "$cost_locale" | awk '{printf "%.4f", $1}')
+  cost_fmt=$(echo "$cost_locale" | awk '{printf "%.2f", $1}')
   cost_int=$(echo "$cost_fmt" | sed 's/[.,].*//')
   cost_frac=$(echo "$cost_fmt" | grep -o '[.,][0-9]*$')
   session_cost_widget="💵${SEP}${dim}\$${rst}${cost_int}${dim}${cost_frac}${rst}"


### PR DESCRIPTION
## Summary

- Fix session cost format from `%.4f` to `%.2f` — display `$0.12` instead of `$0.1234`
- Bump statusline `1.3.1` → `1.3.2`

## Test plan

- [ ] Start a Claude Code session with statusline configured
- [ ] Verify session cost widget shows 2 decimal places (e.g. `💵･$0.12`)
- [ ] Verify it does NOT show 4 decimal places (e.g. `$0.1234`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)