### PR TITLE
feat(plantuml): color coding guidelines with muted pastel palette (v1.5.12)

### DIFF
--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/plantuml/scripts/inject-base-rules.sh
+++ b/plugins/plantuml/scripts/inject-base-rules.sh
@@ -18,7 +18,10 @@ Example:
 \`\`\`plantuml
 @startuml
 title Greeting Sequence
-Alice -> Bob: Hello
+skinparam participantBackgroundColor #E8F4FD
+skinparam participantBorderColor #7FB3D8
+Alice -[#5B9BD5]> Bob: Hello
+Bob -[#70AD47]-> Alice: Hi there!
 @enduml
 \`\`\`
 
@@ -40,6 +43,7 @@ Proactive usage:
 
 Rules:
 - Every PlantUML diagram MUST include a \`title\` directive after the opening tag (@startuml, @startjson, etc.). The title should be a short, descriptive name of the diagram.
+- When appropriate, use color coding in diagrams (skinparam, colored arrows, group backgrounds) with a muted pastel palette on white background (default). Do NOT change backgroundColor unless the user requests it. Add a \`legend\` block when colors encode specific meaning (e.g., blue = external service, red = error path). Does NOT apply to JSON, YAML, or Wireframe (Salt) diagrams.
 - Always keep both parts in sync. When you modify PlantUML source, the PostToolUse hook auto-updates the image URL.
 - Use SVG format (\`/svg/\` path) unless PNG is specifically requested.
 - The alt text in the image link should be a short description of the diagram.

--- a/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
+++ b/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
@@ -14,6 +14,37 @@ Use this guide to choose the right PlantUML diagram type for documentation. When
 
 **IMPORTANT:** Every diagram MUST include a `title` directive immediately after the opening tag. This makes diagrams self-documenting. Example: `title User Authentication Flow`
 
+## Color Coding Guidelines
+
+Use color coding to improve diagram readability. Apply a **muted pastel palette** on white background (default). Do NOT set `skinparam backgroundColor` unless the user explicitly requests it.
+
+**Recommended palette:**
+
+| Color | Hex | Use for |
+|-------|-----|---------|
+| Soft blue | `#E8F4FD` / `#5B9BD5` | Primary elements, main flow |
+| Soft green | `#E8F5E9` / `#70AD47` | Success paths, approved states |
+| Soft red | `#FDE8E8` / `#E74C3C` | Error paths, rejected states |
+| Soft yellow | `#FFF8E1` / `#F4B942` | Warnings, pending states |
+| Soft purple | `#F3E8FD` / `#9B59B6` | External systems, third-party |
+| Soft gray | `#F5F5F5` / `#95A5A6` | Inactive, deprecated |
+
+**Color support by diagram type:**
+
+| Support | Types |
+|---------|-------|
+| ✅ Full (skinparam, arrows, groups) | Sequence, Activity, State, Class, Component, Object, ER, Deployment |
+| 🟡 Limited | Timing, Network, MindMap, Gantt, WBS |
+| ❌ Not supported | JSON, YAML, Wireframe (Salt) |
+
+**When to add a `legend`:**
+- Colors encode specific meaning (error/success, internal/external, sync/async)
+- Diagram has 5+ elements with distinct color-coded roles
+
+**When NOT to color:**
+- Diagram has only 2–3 simple elements (coloring adds noise)
+- JSON, YAML, or Wireframe diagrams (no skinparam support)
+
 ## Behavioral Diagrams (how things work)
 
 | Type | When to use | When to suggest | Syntax |


### PR DESCRIPTION
## Summary

- Added conditional color coding rule to `inject-base-rules.sh` (Rules section)
- Updated example diagram in `inject-base-rules.sh` to demonstrate skinparam colors
- Added `Color Coding Guidelines` section to `plantuml-diagram-guide/SKILL.md` with:
  - Recommended muted pastel palette (6 semantic colors with hex codes)
  - Per-type support table (✅ full / 🟡 limited / ❌ none)
  - Conditions for when to add a `legend` block
  - Conditions for when NOT to color
- Bumped plugin version `1.5.11` → `1.5.12` (PATCH)

## Key design decisions

- **White background always**: `backgroundColor` is never changed by default — only element/arrow colors are set
- **Conditional, not absolute**: coloring is skipped for 2–3 element diagrams (noise) and for JSON/YAML/Wireframe (no skinparam support)
- **Legend only when meaningful**: added only when colors encode logic (error/success/external), not for aesthetics

## Test plan

- [ ] Run `bash plugins/plantuml/scripts/inject-base-rules.sh` — output contains color coding rule
- [ ] Example diagram in output shows `skinparam` + colored arrows
- [ ] `SKILL.md` contains `Color Coding Guidelines` section with palette table
- [ ] `plugin.json` version = `1.5.12`
- [ ] In fresh session: create a complex UML diagram and confirm Claude uses pastel colors + legend where appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)