### PR TITLE
fix(retroscope): PYTHONPATH isolation and correct subagent types (v0.1.5)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/commands/retro/SKILL.md
+++ b/plugins/retroscope/commands/retro/SKILL.md
@@ -74,12 +74,12 @@ Find the JSONL file for the current session:
 
 2. Run stats first:
    ```bash
-   python3 {SCRIPT_DIR}/find-sessions.py --stats "{session_file}"
+   PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --stats "{session_file}"
    ```
 
 3. Extract conversation text:
    ```bash
-   python3 {SCRIPT_DIR}/find-sessions.py --extract "{session_file}"
+   PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --extract "{session_file}"
    ```
    (No `--date` filter — include all messages regardless of when session started.)
 
@@ -108,7 +108,7 @@ Stop here for `session` mode.
 Run `find-sessions.py` to locate matching session files:
 
 ```bash
-python3 {SCRIPT_DIR}/find-sessions.py {today|yesterday} \
+PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py {today|yesterday} \
   --project-dir "{CLAUDE_PROJECT_DIR}" \
   --tz "{config.timezone}"
 ```
@@ -137,7 +137,7 @@ Otherwise, if the file exists:
 
 For each session file, run:
 ```bash
-python3 {SCRIPT_DIR}/find-sessions.py --stats "{session_file}"
+PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --stats "{session_file}"
 ```
 
 Collect: token totals, tool counts, duration, branches, models.
@@ -152,7 +152,7 @@ Aggregate across all sessions for the Overview and Productivity Metrics sections
 
 For each session file, run:
 ```bash
-python3 {SCRIPT_DIR}/find-sessions.py --extract "{session_file}" --date "{YYYY-MM-DD}"
+PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --extract "{session_file}" --date "{YYYY-MM-DD}"
 ```
 
 Concatenate all extracted text (with session separators).
@@ -169,8 +169,9 @@ Read raw JSONL files directly (filter to `type: user` and `type: assistant` mess
 
 1. Read `${SKILL_DIR}/references/report-template.md`
 2. Generate report content based on the template and extracted session data
-3. **If config `model` is `haiku` or `sonnet`**: use the Task tool with `subagent_type: haiku` or `subagent_type: sonnet` to generate the report body. Pass the extracted session text and template as context.
-4. **If config `model` is `inherit`**: generate directly (current session model)
+3. **If config `model` is `haiku`**: use the Task tool with `subagent_type: general-purpose` and `model: haiku` to generate the report body. Pass the extracted session text and template as context.
+4. **If config `model` is `sonnet`**: use the Task tool with `subagent_type: general-purpose` and `model: sonnet` to generate the report body. Pass the extracted session text and template as context.
+5. **If config `model` is `inherit`**: generate directly (current session model)
 
 ## Step 9: Save Report
 

--- a/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
@@ -117,7 +117,7 @@ ls -la "$PLUGIN/scripts/"
 ```bash
 SCRIPT="/Users/artem/devel/claude-plugins/plugins/retroscope/scripts/find-sessions.py"
 
-python3 "$SCRIPT" today --project-dir /Users/artem/devel/claude-plugins 2>&1
+PYTHONPATH="" python3 "$SCRIPT" today --project-dir /Users/artem/devel/claude-plugins 2>&1
 ```
 
 **Expected result:**
@@ -129,7 +129,7 @@ python3 "$SCRIPT" today --project-dir /Users/artem/devel/claude-plugins 2>&1
 #### 2.2 List Mode — Yesterday
 
 ```bash
-python3 "$SCRIPT" yesterday --project-dir /Users/artem/devel/claude-plugins 2>&1
+PYTHONPATH="" python3 "$SCRIPT" yesterday --project-dir /Users/artem/devel/claude-plugins 2>&1
 ```
 
 **Expected result:**
@@ -139,7 +139,7 @@ python3 "$SCRIPT" yesterday --project-dir /Users/artem/devel/claude-plugins 2>&1
 #### 2.3 List Mode — Date Range
 
 ```bash
-python3 "$SCRIPT" "2026-02-01:2026-02-23" --project-dir /Users/artem/devel/claude-plugins 2>&1
+PYTHONPATH="" python3 "$SCRIPT" "2026-02-01:2026-02-23" --project-dir /Users/artem/devel/claude-plugins 2>&1
 ```
 
 **Expected result:**
@@ -149,7 +149,7 @@ python3 "$SCRIPT" "2026-02-01:2026-02-23" --project-dir /Users/artem/devel/claud
 #### 2.4 List Mode — Unknown Project
 
 ```bash
-python3 "$SCRIPT" today --project-dir /tmp/nonexistent-project-xyz 2>&1
+PYTHONPATH="" python3 "$SCRIPT" today --project-dir /tmp/nonexistent-project-xyz 2>&1
 ```
 
 **Expected result:**
@@ -160,7 +160,7 @@ python3 "$SCRIPT" today --project-dir /tmp/nonexistent-project-xyz 2>&1
 
 ```bash
 RECENT=$(ls -t ~/.claude/projects/-Users-artem-devel-claude-plugins/*.jsonl 2>/dev/null | head -1)
-python3 "$SCRIPT" --stats "$RECENT" 2>&1
+PYTHONPATH="" python3 "$SCRIPT" --stats "$RECENT" 2>&1
 ```
 
 **Expected result:**
@@ -174,7 +174,7 @@ python3 "$SCRIPT" --stats "$RECENT" 2>&1
 Verify JSON structure:
 ```bash
 RECENT=$(ls -t ~/.claude/projects/-Users-artem-devel-claude-plugins/*.jsonl 2>/dev/null | head -1)
-python3 "$SCRIPT" --stats "$RECENT" | python3 -c "
+PYTHONPATH="" python3 "$SCRIPT" --stats "$RECENT" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 assert data['session_id'], 'session_id missing'
@@ -202,7 +202,7 @@ print(f'Stats validation: OK (actual: \${actual:.4f}, naive: \${naive:.4f}, rati
 
 ```bash
 RECENT=$(ls -t ~/.claude/projects/-Users-artem-devel-claude-plugins/*.jsonl 2>/dev/null | head -1)
-python3 "$SCRIPT" --extract "$RECENT" --date 2026-02-23 2>&1 | head -20
+PYTHONPATH="" python3 "$SCRIPT" --extract "$RECENT" --date 2026-02-23 2>&1 | head -20
 ```
 
 **Expected result:**
@@ -216,7 +216,7 @@ python3 "$SCRIPT" --extract "$RECENT" --date 2026-02-23 2>&1 | head -20
 ```bash
 RECENT=$(ls -t ~/.claude/projects/-Users-artem-devel-claude-plugins/*.jsonl 2>/dev/null | head -1)
 # Test with wrong date (should produce no output)
-python3 "$SCRIPT" --extract "$RECENT" --date 2020-01-01 2>&1
+PYTHONPATH="" python3 "$SCRIPT" --extract "$RECENT" --date 2020-01-01 2>&1
 ```
 
 **Expected result:**
@@ -570,10 +570,10 @@ python3 -c "import json; json.load(open('$PLUGIN/hooks/hooks.json'))" || exit 1
 python3 -c "import json; json.load(open('$PLUGIN/templates/retroscope.json'))" || exit 1
 
 # Script syntax check
-python3 -m py_compile "$SCRIPT" && echo "find-sessions.py syntax: OK"
+PYTHONPATH="" python3 -m py_compile "$SCRIPT" && echo "find-sessions.py syntax: OK"
 
 # Help text (no session data needed)
-python3 "$SCRIPT" --help >/dev/null && echo "find-sessions.py --help: OK"
+PYTHONPATH="" python3 "$SCRIPT" --help >/dev/null && echo "find-sessions.py --help: OK"
 ```
 
 ### Expected Success Rate


### PR DESCRIPTION
## Summary

- **PYTHONPATH isolation**: всі виклики `find-sessions.py` тепер мають префікс `PYTHONPATH=""` — усуває помилку "can't find '__main__' module" коли Bash tool CWD є Python-проектом
- **Correct subagent types**: `subagent_type: haiku/sonnet` не існують — виправлено на `subagent_type: general-purpose` з `model: haiku/sonnet`
- **ACCEPTANCE_TESTS**: всі `python3 "$SCRIPT"` → `PYTHONPATH="" python3 "$SCRIPT"`

## Root cause

`python3 /abs/path/script.py` в zsh Bash tool: якщо CWD містить Python-пакет, Python шукає `__main__.py` в CWD замість запуску файлу. `PYTHONPATH=""` ізолює від CWD.

## Test plan

- [ ] `/retro today` генерує звіт без червоних помилок
- [ ] `model: haiku` → subagent запускається без "Agent type 'haiku' not found"
- [ ] `model: sonnet` → аналогічно

🤖 Generated with [Claude Code](https://claude.com/claude-code)