### PR TITLE
feat(retroscope): report template & UX improvements (v0.1.3)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/commands/retro/SKILL.md
+++ b/plugins/retroscope/commands/retro/SKILL.md
@@ -19,6 +19,8 @@ Generate a retrospective summary of Claude Code session(s).
 | `today` | Aggregate all today's sessions | Saved to storage repo + git commit |
 | `yesterday` | Aggregate all yesterday's sessions | Saved to storage repo + git commit |
 
+Add `--force` to any mode to regenerate even if a cached report exists (e.g., `/retro today --force`).
+
 ## Step 1: Load Config
 
 Look for config in this order:
@@ -35,6 +37,8 @@ Look for config in this order:
 
 If the user provided a mode argument (e.g., `/retro session`, `/retro today`), use it.
 Otherwise use AskUserQuestion with options: `session`, `today`, `yesterday`.
+
+Parse the user's argument for both mode and flags. If `--force` is present, set `force = true` and strip it from the mode argument before further processing.
 
 **If no config was found** (user chose to continue without config):
 - Only `session` mode is available (no storage configured for today/yesterday).
@@ -122,7 +126,9 @@ Determine report output path:
 
 Where `{project_name}` = basename of `CLAUDE_PROJECT_DIR`.
 
-If the file exists:
+If `force` is set: skip cache check entirely, always regenerate.
+
+Otherwise, if the file exists:
 - Get modification time of summary.md
 - Get modification times of all session files
 - If summary.md is newer than ALL session files → display cached report and stop
@@ -135,6 +141,8 @@ python3 {SCRIPT_DIR}/find-sessions.py --stats "{session_file}"
 ```
 
 Collect: token totals, tool counts, duration, branches, models.
+
+From each stats JSON, collect both `estimated_cost_usd` (actual cost with cache discounts) and `naive_cost_usd` (all input tokens at full rate, matches Claude Code UI display). Show both in the Productivity Metrics section.
 
 Aggregate across all sessions for the Overview and Productivity Metrics sections.
 

--- a/plugins/retroscope/commands/retro/references/report-template.md
+++ b/plugins/retroscope/commands/retro/references/report-template.md
@@ -26,23 +26,27 @@ Use this template when generating retrospective reports. Fill in all sections ba
 
 | Status | Task | Links |
 |--------|------|-------|
-| ✅ Done | {completed task} | {PR #N, issue #N, or —} |
-| 🚧 In progress | {ongoing work} | {branch feature/foo} |
-| ❓ Open | {unresolved question} | {issue #N or —} |
-| 🔬 Research | {topic investigated} | {session {uuid-short}} |
-| ✔️ Decision | {what was decided} | {discussion #N or —} |
+| ✅ Done | {completed task} | 📌 PR #N · 🔀 `branch` |
+| 🚧 In progress | {ongoing work} | 🔀 `feature/foo` |
+| ❓ Open | {unresolved question} | 🐛 Issue #N |
+| 🔬 Research | {topic investigated} | 💬 `uuid-short` |
+| ✔️ Decision | {what was decided} | 📋 `plan-file.md` |
 | ❌ Abandoned | {abandoned task and reason} | — |
 | 💡 Idea | {idea for future} | — |
-| ⚠️ Blocked | {what is blocked and why} | {issue #N} |
+| ⚠️ Blocked | {what is blocked and why} | 🐛 Issue #N |
 
 _(Include only rows that apply. Remove unused status rows.)_
 
-## 🔗 References
+**Link icons:** 📌 PR · 🔀 Branch · 💬 Session · 📋 Plan · 🐛 Issue/Discussion
+Use `·` (middle dot) to separate multiple links in one cell.
 
-- **PRs:** {PR URLs from conversation, or "none"}
-- **Issues/Discussions:** {GitHub/JIRA references, or "none"}
-- **Branches:** {git branches touched}
-- **Sessions:** {session UUIDs with slugs, e.g. "03e14812 (wild-dancing-wigderson)"}
+## 📄 Documentation Changes
+
+| Change | File(s) |
+|--------|---------|
+| {short description of substantial change} | `{file path}` |
+
+_(Include only significant documentation changes: new docs, structural updates, important clarifications. Skip trivial edits like typo fixes.)_
 
 ## 💬 Communication Insights
 
@@ -54,7 +58,8 @@ _(Include only rows that apply. Remove unused status rows.)_
 
 ## 📈 Productivity Metrics
 
-- **Token usage:** {input / output / cache totals} (est. cost: ${estimated_cost})
+- **Estimated cost:** ${estimated_cost_usd} (with cache discounts) / ${naive_cost_usd} (without cache discounts, as shown in Claude Code UI)
+- **Token usage:** {input / output / cache totals}
 - **Tool breakdown:** {top tools — e.g. "Read: 42, Bash: 18, Edit: 15, Write: 7"}
 - **Session pacing:** {average time between exchanges or notable patterns}
 


### PR DESCRIPTION
## Summary

- **References → Links column**: видалено секцію `## References`, посилання перенесені в колонку Links таблиці Tasks & Outcomes з іконками (📌 PR · 🔀 Branch · 💬 Session · 📋 Plan · 🐛 Issue)
- **Documentation Changes section**: нова таблиця між Tasks & Outcomes і Communication Insights для значущих doc змін
- **Dual cost display**: рядок вартості розділено на `estimated_cost_usd` (з cache discount) та `naive_cost_usd` (як Claude Code UI показує)
- **`--force` flag**: `/retro today --force` пропускає cache check і завжди перегенерує репорт

## Test plan

- [ ] Запустити `/retro today` — переконатися що секція References відсутня, Links мають іконки
- [ ] Запустити `/retro today --force` — переконатися що репорт перегенерується навіть якщо кешований файл свіжий
- [ ] Перевірити що Productivity Metrics показує обидві ціни
- [ ] Перевірити що Documentation Changes секція присутня в репорті

🤖 Generated with [Claude Code](https://claude.com/claude-code)