### PR TITLE
docs: add Bash tool shell patterns for reliable acceptance tests (v0.1.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,7 +575,17 @@ For tests requiring manual execution (especially SessionStart hooks, fresh sessi
 
 **Steps:**
 ```bash
-[commands]
+# Use absolute paths — CWD is not guaranteed between Bash tool calls
+SCRIPT="/absolute/path/to/plugins/<name>/scripts/my-script.sh"
+
+# Use printf '%s' for JSON — echo interprets \n in zsh
+printf '%s' '{"tool_input":{"command":"git checkout -b feature/foo"}}' | bash "$SCRIPT"
+
+# Use git -C instead of cd
+git -C /tmp/test-repo init -q
+
+# Use env for environment variable injection
+env CLAUDE_PROJECT_DIR=/tmp/test-repo bash "$SCRIPT"
 ```
 
 **Expected result:**
@@ -606,7 +616,25 @@ For tests requiring manual execution (especially SessionStart hooks, fresh sessi
 - **Use tables**: For comparison data (scenarios, pass/fail, automation status)
 - **Reference real files**: Link to actual plugin files in examples
 
-### 8. Testing SessionStart Hooks and Proactive Behavior
+### 8. Shell Command Patterns for Bash Tool Compatibility
+
+Tests in `ACCEPTANCE_TESTS.md` are run by Claude Code's Bash tool (zsh on macOS). Follow these patterns to avoid common failures:
+
+| Problem | Wrong | Correct |
+|---------|-------|---------|
+| CWD not preserved between calls | `SCRIPT="plugins/foo/scripts/bar.sh"` | `SCRIPT="/absolute/path/to/bar.sh"` |
+| `echo` interprets `\n` in zsh | `echo '{"cmd":"git commit -m \"msg\""}'` | `printf '%s' '{"cmd":"git commit -m \"msg\""}'` |
+| `cd` state lost between Bash calls | `cd /tmp/repo && git status` | `git -C /tmp/repo status` |
+| Inline env var scoping | `CLAUDE_PROJECT_DIR=/tmp bash "$SCRIPT"` | `env CLAUDE_PROJECT_DIR=/tmp bash "$SCRIPT"` |
+
+**Rules:**
+- ALWAYS use absolute paths for scripts referenced in test steps
+- ALWAYS use `printf '%s'` (not `echo`) when passing JSON to hook scripts
+- ALWAYS use `git -C /path` instead of `cd /path && git`
+- ALWAYS use `env VAR=val cmd` for environment variable injection
+- NEVER rely on CWD being set correctly — each Bash tool call may start from project root
+
+### 9. Testing SessionStart Hooks and Proactive Behavior
 
 **Critical insight from [issue #28](https://github.com/Tribe-Coding/claude-plugins/issues/28):** SessionStart hooks that inject MANDATORY instructions work correctly, but testing them requires understanding environmental failure modes.
 

--- a/plugins/git-branch-naming/.claude-plugin/plugin.json
+++ b/plugins/git-branch-naming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-branch-naming",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Git branch naming convention enforcement: validates names, warns on content mismatch before push",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/git-branch-naming/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/git-branch-naming/docs/ACCEPTANCE_TESTS.md
@@ -66,32 +66,33 @@ head -10 plugins/git-branch-naming/commands/git-branch-naming-setup/SKILL.md
 
 **Steps:**
 ```bash
-SCRIPT="plugins/git-branch-naming/scripts/validate-branch.sh"
+# Use absolute path — CWD is not guaranteed between Bash tool calls
+SCRIPT="/path/to/plugins/git-branch-naming/scripts/validate-branch.sh"
 
 # Test: valid branch name → passthrough (exit 0, no output)
-echo '{"tool_input":{"command":"git checkout -b feature/user-auth"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git checkout -b feature/user-auth"}}' | bash "$SCRIPT"
 echo "Exit: $?"  # Expected: 0
 
 # Test: missing prefix → ask/deny output
-echo '{"tool_input":{"command":"git checkout -b my-feature"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git checkout -b my-feature"}}' | bash "$SCRIPT"
 echo "Exit: $?"  # Expected: 0 (default is ask), output JSON
 
 # Test: uppercase → invalid
-echo '{"tool_input":{"command":"git branch MyFeature/UserAuth"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git branch MyFeature/UserAuth"}}' | bash "$SCRIPT"
 
 # Test: underscore → invalid
-echo '{"tool_input":{"command":"git switch -c feature/user_auth"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git switch -c feature/user_auth"}}' | bash "$SCRIPT"
 
 # Test: valid switch -c
-echo '{"tool_input":{"command":"git switch -c bugfix/fix-null-pointer"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git switch -c bugfix/fix-null-pointer"}}' | bash "$SCRIPT"
 echo "Exit: $?"  # Expected: 0 (passthrough)
 
 # Test: non-git command → passthrough
-echo '{"tool_input":{"command":"npm install"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"npm install"}}' | bash "$SCRIPT"
 echo "Exit: $?"  # Expected: 0
 
 # Test: git status → passthrough
-echo '{"tool_input":{"command":"git status"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git status"}}' | bash "$SCRIPT"
 echo "Exit: $?"  # Expected: 0
 ```
 
@@ -186,22 +187,22 @@ EOF
 
 **Tests:**
 ```bash
-SCRIPT="plugins/git-branch-naming/scripts/validate-branch.sh"
+SCRIPT="/path/to/plugins/git-branch-naming/scripts/validate-branch.sh"
 
 # Test: custom prefix allowed
-CLAUDE_PROJECT_DIR=/tmp/test-project \
-  echo '{"tool_input":{"command":"git checkout -b feat/new-thing"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git checkout -b feat/new-thing"}}' \
+  | env CLAUDE_PROJECT_DIR=/tmp/test-project bash "$SCRIPT"
 echo "Exit: $?"  # Expected: 0 (passthrough)
 
 # Test: default prefix denied (not in custom list)
-CLAUDE_PROJECT_DIR=/tmp/test-project \
-  echo '{"tool_input":{"command":"git checkout -b feature/new-thing"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git checkout -b feature/new-thing"}}' \
+  | env CLAUDE_PROJECT_DIR=/tmp/test-project bash "$SCRIPT"
 # Expected: JSON with permissionDecision: "deny"
 
 # Test: max length enforced (> 30 chars)
 # Note: branch name must actually exceed maxLength=30. "feat/this-is-a-really-too-long-name" = 35 chars
-CLAUDE_PROJECT_DIR=/tmp/test-project \
-  echo '{"tool_input":{"command":"git checkout -b feat/this-is-a-really-too-long-name"}}' | bash "$SCRIPT"
+printf '%s' '{"tool_input":{"command":"git checkout -b feat/this-is-a-really-too-long-name"}}' \
+  | env CLAUDE_PROJECT_DIR=/tmp/test-project bash "$SCRIPT"
 # Expected: JSON with permissionDecision: "deny"
 ```
 
@@ -221,29 +222,30 @@ CLAUDE_PROJECT_DIR=/tmp/test-project \
 
 **Setup:**
 ```bash
-# Create test repo with docs/ branch
-mkdir -p /tmp/test-mismatch-repo
-cd /tmp/test-mismatch-repo && git init -q
-git config user.email "test@test.com" && git config user.name "Test"
-echo "Initial" > README.md && git add . && git commit -q -m "init"
-git checkout -q -b docs/update-readme
+# Use git -C instead of cd — CWD does not persist between Bash tool calls
+SCRIPT="/path/to/plugins/git-branch-naming/scripts/check-content-mismatch.sh"
+
+rm -rf /tmp/test-mismatch-repo
+mkdir /tmp/test-mismatch-repo
+git -C /tmp/test-mismatch-repo init -q
+git -C /tmp/test-mismatch-repo -c user.email=t@t.com -c user.name=T commit -q --allow-empty -m "init"
+git -C /tmp/test-mismatch-repo checkout -q -b docs/update-readme
 # Stage code files on docs branch
-echo "console.log('test')" > app.js
-echo "def foo(): pass" > main.py
-git add app.js main.py
+printf '%s\n' "console.log('test')" > /tmp/test-mismatch-repo/app.js
+printf '%s\n' "def foo(): pass" > /tmp/test-mismatch-repo/main.py
+git -C /tmp/test-mismatch-repo add app.js main.py
 ```
 
 **Tests:**
 ```bash
-SCRIPT="plugins/git-branch-naming/scripts/check-content-mismatch.sh"
-
 # Test: docs branch with 100% code files → mismatch
 bash "$SCRIPT" --staged "docs/update-readme" "/tmp/test-mismatch-repo"
 # Expected: non-empty warning message
 
 # Test: feature branch with code files → no mismatch
-cd /tmp/test-mismatch-repo && git checkout -q -b feature/add-login
-echo "auth.ts content" > auth.ts && git add auth.ts
+git -C /tmp/test-mismatch-repo checkout -q -b feature/add-login
+printf '%s\n' "auth.ts content" > /tmp/test-mismatch-repo/auth.ts
+git -C /tmp/test-mismatch-repo add auth.ts
 bash "$SCRIPT" --staged "feature/add-login" "/tmp/test-mismatch-repo"
 # Expected: empty output (no mismatch)
 
@@ -252,9 +254,13 @@ bash "$SCRIPT" --staged "release/1.0.0" "/tmp/test-mismatch-repo"
 # Expected: empty output (release skipped)
 
 # Test: too few files → skip
-cd /tmp/test-mismatch-repo && git checkout -q -b docs/tiny
-echo "a.ts content" > a.ts && git add a.ts
-bash "$SCRIPT" --staged "docs/tiny" "/tmp/test-mismatch-repo"
+rm -rf /tmp/test-mismatch-tiny && mkdir /tmp/test-mismatch-tiny
+git -C /tmp/test-mismatch-tiny init -q
+git -C /tmp/test-mismatch-tiny -c user.email=t@t.com -c user.name=T commit -q --allow-empty -m "init"
+git -C /tmp/test-mismatch-tiny checkout -q -b docs/tiny
+printf '%s\n' "a.ts content" > /tmp/test-mismatch-tiny/a.ts
+git -C /tmp/test-mismatch-tiny add a.ts
+bash "$SCRIPT" --staged "docs/tiny" "/tmp/test-mismatch-tiny"
 # Expected: empty output (only 1 file, skip check)
 ```
 


### PR DESCRIPTION
## Summary

- Add section **"8. Shell Command Patterns for Bash Tool Compatibility"** to `CLAUDE.md` with quick-reference table and mandatory rules for all future acceptance tests
- Update test template in `CLAUDE.md` to show correct patterns inline
- Fix existing tests 2, 4, 5 in `git-branch-naming/ACCEPTANCE_TESTS.md` to use the correct patterns
- Bump `git-branch-naming` 0.1.3 → 0.1.4 (PATCH: docs only)

## Problem

Tests written for interactive terminal break when run via Claude Code's Bash tool (zsh on macOS):

| Pattern | Problem |
|---------|---------|
| `SCRIPT="plugins/foo/bar.sh"` | CWD not guaranteed → empty path |
| `echo '{"a":"b\nc"}'` | zsh `echo` interprets `\n` → broken JSON |
| `cd /tmp && git status` | `cd` state lost between Bash tool calls |
| `VAR=val bash script` | fragile under zsh eval |

## Fix

Canonical patterns for all acceptance tests:
- `printf '%s'` instead of `echo` for JSON
- Absolute paths for all scripts
- `git -C /path` instead of `cd /path && git`
- `env VAR=val bash script` for env injection

## Test plan

- [ ] Verify tests 2, 4, 5 in git-branch-naming run without "bash: No such file" errors
- [ ] New plugins follow the patterns from the updated CLAUDE.md template

🤖 Generated with [Claude Code](https://claude.com/claude-code)