### PR TITLE
chore: enable git-branch-naming plugin in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "git-branch-naming@tribe-coding": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` to the repo with `git-branch-naming@tribe-coding` enabled
- Ensures the plugin is active by default for all contributors working in this repo

## Test plan

- [ ] Open Claude Code in this repo — git-branch-naming plugin should be active
- [ ] Try creating a branch without prefix — should get a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)