### PR TITLE
fix(retroscope): check config before mode selection in /retro (v0.1.2)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -14,9 +14,11 @@ Reports include: task outcomes, decisions made, open questions, GitHub/PR refere
 
 1. Install the plugin (via claude-marketplace-sync or manually)
 2. Start a Claude Code session
-3. Run `/retroscope:setup` — interactive wizard configures storage and options
+3. Run `/retro` — if no config is found, it will offer to run setup automatically
 4. Work normally in Claude Code
 5. Run `/retro today` at end of day
+
+> **Tip:** You can also run `/retroscope:setup` directly at any time to configure or update settings.
 
 ## Report Format
 
@@ -129,7 +131,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude/retros
 - Encoded path: `/Users/artem/devel/foo` → `-Users-artem-devel-foo`
 
 **Storage dir not initialized:**
-- Run `/retroscope:setup` to create and configure the storage repo
+- Run `/retro` and choose "Yes, run setup now" when prompted, or run `/retroscope:setup` directly
 
 **Report quality is poor:**
 - Switch from `haiku` to `sonnet` model in config

--- a/plugins/retroscope/commands/retro/SKILL.md
+++ b/plugins/retroscope/commands/retro/SKILL.md
@@ -19,22 +19,26 @@ Generate a retrospective summary of Claude Code session(s).
 | `today` | Aggregate all today's sessions | Saved to storage repo + git commit |
 | `yesterday` | Aggregate all yesterday's sessions | Saved to storage repo + git commit |
 
-## Step 1: Determine Mode
+## Step 1: Load Config
+
+Look for config in this order:
+1. `{CLAUDE_PROJECT_DIR}/.claude/retroscope.json` (project-level)
+2. `~/.claude/retroscope.json` (user-level)
+
+**If no config found:** ask the user whether to run setup now using AskUserQuestion:
+- Option A: "Yes, run setup now" → invoke `/retroscope:setup` skill and **stop**.
+- Option B: "No, continue without config" → continue with defaults (`sessionSource: logs`, display-only, no storage).
+
+## Step 2: Determine Mode
 
 **You MUST ask the user which mode they want. Do NOT skip this step or assume a default.**
 
 If the user provided a mode argument (e.g., `/retro session`, `/retro today`), use it.
 Otherwise use AskUserQuestion with options: `session`, `today`, `yesterday`.
 
-## Step 2: Load Config
-
-Look for config in this order:
-1. `{CLAUDE_PROJECT_DIR}/.claude/retroscope.json` (project-level)
-2. `~/.claude/retroscope.json` (user-level)
-
-**If no config found:**
-- For `today` or `yesterday` mode → tell the user to run `/retroscope:setup` first and **stop**.
-- For `session` mode → show a note: "💡 Tip: Run `/retroscope:setup` to configure storage, language, and other options." Then continue with defaults (`sessionSource: logs`).
+**If no config was found** (user chose to continue without config):
+- Only `session` mode is available (no storage configured for today/yesterday).
+- Skip the mode question and use `session` mode directly, showing a note: "💡 Tip: Run `/retroscope:setup` to enable daily reports (today/yesterday)."
 
 Config fields used:
 - `storageDir` — where to save reports (REQUIRED for today/yesterday)

--- a/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
@@ -288,28 +288,36 @@ print('Template config: all fields valid')
 
 **Automation:** 🟡 (requires configured storage dir)
 
-#### 5.1 No Config → Different behavior by mode
+#### 5.1 No Config → Setup Prompt First
 
-**For `today`/`yesterday` mode without retroscope config:**
+When retroscope config is absent, `/retro` must ask about setup **before** offering a mode choice.
+
+**Steps:**
+1. Ensure no config exists:
+   ```bash
+   ls ~/.claude/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
+   ls .claude/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
+   ```
+2. Run any `/retro` command (with or without mode argument):
+   ```
+   /retro
+   ```
+
+**Expected result:**
+- ✅ Claude detects missing config **before** asking which mode to use
+- ✅ AskUserQuestion dialog appears with two options:
+  - "Yes, run setup now" → invokes `/retroscope:setup` and stops
+  - "No, continue without config" → proceeds in `session` mode only (no mode selection dialog shown)
+- ✅ If user picks "No, continue without config" → session report shown with tip: "💡 Tip: Run `/retroscope:setup` to enable daily reports (today/yesterday)."
+- ✅ Does NOT show mode selection dialog when no config found
+- ✅ Does NOT crash or generate empty report
+
+**Negative test — explicit mode with no config:**
 ```
 /retro today
 ```
-
-**Expected result:**
-- ✅ Claude detects missing config
-- ✅ Tells user to run `/retroscope:setup` first and **stops** (does not proceed)
-- ✅ Does NOT crash or generate empty report
-
-**For `session` mode without retroscope config:**
-```
-/retro session
-```
-
-**Expected result:**
-- ✅ Claude detects missing config
-- ✅ Shows tip: "💡 Tip: Run `/retroscope:setup` to configure storage, language, and other options."
-- ✅ **Continues** with default `sessionSource: logs` (does not stop)
-- ✅ Generates session report and displays it in terminal
+- ✅ Still shows setup prompt first (config check precedes mode resolution)
+- ✅ If user picks "No, continue without config" → Claude explains that today/yesterday mode requires storage config and shows session report instead
 
 #### 5.2 Today Report (with config)
 


### PR DESCRIPTION
## Summary

- `/retro` now checks for config **before** showing the mode selection dialog
- If no config found → offers to run `/retroscope:setup` immediately (AskUserQuestion)
- If user declines setup → runs `session` mode directly (no mode picker shown)

## Problem

Previously: mode picker appeared first → user picked `today`/`yesterday` → then got told to run setup and stop. Confusing UX.

Now: setup prompt appears first → if user says "No" → only `session` mode runs (with a tip to run setup for daily reports).

## Files changed

- `commands/retro/SKILL.md` — swapped Step 1 (config) and Step 2 (mode), added no-config branch logic
- `docs/ACCEPTANCE_TESTS.md` — rewrote Test 5.1 for the new flow
- `README.md` — updated Quick Start and Troubleshooting sections

## Test plan

- [ ] Run `/retro` with no `~/.claude/retroscope.json` → setup prompt appears before mode selection
- [ ] Choose "Yes, run setup now" → `/retroscope:setup` wizard launches
- [ ] Choose "No, continue without config" → session report shown, no mode picker
- [ ] Run `/retro today` with no config → still shows setup prompt first
- [ ] Run `/retro` with config present → mode picker appears as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)