### PR TITLE
fix(git-branch-naming): correct max-length test example (v0.1.2)

### DIFF
--- a/plugins/git-branch-naming/.claude-plugin/plugin.json
+++ b/plugins/git-branch-naming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-branch-naming",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Git branch naming convention enforcement: validates names, warns on content mismatch before push",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/git-branch-naming/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/git-branch-naming/docs/ACCEPTANCE_TESTS.md
@@ -177,8 +177,9 @@ CLAUDE_PROJECT_DIR=/tmp/test-project \
 # Expected: JSON with permissionDecision: "deny"
 
 # Test: max length enforced (> 30 chars)
+# Note: branch name must actually exceed maxLength=30. "feat/this-is-a-really-too-long-name" = 35 chars
 CLAUDE_PROJECT_DIR=/tmp/test-project \
-  echo '{"tool_input":{"command":"git checkout -b feat/this-is-too-long-name"}}' | bash "$SCRIPT"
+  echo '{"tool_input":{"command":"git checkout -b feat/this-is-a-really-too-long-name"}}' | bash "$SCRIPT"
 # Expected: JSON with permissionDecision: "deny"
 ```
 


### PR DESCRIPTION
## Summary

- Fix incorrect branch name example in Test 4 (max length enforcement)
- `feat/this-is-too-long-name` is only 26 chars — under the 30-char limit, so it never triggered a deny
- Replaced with `feat/this-is-a-really-too-long-name` (35 chars) which correctly triggers the deny decision
- Added comment with char count to prevent future confusion
- Bump version 0.1.1 → 0.1.2 (PATCH: docs fix)

## Test plan

- [ ] Verify `feat/this-is-a-really-too-long-name` (35 chars) triggers `permissionDecision: "deny"` with maxLength=30 config
- [ ] Verify `feat/this-is-too-long-name` (26 chars) passes silently with maxLength=30 config

🤖 Generated with [Claude Code](https://claude.com/claude-code)