### PR TITLE
feat(plantuml): require title directive in all diagrams (v1.5.11)

### DIFF
--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/plantuml/scripts/inject-base-rules.sh
+++ b/plugins/plantuml/scripts/inject-base-rules.sh
@@ -17,6 +17,7 @@ Every PlantUML diagram MUST have two parts, in this order:
 Example:
 \`\`\`plantuml
 @startuml
+title Greeting Sequence
 Alice -> Bob: Hello
 @enduml
 \`\`\`
@@ -38,6 +39,7 @@ Proactive usage:
 - **ALWAYS invoke the \`plantuml-diagram-guide\` skill BEFORE creating any PlantUML diagram** to choose the correct diagram type. This is MANDATORY — do not skip this step even if you think you know which type to use.
 
 Rules:
+- Every PlantUML diagram MUST include a \`title\` directive after the opening tag (@startuml, @startjson, etc.). The title should be a short, descriptive name of the diagram.
 - Always keep both parts in sync. When you modify PlantUML source, the PostToolUse hook auto-updates the image URL.
 - Use SVG format (\`/svg/\` path) unless PNG is specifically requested.
 - The alt text in the image link should be a short description of the diagram.

--- a/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
+++ b/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
@@ -12,6 +12,8 @@ description: >
 
 Use this guide to choose the right PlantUML diagram type for documentation. When creating or updating `.md` files, proactively suggest and use the appropriate diagram type.
 
+**IMPORTANT:** Every diagram MUST include a `title` directive immediately after the opening tag. This makes diagrams self-documenting. Example: `title User Authentication Flow`
+
 ## Behavioral Diagrams (how things work)
 
 | Type | When to use | When to suggest | Syntax |


### PR DESCRIPTION
## Summary

- Added mandatory `title` directive rule to `inject-base-rules.sh` (Rules section)
- Updated example diagram in `inject-base-rules.sh` to include `title Greeting Sequence`
- Added `**IMPORTANT:**` note about required `title` in `plantuml-diagram-guide/SKILL.md`
- Bumped plugin version `1.5.10` → `1.5.11` (PATCH)

## Motivation

Without a `title`, PlantUML diagrams are not self-documenting — it's unclear what they represent without reading the full source. Making `title` mandatory ensures every diagram has a descriptive label.

## Test plan

- [ ] Verify `inject-base-rules.sh` output includes new title rule
- [ ] Verify example diagram in output shows `title Greeting Sequence`
- [ ] Verify `SKILL.md` contains IMPORTANT note about title
- [ ] Verify `plugin.json` version = `1.5.11`
- [ ] In a fresh session: create a PlantUML diagram and confirm Claude includes `title`

🤖 Generated with [Claude Code](https://claude.com/claude-code)