### PR TITLE
fix(retroscope): forbid Read tool on .jsonl files, use Bash instead (v0.1.7)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/commands/retro/SKILL.md
+++ b/plugins/retroscope/commands/retro/SKILL.md
@@ -70,7 +70,11 @@ Read `sessionSource` from config (default: `logs`).
 
 Find the JSONL file for the current session:
 
-1. Get current session ID — read `$CLAUDE_SESSION_ID` env var, or fall back to extracting it from `~/.claude/projects/` by finding the most recently modified JSONL file under the encoded current project path.
+1. Get current session ID — read `$CLAUDE_SESSION_ID` env var, or fall back to finding the most recently modified JSONL file under the encoded current project path:
+   ```bash
+   ls -t ~/.claude/projects/<encoded-project-dir>/*.jsonl | head -1
+   ```
+   **Never use the Read tool on `.jsonl` files — they can exceed 256 KB. Always use Bash commands.**
 
 2. Resolve script path — `SCRIPT_DIR` = `${SKILL_DIR}/../../scripts` (i.e., `scripts/` at the plugin root).
 
@@ -161,7 +165,16 @@ Concatenate all extracted text (with session separators).
 
 **If `extractMode: false`:**
 
-Read raw JSONL files directly (filter to `type: user` and `type: assistant` messages only).
+Parse JSONL files via Bash — **never use the Read tool on `.jsonl` files** (they can exceed 256 KB / 25K tokens):
+```bash
+PYTHONPATH="" python3 -c "
+import json, sys
+for line in open(sys.argv[1]):
+    obj = json.loads(line)
+    if obj.get('type') in ('user', 'assistant'):
+        print(json.dumps(obj))
+" "{session_file}"
+```
 
 **If combined content exceeds ~100K tokens:**
 - Warn user about large session size


### PR DESCRIPTION
## Summary

- Fixes `File content exceeds maximum allowed size` errors when Claude uses the `Read` tool on session `.jsonl` files (observed at 288.7 KB and 30 826 tokens in session `7b4c9110`)
- Step 3b: replaced implicit file lookup with explicit `ls -t ... | head -1` Bash command + warning "Never use the Read tool on `.jsonl` files"
- Step 7 (`extractMode: false`): replaced "Read raw JSONL files directly" with a concrete `Bash` + `python3` snippet that streams the file line-by-line
- Bumped version `0.1.6` → `0.1.7` (PATCH)

**Root cause (from session `7b4c9110`, lines 99 and 229):**
```
File content (288.7KB) exceeds maximum allowed size (256KB).
File content (30826 tokens) exceeds maximum allowed tokens (25000).
```
The skill instructed Claude to "Read raw JSONL files directly" which caused it to use the `Read` tool — inappropriate for large binary-ish log files.

## Test plan

- [ ] Run `/retro session` with `sessionSource: logs` on a session whose `.jsonl` exceeds 256 KB — verify no `Read` tool is called on the file
- [ ] Run `/retro today` with `extractMode: false` — verify Bash+python3 snippet is used instead of `Read`
- [ ] Run `claude-marketplace-sync --force` after merge to update cache to v0.1.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)