### PR TITLE
fix(retroscope): accurate cost estimation with cache discounts (v0.1.1)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -48,7 +48,8 @@ Highly productive session focused on new plugin development...
 ...
 
 ## 📈 Productivity Metrics
-- Token usage: 1.2M input / 45K output (est. cost: $0.04)
+- Token usage: 1.2M input / 45K output
+- Estimated cost: $4.84 actual / $32.36 naive (6.7x cache savings)
 - Tool breakdown: Read: 42, Bash: 18, Edit: 15, Write: 7
 
 ## 🔮 Next Steps
@@ -91,7 +92,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude/retros
 
 1. **Session discovery** — `find-sessions.py` locates JSONL session files in `~/.claude/projects/` for the target date
 2. **Content extraction** — Filters user prompts and assistant responses (skips tool inputs/outputs when extract mode is on)
-3. **Statistics** — Aggregates token usage, tool calls, duration across sessions
+3. **Statistics** — Aggregates token usage, tool calls, duration across sessions; calculates two cost estimates: *actual* (with cache discounts) and *naive* (all tokens at full input rate, as reported by Claude Code). Pricing fetched from Anthropic docs, cached 24h, with hardcoded fallback
 4. **Report generation** — Claude generates the report using the template, optionally using a haiku subagent for cost efficiency
 5. **Storage** — Saves to the configured storage repo and creates a git commit
 6. **Caching** — If a report already exists and is newer than all session files, displays cached version instantly
@@ -111,7 +112,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude/retros
 - `/retro last-week` — Mon–Sun of previous week
 - Streak tracking — consecutive productive days, activity heatmap
 - CLAUDE.md audit — suggest rules based on repeated session patterns
-- Cost tracking — estimated $ per session/day/week
+- Cost tracking per day/week rollup (per-session cost already tracked in v0.1.1)
 - Focus score — on-task vs tangential exchange ratio
 - Git stats integration — lines changed, commits per session
 - Export formats — JSON, CSV for external dashboards

--- a/plugins/retroscope/commands/retro/SKILL.md
+++ b/plugins/retroscope/commands/retro/SKILL.md
@@ -21,23 +21,23 @@ Generate a retrospective summary of Claude Code session(s).
 
 ## Step 1: Determine Mode
 
+**You MUST ask the user which mode they want. Do NOT skip this step or assume a default.**
+
 If the user provided a mode argument (e.g., `/retro session`, `/retro today`), use it.
-Otherwise ask:
+Otherwise use AskUserQuestion with options: `session`, `today`, `yesterday`.
 
-```
-Use AskUserQuestion with options: session, today, yesterday
-```
-
-## Step 2: Load Config (today/yesterday only)
+## Step 2: Load Config
 
 Look for config in this order:
 1. `{CLAUDE_PROJECT_DIR}/.claude/retroscope.json` (project-level)
 2. `~/.claude/retroscope.json` (user-level)
 
-If no config found → tell the user to run `/retroscope:setup` first and stop.
+**If no config found:**
+- For `today` or `yesterday` mode → tell the user to run `/retroscope:setup` first and **stop**.
+- For `session` mode → show a note: "💡 Tip: Run `/retroscope:setup` to configure storage, language, and other options." Then continue with defaults (`sessionSource: logs`).
 
 Config fields used:
-- `storageDir` — where to save reports (REQUIRED)
+- `storageDir` — where to save reports (REQUIRED for today/yesterday)
 - `language` — report language (default: English)
 - `model` — report generation model: `haiku`, `sonnet`, or `inherit` (default: `haiku`)
 - `extractMode` — pre-filter sessions to text-only (default: `true`)
@@ -57,8 +57,6 @@ Read `sessionSource` from config (default: `logs`).
 |-------|----------|
 | `logs` (default) | Read JSONL session file — complete and reliable even if context was compressed or cleared |
 | `context` | Use current conversation context — faster, no file I/O, but may miss earlier turns if context was compressed (`/compact`) or cleared (`/clear`) |
-
-**If no config found:** use `logs` as default (do not require config for `session` mode — only `storageDir` needs setup for today/yesterday).
 
 ### 3b. Source: `logs`
 

--- a/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
@@ -38,7 +38,7 @@ Critical components to test:
 | 1.4 SKILL.md frontmatter | ✅ Pass | Both commands |
 | 2.1 list mode — today | ✅ Pass | Found 3 sessions |
 | 2.2 list mode — yesterday | ✅ Pass | 0 sessions (no sessions yesterday) |
-| 2.3 stats mode | ✅ Pass | JSON output correct |
+| 2.3 stats mode | ✅ Pass | JSON output correct, includes estimated_cost_usd, pricing_model, pricing_source |
 | 2.4 extract mode | ✅ Pass | User/assistant text extracted |
 | 7.1 session-end.sh | ✅ Pass | Output shown when suggestRetroOnExit=true |
 | 7.2 session-end.sh silent | ✅ Pass | No output when suggestRetroOnExit=false |
@@ -166,6 +166,7 @@ python3 "$SCRIPT" --stats "$RECENT" 2>&1
 **Expected result:**
 - ✅ Valid JSON on stdout
 - ✅ Contains: `session_id`, `slug`, `branches`, `models`, `time_range`, `message_counts`, `token_usage`, `tool_counts`
+- ✅ Contains: `estimated_cost_usd` (float, ≥0), `naive_cost_usd` (float, ≥ estimated_cost_usd), `pricing_model` (string like `sonnet-4.6`), `pricing_source` (string: `fetched`, `cached`, or `static`)
 - ✅ `message_counts.user > 0` and `message_counts.assistant > 0`
 - ✅ `time_range.start` and `time_range.end` are valid ISO timestamps
 - ✅ `token_usage.output_tokens > 0`
@@ -181,7 +182,19 @@ assert data['time_range']['start'], 'time_range.start missing'
 assert data['message_counts']['user'] > 0, 'no user messages'
 assert data['message_counts']['assistant'] > 0, 'no assistant messages'
 assert data['token_usage']['output_tokens'] > 0, 'no output tokens'
-print('Stats validation: OK')
+assert 'estimated_cost_usd' in data, 'estimated_cost_usd missing'
+assert isinstance(data['estimated_cost_usd'], (int, float)), 'estimated_cost_usd must be numeric'
+assert data['estimated_cost_usd'] >= 0, 'cost must be non-negative'
+assert 'naive_cost_usd' in data, 'naive_cost_usd missing'
+assert isinstance(data['naive_cost_usd'], (int, float)), 'naive_cost_usd must be numeric'
+assert data['naive_cost_usd'] >= data['estimated_cost_usd'], 'naive_cost must be >= estimated_cost'
+assert 'pricing_model' in data, 'pricing_model missing'
+assert isinstance(data['pricing_model'], str), 'pricing_model must be a string'
+assert data.get('pricing_source') in ('fetched', 'cached', 'static'), f'unexpected pricing_source: {data.get(\"pricing_source\")}'
+actual = data['estimated_cost_usd']
+naive = data['naive_cost_usd']
+ratio = naive / actual if actual > 0 else 0
+print(f'Stats validation: OK (actual: \${actual:.4f}, naive: \${naive:.4f}, ratio: {ratio:.1f}x, model: {data[\"pricing_model\"]} [{data[\"pricing_source\"]}])')
 "
 ```
 
@@ -275,17 +288,28 @@ print('Template config: all fields valid')
 
 **Automation:** 🟡 (requires configured storage dir)
 
-#### 5.1 No Config → Setup Prompt
+#### 5.1 No Config → Different behavior by mode
 
-In a session without retroscope config:
+**For `today`/`yesterday` mode without retroscope config:**
 ```
 /retro today
 ```
 
 **Expected result:**
 - ✅ Claude detects missing config
-- ✅ Suggests running `/retroscope:setup`
+- ✅ Tells user to run `/retroscope:setup` first and **stops** (does not proceed)
 - ✅ Does NOT crash or generate empty report
+
+**For `session` mode without retroscope config:**
+```
+/retro session
+```
+
+**Expected result:**
+- ✅ Claude detects missing config
+- ✅ Shows tip: "💡 Tip: Run `/retroscope:setup` to configure storage, language, and other options."
+- ✅ **Continues** with default `sessionSource: logs` (does not stop)
+- ✅ Generates session report and displays it in terminal
 
 #### 5.2 Today Report (with config)
 

--- a/plugins/retroscope/scripts/find-sessions.py
+++ b/plugins/retroscope/scripts/find-sessions.py
@@ -11,7 +11,10 @@ Modes:
 import argparse
 import json
 import os
+import re
 import sys
+import time
+import urllib.request
 from datetime import datetime, date, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -298,8 +301,162 @@ def extract_assistant_text(content) -> tuple[str, list]:
 
 
 # ---------------------------------------------------------------------------
-# Stats mode
+# Stats mode — pricing
 # ---------------------------------------------------------------------------
+
+_PRICING_URL = "https://platform.claude.com/docs/en/docs/about-claude/pricing"
+_PRICING_CACHE_FILE = f"/tmp/claude-model-pricing-{os.getuid()}.json"
+_PRICING_CACHE_TTL = 86400  # 24 hours
+
+# Fallback pricing per 1M tokens: {key: {"input", "output", "cache_write", "cache_read"}}
+# Used only when both fetch and cache fail.
+# Source: https://platform.claude.com/docs/en/docs/about-claude/pricing (Feb 2026)
+FALLBACK_PRICING = {
+    "opus-4.6":   {"input": 5.0,  "output": 25.0, "cache_write": 6.25,  "cache_read": 0.50},
+    "opus-4.5":   {"input": 5.0,  "output": 25.0, "cache_write": 6.25,  "cache_read": 0.50},
+    "sonnet-4.6": {"input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30},
+    "sonnet-4.5": {"input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30},
+    "haiku-4.5":  {"input": 1.0,  "output": 5.0,  "cache_write": 1.25,  "cache_read": 0.10},
+    # Claude 3.x legacy
+    "opus-3":     {"input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50},
+    "sonnet-3":   {"input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30},
+    "haiku-3":    {"input": 0.25, "output": 1.25,  "cache_write": 0.30,  "cache_read": 0.03},
+}
+
+
+def fetch_pricing() -> dict | None:
+    """Fetch pricing from platform.claude.com pricing page (SSR HTML).
+
+    Parses the HTML table with columns:
+      Model | Base Input | 5m Cache Writes | 1h Cache Writes | Cache Hits | Output
+    Returns dict like FALLBACK_PRICING, or None on failure.
+    """
+    try:
+        req = urllib.request.Request(
+            _PRICING_URL,
+            headers={"User-Agent": "retroscope-find-sessions/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+    except Exception:
+        return None
+
+    row_re = re.compile(r"<tr[^>]*>(.*?)</tr>", re.DOTALL)
+    td_re = re.compile(r"<td[^>]*>(.*?)</td>", re.DOTALL)
+    tag_re = re.compile(r"<[^>]+>")
+    price_re = re.compile(r"\$([0-9.]+)\s*/\s*MTok")
+
+    pricing = {}
+    for row_match in row_re.finditer(html):
+        row_html = row_match.group(1)
+        cells = td_re.findall(row_html)
+        if len(cells) < 6:
+            continue
+
+        cells_text = [tag_re.sub("", c).strip() for c in cells]
+        model_cell = cells_text[0]
+        if not model_cell.startswith("Claude "):
+            continue
+
+        prices = []
+        for cell in cells_text[1:6]:
+            m = price_re.search(cell)
+            prices.append(float(m.group(1)) if m else None)
+
+        if len(prices) < 5 or None in prices:
+            continue
+
+        # "Claude Opus 4.6" -> "opus-4.6"; "Claude Opus 4" -> "opus-4"
+        name_match = re.match(r"Claude\s+(\w+)\s+([\d.]+)", model_cell)
+        if not name_match:
+            continue
+        key = f"{name_match.group(1).lower()}-{name_match.group(2)}"
+
+        # Columns: Base Input | 5m Cache Writes | 1h Cache Writes | Cache Hits | Output
+        pricing[key] = {
+            "input": prices[0],
+            "cache_write": prices[1],
+            "cache_read": prices[3],
+            "output": prices[4],
+        }
+
+    return pricing if pricing else None
+
+
+def load_pricing() -> tuple[dict, str]:
+    """Load pricing: try cache → fetch from web → fall back to hardcoded.
+
+    Returns (pricing_dict, source) where source is "cached", "fetched", or "static".
+    """
+    # 1. Check cache file (valid for 24h)
+    try:
+        if os.path.exists(_PRICING_CACHE_FILE):
+            mtime = os.stat(_PRICING_CACHE_FILE).st_mtime
+            if time.time() - mtime < _PRICING_CACHE_TTL:
+                with open(_PRICING_CACHE_FILE) as f:
+                    cached = json.load(f)
+                if isinstance(cached.get("models"), dict) and cached["models"]:
+                    return cached["models"], "cached"
+    except Exception:
+        pass
+
+    # 2. Fetch fresh pricing from Anthropic docs
+    fetched = fetch_pricing()
+    if fetched:
+        try:
+            with open(_PRICING_CACHE_FILE, "w") as f:
+                json.dump({
+                    "fetched_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "models": fetched,
+                }, f)
+        except Exception:
+            pass  # cache write failure is non-fatal
+        return fetched, "fetched"
+
+    # 3. Hardcoded fallback
+    return FALLBACK_PRICING, "static"
+
+
+def match_model_to_pricing(model_id: str, pricing: dict) -> tuple[dict | None, str]:
+    """Match a full model ID to the best pricing entry.
+
+    model_id examples: "claude-sonnet-4-6-20250514", "claude-opus-4-6"
+    pricing keys: "sonnet-4.6", "opus-4.6", "haiku-4.5", etc.
+
+    Returns (pricing_entry, matched_key) or (None, "") if no match.
+    """
+    model_lower = model_id.lower()
+
+    # Extract family and version from model ID
+    # Patterns: claude-{family}-{major}-{minor}[-date] or claude-{family}-{major}
+    family_match = re.search(r"claude-(opus|sonnet|haiku)-(\d+)-?(\d+)?", model_lower)
+    if family_match:
+        family = family_match.group(1)
+        major = family_match.group(2)
+        minor = family_match.group(3)
+        if minor:
+            # Try exact version match first
+            key = f"{family}-{major}.{minor}"
+            if key in pricing:
+                return pricing[key], key
+        # Try major-only match (e.g. "sonnet-4" matches "sonnet-4.6")
+        prefix = f"{family}-{major}."
+        candidates = [k for k in pricing if k.startswith(prefix)]
+        if candidates:
+            # Pick highest version
+            best = sorted(candidates, key=lambda k: float(k.split("-")[1]))[-1]
+            return pricing[best], best
+
+    # Fallback: family keyword match
+    for family in ("opus", "sonnet", "haiku"):
+        if family in model_lower:
+            candidates = [k for k in pricing if k.startswith(family + "-")]
+            if candidates:
+                best = sorted(candidates, key=lambda k: float(k.split("-")[1]))[-1]
+                return pricing[best], best
+
+    return None, ""
+
 
 def get_stats(jsonl_file: str):
     """
@@ -411,6 +568,60 @@ def get_stats(jsonl_file: str):
     if first_ts and last_ts:
         duration = (last_ts - first_ts).total_seconds() / 60
         stats["time_range"]["duration_minutes"] = round(duration, 1)
+
+    # Estimate cost using dynamic pricing (fetched or cached), fallback to hardcoded
+    pricing_dict, pricing_source = load_pricing()
+
+    # Per-message per-model cost: re-read file for accurate weighted calculation
+    actual_cost = 0.0
+    naive_cost = 0.0  # Claude Code style: all input tokens at full input rate
+    cost_model_used = ""
+    try:
+        with open(jsonl_file, errors="ignore") as f2:
+            for line2 in f2:
+                line2 = line2.strip()
+                if not line2:
+                    continue
+                try:
+                    obj2 = json.loads(line2)
+                except json.JSONDecodeError:
+                    continue
+                msg2 = obj2.get("message", {})
+                model2 = msg2.get("model", "")
+                usage2 = msg2.get("usage", {})
+                if not model2 or not usage2:
+                    continue
+
+                entry, key = match_model_to_pricing(model2, pricing_dict)
+                if entry is None:
+                    continue
+                if not cost_model_used:
+                    cost_model_used = key
+
+                inp = usage2.get("input_tokens", 0)
+                out = usage2.get("output_tokens", 0)
+                cw = usage2.get("cache_creation_input_tokens", 0)
+                cr = usage2.get("cache_read_input_tokens", 0)
+
+                # Actual cost: each token type at its real rate
+                actual_cost += (
+                    inp * entry["input"]       / 1_000_000
+                    + out * entry["output"]    / 1_000_000
+                    + cw * entry["cache_write"] / 1_000_000
+                    + cr * entry["cache_read"]  / 1_000_000
+                )
+                # Naive cost: all input tokens at full input rate (no cache discount)
+                naive_cost += (
+                    (inp + cw + cr) * entry["input"] / 1_000_000
+                    + out * entry["output"]           / 1_000_000
+                )
+    except OSError:
+        pass
+
+    stats["estimated_cost_usd"] = round(actual_cost, 4)
+    stats["naive_cost_usd"] = round(naive_cost, 4)
+    stats["pricing_model"] = cost_model_used or "unknown"
+    stats["pricing_source"] = pricing_source
 
     print(json.dumps(stats, indent=2))
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `find-sessions.py --stats` now correctly accounts for `cache_read_input_tokens` (the main source of cost in heavy sessions) — previously these millions of tokens were ignored, causing ~5-7x underestimation
- **Two cost estimates**: `estimated_cost_usd` (actual, with cache discounts) vs `naive_cost_usd` (all tokens at full input rate — matches what Claude Code displays in statusline)
- **Live pricing**: fetches current rates from `platform.claude.com` docs page (SSR HTML parse, 12 models), cached 24h in `/tmp`, hardcoded fallback. Fixes hardcoded Opus 4.6 being priced at $15/MTok instead of $5/MTok
- **SKILL.md fix**: Step 1 now always asks for mode (no assumed default); Step 2 config check is universal for all modes, not just today/yesterday

## Cost estimation example (current session)

| Estimate | Value | Method |
|----------|-------|--------|
| `estimated_cost_usd` | $4.84 | Per-model, with cache_read discount (0.1× input rate) |
| `naive_cost_usd` | $32.36 | All tokens at full input rate (matches Claude Code) |

7x difference because ~95% of tokens are cache reads.

## Test plan

- [ ] `python3 find-sessions.py --stats <session.jsonl>` — verify both `estimated_cost_usd` and `naive_cost_usd` present and reasonable
- [ ] `pricing_source` is `"fetched"` on first run, `"cached"` on second run within 24h
- [ ] Delete cache file, disconnect network → `pricing_source: "static"` (fallback)
- [ ] `/retro` without args → AskUserQuestion for mode
- [ ] `/retro today` without config → stops and suggests `/retroscope:setup`
- [ ] `/retro session` without config → shows tip, continues with defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)