### PR TITLE
fix(retroscope): read summary.md before write in Step 9 (v0.1.8)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/commands/retro/SKILL.md
+++ b/plugins/retroscope/commands/retro/SKILL.md
@@ -199,6 +199,7 @@ for line in open(sys.argv[1]):
    ```
    {storageDir}/reports/{project_name}/daily/{YYYY}/{MM}/{DD}/summary.md
    ```
+   **If the file already exists: Read it first, then use Edit to replace the content.** The Write tool blocks overwriting an unread file. Never skip the Read step when the file may exist from a previous run.
 
 3. Git commit in storage repo:
    ```bash


### PR DESCRIPTION
## Summary

- Fixes `File has not been read yet. Read it first before writing to it.` error in Step 9 when `summary.md` already exists from a previous run
- Added explicit instruction: if the file exists, Read it first, then use Edit to replace content
- Bumped version `0.1.7` → `0.1.8` (PATCH)

**Root cause (from session `7b4c9110`, line 125):**
Claude called the Write tool on `summary.md` which existed from an earlier partial run. Claude Code's Write tool enforces a read-before-write safety check and blocked the operation. Claude recovered by reading then using Edit, but this caused an unnecessary error and extra tool calls.

## Test plan

- [ ] Run `/retro today` twice in a row — second run should not produce "File has not been read yet" error
- [ ] Verify report is updated correctly on second run (no stale content)
- [ ] Run `claude-marketplace-sync --force` after merge to update cache to v0.1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)