### PR TITLE
feat(plantuml): two-path ASCII rendering with SVG links (v1.6.0)

### DIFF
--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.5.12",
+  "version": "1.6.0",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/plantuml/scripts/inject-base-rules.sh
+++ b/plugins/plantuml/scripts/inject-base-rules.sh
@@ -29,16 +29,24 @@ Bob -[#70AD47]-> Alice: Hi there!
 
 Proactive usage:
 - When creating or updating \`.md\` documentation files, proactively add PlantUML diagrams to illustrate architecture, sequences, state machines, data flow, and component relationships.
-- When explaining architecture or flows in the terminal, use PlantUML's ASCII text renderer:
+- When explaining architecture or flows in the terminal, determine diagram type first, then use one of two rendering paths:
+
+  **ASCII-friendly types** (sequence, activity, state, class, component, object, usecase):
   1. Create the PlantUML source code
-  2. Encode it: \`echo "\$source" | python3 ${PLUGIN_ROOT}/scripts/plantuml-encode.py\`
+  2. Encode it: \`encoded=\$(echo "\$source" | python3 ${PLUGIN_ROOT}/scripts/plantuml-encode.py --encode-only)\`
   3. Fetch ASCII output via WebFetch from: \`https://www.plantuml.com/plantuml/txt/<encoded>\`
   4. Display the rendered ASCII diagram
-  5. If WebFetch fails: retry once with simpler diagram
-  6. If both attempts fail: inform user PlantUML API unavailable, then generate ASCII diagram yourself using box-drawing characters (as fallback only)
-  Do NOT paste raw PlantUML source. Do NOT manually draw ASCII if PlantUML API is available.
-  If rendering fails (exit code 1): retry once with simpler diagram. If both attempts fail: inform user PlantUML API unavailable, then generate ASCII diagram yourself using box-drawing characters (as fallback only).
-  Do NOT paste raw PlantUML source. Do NOT manually draw ASCII if PlantUML API is available.
+  5. After the ASCII diagram, show a clickable SVG link: \`[View SVG diagram](https://www.plantuml.com/plantuml/svg/<encoded>)\`
+  6. If WebFetch fails: retry once with simpler diagram
+  7. If both attempts fail: inform user PlantUML API unavailable, then generate ASCII diagram yourself using box-drawing characters (as fallback only)
+
+  **Link-only types** (timing, gantt, mindmap, WBS, wireframe, network, JSON, YAML, ER, deployment):
+  1. Create the PlantUML source code
+  2. Show source in a fenced \`plantuml\` code block
+  3. Encode it: \`encoded=\$(echo "\$source" | python3 ${PLUGIN_ROOT}/scripts/plantuml-encode.py --encode-only)\`
+  4. Show a clickable SVG link: \`[View SVG diagram](https://www.plantuml.com/plantuml/svg/<encoded>)\`
+
+  Do NOT paste raw PlantUML source without a code block. Do NOT manually draw ASCII if PlantUML API is available.
 - **ALWAYS invoke the \`plantuml-diagram-guide\` skill BEFORE creating any PlantUML diagram** to choose the correct diagram type. This is MANDATORY — do not skip this step even if you think you know which type to use.
 
 Rules:


### PR DESCRIPTION
## Summary

- ASCII-friendly diagram types (sequence, activity, state, class, component, object, usecase) now render ASCII via `plantuml.com/txt/` **and** show a clickable SVG link after the diagram
- Link-only types (timing, gantt, mindmap, WBS, wireframe, network, JSON, YAML, ER, deployment) show source code block + SVG link only (ASCII renders poorly for these types)
- Use `--encode-only` flag to cleanly reuse encoded string in both `/txt/` and `/svg/` URLs
- Remove duplicated fallback instructions (lines 37–41 were repeating 37–38 verbatim)

## Test plan

- [ ] Run `bash plugins/plantuml/scripts/inject-base-rules.sh` — output is well-formed, `${PLUGIN_ROOT}` expands to absolute path
- [ ] In fresh session: ask Claude to explain a sequence diagram in terminal → should render ASCII + show SVG link
- [ ] In fresh session: ask Claude to explain a gantt chart in terminal → should show source block + SVG link only (no ASCII attempt)
- [ ] Verify `--encode-only` flag works: `echo "@startuml\ntitle T\n@enduml" | python3 plugins/plantuml/scripts/plantuml-encode.py --encode-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)