### PR TITLE
feat(playbook): add playbook plugin with guideline presets (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,6 +27,11 @@
       "name": "retroscope",
       "source": "./plugins/retroscope",
       "description": "Retrospective session reports: summarize tasks, decisions, and open questions from Claude Code sessions"
+    },
+    {
+      "name": "playbook",
+      "source": "./plugins/playbook",
+      "description": "Curated presets of coding guidelines injected into sessions on demand"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## PR Merge
+
+`allow_auto_merge` is **disabled** in this repo — `gh pr merge --auto` will fail. Always use:
+```bash
+gh pr merge <N> --squash
+```
+
 ## ⚠️ CRITICAL: Version Bump Requirement
 
 **MANDATORY: Claude Code MUST automatically bump version when plugin files change**

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "playbook",
+  "version": "0.1.0",
+  "description": "Curated presets of coding guidelines injected into sessions on demand",
+  "author": { "name": "Tribe Coding" },
+  "license": "MIT",
+  "commands": ["./commands/"],
+  "skills": ["./skills/"]
+}

--- a/plugins/playbook/commands/playbook-setup/SKILL.md
+++ b/plugins/playbook/commands/playbook-setup/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: playbook-setup
+description: >
+  Interactive setup wizard for playbook presets. Creates or updates
+  ~/.claude/playbook.json (global) or .claude/playbook.json (project).
+  Run this command to choose which coding guideline presets to enable.
+  Keywords: playbook setup, configure guidelines, enable presets.
+---
+
+# Playbook Setup
+
+Configure which coding guideline presets are active for your sessions.
+
+## Steps
+
+### 1. Scan available presets
+
+Read all `.md` files in `${SKILL_DIR}/../../presets/`. For each file, extract the YAML frontmatter fields `name`, `description`, and `tags`.
+
+### 2. Show current configuration
+
+Check both config files and display current state:
+- Global (`~/.claude/playbook.json`): list enabled presets
+- Project (`.claude/playbook.json` in repo root): list enabled presets and excludes
+- If neither exists, say "No presets configured yet."
+
+### 3. Ask which presets to enable
+
+Use `AskUserQuestion` with `multiSelect: true`. List all available presets with their descriptions. Pre-select any currently enabled presets.
+
+### 4. Ask config level
+
+Use `AskUserQuestion`:
+- **Global** (`~/.claude/playbook.json`) — applies to all projects by default
+- **Project** (`.claude/playbook.json`) — applies only to this project, committed to git
+
+### 5. Handle excludes (project level only)
+
+If configuring at project level AND global config exists:
+- Ask if any global presets should be excluded in this project
+- Use `AskUserQuestion` with `multiSelect: true`, listing only the globally enabled presets
+
+### 6. Write config
+
+Write the JSON config file to the chosen location:
+
+```json
+{
+  "presets": ["preset-name-1", "preset-name-2"],
+  "exclude": []
+}
+```
+
+Omit the `"exclude"` field for global configs or when empty.
+
+### 7. Confirm
+
+Display:
+- Config file path written
+- List of enabled presets (after merge logic)
+- Reminder: "Restart your session or run `/clear` for changes to take effect."

--- a/plugins/playbook/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/playbook/docs/ACCEPTANCE_TESTS.md
@@ -1,0 +1,215 @@
+# Playbook Acceptance Tests
+
+## Purpose
+
+The playbook plugin injects curated coding guideline presets into Claude Code sessions. These tests verify that preset selection, config merging, RULES extraction, and on-demand REFERENCE browsing work correctly across both global and project config levels.
+
+## Test Execution Order
+
+1. Static checks (automated)
+2. Script unit tests (automated)
+3. Config merge tests (automated)
+4. SessionStart integration (manual — requires fresh session)
+5. Skill invocation tests (manual — requires fresh session)
+
+## Automation Status
+
+- ✅ Fully automated: Tests 1-3
+- ⚠️ Manual only: Tests 4-5 (require fresh Claude Code session)
+
+---
+
+## 1. Static Checks
+
+**Objective:** Validate plugin structure and file formats.
+
+**Automation:** ✅
+
+**Steps:**
+
+```bash
+PLUGIN="/Users/artem/devel/claude-plugins/plugins/playbook"
+
+# plugin.json is valid JSON with required fields
+jq -e '.name, .version, .commands, .skills' "$PLUGIN/.claude-plugin/plugin.json"
+
+# hooks.json is valid JSON with SessionStart hook
+jq -e '.hooks.SessionStart' "$PLUGIN/hooks/hooks.json"
+
+# All presets have YAML frontmatter and both zones
+for f in "$PLUGIN"/presets/*.md; do
+  head -1 "$f" | grep -q '^---' && echo "✅ frontmatter: $(basename "$f")" || echo "❌ frontmatter: $(basename "$f")"
+  grep -q '<!-- RULES -->' "$f" && echo "✅ RULES zone: $(basename "$f")" || echo "❌ RULES zone: $(basename "$f")"
+  grep -q '<!-- REFERENCE -->' "$f" && echo "✅ REFERENCE zone: $(basename "$f")" || echo "❌ REFERENCE zone: $(basename "$f")"
+done
+
+# SKILL.md files have YAML frontmatter
+for f in "$PLUGIN"/commands/*/SKILL.md "$PLUGIN"/skills/*/SKILL.md; do
+  head -1 "$f" | grep -q '^---' && echo "✅ frontmatter: $f" || echo "❌ frontmatter: $f"
+done
+```
+
+**Expected result:**
+- ✅ All JSON files parse successfully
+- ✅ All presets have frontmatter, RULES zone, and REFERENCE zone
+- ✅ All SKILL.md files have frontmatter
+
+---
+
+## 2. Script Unit Tests — inject-rules.sh
+
+**Objective:** Verify RULES extraction, config loading, and silent exit.
+
+**Automation:** ✅
+
+**Steps:**
+
+```bash
+SCRIPT="/Users/artem/devel/claude-plugins/plugins/playbook/scripts/inject-rules.sh"
+PLUGIN="/Users/artem/devel/claude-plugins/plugins/playbook"
+
+# Test 2.1: Project config with both presets
+mkdir -p /tmp/playbook-test-2/.claude
+printf '{"presets":["documentation-principles","github-workflow"]}' > /tmp/playbook-test-2/.claude/playbook.json
+output=$(env CLAUDE_PROJECT_DIR=/tmp/playbook-test-2 CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
+echo "$output" | grep -q "MANDATORY" && echo "✅ 2.1: RULES extracted" || echo "❌ 2.1: RULES not found"
+echo "$output" | grep -q "Documentation" && echo "✅ 2.1: doc preset" || echo "❌ 2.1: doc preset missing"
+echo "$output" | grep -q "GitHub Workflow" && echo "✅ 2.1: github preset" || echo "❌ 2.1: github preset missing"
+
+# Test 2.2: Silent exit with no config
+output=$(env HOME=/tmp/nonexistent CLAUDE_PROJECT_DIR=/tmp/nonexistent CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
+[[ -z "$output" ]] && echo "✅ 2.2: Silent exit" || echo "❌ 2.2: Unexpected output: $output"
+
+# Test 2.3: Nonexistent preset name (graceful skip)
+mkdir -p /tmp/playbook-test-3/.claude
+printf '{"presets":["nonexistent-preset"]}' > /tmp/playbook-test-3/.claude/playbook.json
+output=$(env CLAUDE_PROJECT_DIR=/tmp/playbook-test-3 HOME=/tmp/nonexistent CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
+[[ -z "$output" ]] && echo "✅ 2.3: Nonexistent preset skipped silently" || echo "❌ 2.3: Unexpected output"
+
+# Cleanup
+rm -rf /tmp/playbook-test-2 /tmp/playbook-test-3
+```
+
+**Expected result:**
+- ✅ 2.1: Both presets extracted with MANDATORY rules
+- ✅ 2.2: Zero output when no config exists
+- ✅ 2.3: Nonexistent presets skipped without error
+
+---
+
+## 3. Config Merge Tests
+
+**Objective:** Verify union + exclude merge logic across global and project configs.
+
+**Automation:** ✅
+
+**Steps:**
+
+```bash
+SCRIPT="/Users/artem/devel/claude-plugins/plugins/playbook/scripts/inject-rules.sh"
+PLUGIN="/Users/artem/devel/claude-plugins/plugins/playbook"
+
+# Setup fake HOME with global config
+FAKE_HOME="/tmp/playbook-home-test"
+mkdir -p "$FAKE_HOME/.claude"
+printf '{"presets":["documentation-principles","github-workflow"]}' > "$FAKE_HOME/.claude/playbook.json"
+
+# Test 3.1: Global only (no project config)
+output=$(env HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR=/tmp/nonexistent CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
+echo "$output" | grep -q "Documentation" && echo "✅ 3.1: Global doc preset" || echo "❌ 3.1"
+echo "$output" | grep -q "GitHub Workflow" && echo "✅ 3.1: Global github preset" || echo "❌ 3.1"
+
+# Test 3.2: Project excludes one global preset
+mkdir -p /tmp/playbook-proj-test/.claude
+printf '{"presets":[],"exclude":["documentation-principles"]}' > /tmp/playbook-proj-test/.claude/playbook.json
+output=$(env HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR=/tmp/playbook-proj-test CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
+echo "$output" | grep -q "Documentation" && echo "❌ 3.2: Doc should be excluded" || echo "✅ 3.2: Doc excluded"
+echo "$output" | grep -q "GitHub Workflow" && echo "✅ 3.2: Github kept" || echo "❌ 3.2: Github missing"
+
+# Test 3.3: Deduplication (same preset in both configs)
+printf '{"presets":["documentation-principles"]}' > /tmp/playbook-proj-test/.claude/playbook.json
+output=$(env HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR=/tmp/playbook-proj-test CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
+count=$(echo "$output" | grep -c "Documentation — Base Rules")
+[[ "$count" -eq 1 ]] && echo "✅ 3.3: No duplication" || echo "❌ 3.3: Duplicated ($count times)"
+
+# Cleanup
+rm -rf "$FAKE_HOME" /tmp/playbook-proj-test
+```
+
+**Expected result:**
+- ✅ 3.1: Both global presets output
+- ✅ 3.2: Excluded preset not in output, other preset kept
+- ✅ 3.3: Same preset in both configs outputs only once
+
+---
+
+## 4. SessionStart Integration
+
+**Objective:** Verify that RULES are injected into Claude Code session context.
+
+**Automation:** ⚠️ Manual only (requires fresh session)
+
+### Manual Test Procedure
+
+**Step 1:** Create a test config:
+```bash
+mkdir -p ~/.claude
+printf '{"presets":["documentation-principles"]}' > ~/.claude/playbook.json
+```
+
+**Step 2:** Start a fresh Claude Code session in any git repo.
+
+**Step 3:** Ask Claude: "What are the documentation rules?"
+
+**Expected:** Claude should mention:
+- Documentation is part of the codebase
+- Commit checklist (architecture, API, ADR, conventions, cross-links)
+- NEVER leave `TODO: document this`
+
+**Step 4:** Clean up:
+```bash
+rm ~/.claude/playbook.json
+```
+
+---
+
+## 5. Skill Invocation Tests
+
+**Objective:** Verify `/playbook-setup` and `/playbook-browse` work correctly.
+
+**Automation:** ⚠️ Manual only (requires Claude Code session)
+
+### Test 5.1: /playbook-setup
+
+**Step 1:** In a Claude Code session, run `/playbook-setup`
+
+**Expected:**
+- Lists available presets with descriptions
+- Asks which to enable (multiSelect)
+- Asks global vs project level
+- Writes config JSON to chosen location
+- Shows confirmation
+
+### Test 5.2: /playbook-browse
+
+**Step 1:** In a Claude Code session, run `/playbook-browse`
+
+**Expected:**
+- Lists available presets
+- After selection, displays REFERENCE zone content
+- Content includes full documentation (not just RULES)
+
+---
+
+## Regression Testing Guide
+
+Run tests 1-3 automatically before every release:
+```bash
+# Run all automated tests
+bash /Users/artem/devel/claude-plugins/plugins/playbook/docs/ACCEPTANCE_TESTS.md
+```
+
+Run tests 4-5 manually:
+- After any change to `inject-rules.sh`
+- After adding new presets
+- After changing hooks.json

--- a/plugins/playbook/hooks/hooks.json
+++ b/plugins/playbook/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/inject-rules.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/playbook/presets/documentation-principles.md
+++ b/plugins/playbook/presets/documentation-principles.md
@@ -1,0 +1,74 @@
+---
+name: documentation-principles
+description: "Documentation hierarchy, commit checklist, ADR policy, forbidden patterns"
+tags: [docs, commits]
+---
+
+<!-- RULES -->
+## Documentation — Base Rules
+
+MANDATORY: Documentation is part of the codebase. A change is not complete until docs reflect it.
+
+- Before EVERY commit → run the documentation checklist:
+  1. Architecture changed? → update `docs/architecture.md`
+  2. API changed? → update `docs/api/`
+  3. Significant decision? → create/update `docs/adr/`
+  4. Coding conventions affected? → update `docs/conventions.md`
+  5. Cross-links still valid?
+- If none apply → state why in commit message
+- NEVER leave `TODO: document this` in code
+- NEVER duplicate info across docs — single source of truth, link instead
+- For full principles: invoke `/playbook-browse` and select "documentation-principles"
+<!-- /RULES -->
+
+<!-- REFERENCE -->
+## Philosophy
+
+Documentation is not a deliverable — it is part of the codebase. A change is not complete until the docs reflect it.
+
+Project-level `CLAUDE.md` should be **minimal**: build/test commands, project-specific tooling, and links to documentation. Everything else lives in the doc hierarchy and is reachable via those links. This keeps context overhead low while keeping knowledge accessible.
+
+## Hierarchy
+
+Documentation follows a hierarchy rooted at the project `CLAUDE.md`. Every document should be reachable by following links upward from any entry point. The exact structure may vary by project type, stack, and scale — the levels below are a common baseline, not a rigid prescription:
+
+- `CLAUDE.md` (project root) — agent instructions, build/test commands, links to docs below
+- `docs/architecture.md` — system-wide structure, component boundaries, data flows
+- `docs/conventions.md` — coding standards, naming, patterns, tooling choices
+- `docs/adr/NNNN-title.md` — Architecture Decision Records for significant choices
+- `docs/api/` — per-module/service API contracts and interfaces
+- `docs/<component>/` — component-specific documentation
+
+Adapt the hierarchy to the project. Infrastructure-heavy projects may need `docs/infrastructure/`. Multi-service projects may have per-service subtrees. The principle stays the same: **one coherent tree, navigable from the top**.
+
+## Cross-linking
+
+Cross-links between documents are mandatory. If doc A references a concept explained in doc B — link it explicitly. No dead ends. A reader following links from `CLAUDE.md` should be able to reach any relevant piece of documentation without guessing.
+
+## On every commit
+
+Before finalizing any commit, go through this checklist:
+
+1. Does this change affect system architecture or component boundaries? → update `docs/architecture.md`
+2. Does this change introduce, modify or remove a public API, interface, or contract? → update `docs/api/<relevant>.md`
+3. Does this change reflect a significant decision (technology choice, pattern adoption, tradeoff made)? → create or update `docs/adr/`
+4. Does this change affect how future contributors should write code in this area? → update `docs/conventions.md`
+5. Are all cross-links between docs still valid and accurate?
+
+If none of the above apply — explicitly state why in the commit message (`docs: no update needed — isolated internal refactor`).
+
+## ADR policy
+
+Create an ADR when:
+- choosing between two or more viable approaches
+- deviating from an established convention
+- making a decision that would confuse a future contributor without context
+
+ADR format: **Context → Decision → Consequences**. Keep it short. Link to relevant code.
+
+## Forbidden patterns
+
+- Inline comments as a substitute for documentation
+- Duplicating information across multiple docs (single source of truth — link instead)
+- Leaving `TODO: document this` in code
+<!-- /REFERENCE -->

--- a/plugins/playbook/presets/github-workflow.md
+++ b/plugins/playbook/presets/github-workflow.md
@@ -1,0 +1,57 @@
+---
+name: github-workflow
+description: "PR merge rules, PR description updates, issue linking"
+tags: [github, pr, workflow]
+---
+
+<!-- RULES -->
+## GitHub Workflow — Base Rules
+
+MANDATORY: Follow these rules for all PR and branch operations.
+
+- ALWAYS use `--squash` for PR merge (unless repo explicitly uses merge/rebase)
+- Before using `gh pr merge --auto` → check `gh api repos/OWNER/REPO --jq '.allow_auto_merge'`
+- After committing on a PR branch → offer to update the PR description
+- When creating PR without linked issue → ask user to create one first
+- "Not mergeable" after another PR merged → `git fetch origin main && git rebase origin/main && git push --force-with-lease`
+- For full workflow: invoke `/playbook-browse` and select "github-workflow"
+<!-- /RULES -->
+
+<!-- REFERENCE -->
+## PR Merge
+
+- **Never use `gh pr merge --auto`** without first checking if the repo has auto-merge enabled (`gh api repos/OWNER/REPO --jq '.allow_auto_merge'`). Most repos have it disabled — `--auto` will fail.
+- **Always use `--squash`** unless the repo explicitly uses merge commits or rebase strategy.
+- **"Not mergeable" after another PR merged**: happens when two branches diverge after squash merge of the first. Fix:
+  ```bash
+  git fetch origin main
+  git rebase origin/main
+  git push --force-with-lease origin <branch>
+  # then retry: gh pr merge <N> --squash
+  ```
+- **`--force-with-lease` is safer than `--force`**: fails if the remote was updated by someone else since your last fetch.
+
+## After committing to a branch with an open PR
+
+After creating a commit on a branch that has an open PR, **always offer to update the PR description**:
+
+1. Check if current branch has an open PR:
+   ```bash
+   gh pr list --head $(git branch --show-current) --state open --json number,title
+   ```
+
+2. If PR exists, ask the user:
+   > "PR #N exists for this branch. Do you want me to update its description to reflect all commits?"
+
+3. If yes, regenerate the PR body:
+   - Analyze ALL commits: `git log main..HEAD`
+   - Update summary to reflect the full scope of changes
+   - Keep existing issue links (`Closes #N`)
+   - Use `gh pr edit <NUMBER> --body "..."`
+
+## Every PR should have a linked issue
+
+When creating a PR without a linked issue:
+- Ask the user if they want to create an issue first
+- If yes, create the issue, then link it with `Closes #N`
+<!-- /REFERENCE -->

--- a/plugins/playbook/scripts/inject-rules.sh
+++ b/plugins/playbook/scripts/inject-rules.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# inject-rules.sh — SessionStart hook for playbook plugin
+# Reads global + project config, merges presets, outputs RULES zones to stdout.
+# Silent exit (zero output) when no config or no presets are enabled.
+
+set -euo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+PRESETS_DIR="$PLUGIN_ROOT/presets"
+
+GLOBAL_CONFIG="$HOME/.claude/playbook.json"
+PROJECT_CONFIG="${CLAUDE_PROJECT_DIR:-.}/.claude/playbook.json"
+
+# Collect preset names from both configs
+global_presets=""
+project_presets=""
+project_exclude=""
+
+if [[ -f "$GLOBAL_CONFIG" ]]; then
+  global_presets=$(jq -r '.presets // [] | .[]' "$GLOBAL_CONFIG" 2>/dev/null || true)
+fi
+
+if [[ -f "$PROJECT_CONFIG" ]]; then
+  project_presets=$(jq -r '.presets // [] | .[]' "$PROJECT_CONFIG" 2>/dev/null || true)
+  project_exclude=$(jq -r '.exclude // [] | .[]' "$PROJECT_CONFIG" 2>/dev/null || true)
+fi
+
+# Merge: union of global + project presets, minus project exclude
+# Use newline-separated lists + grep for bash 3.2 compatibility (macOS)
+all_presets=$(printf '%s\n%s' "$global_presets" "$project_presets" | sort -u | grep -v '^$' || true)
+
+if [[ -z "$all_presets" ]]; then
+  exit 0
+fi
+
+# Filter out excluded presets
+enabled=""
+while IFS= read -r name; do
+  [[ -z "$name" ]] && continue
+  if [[ -n "$project_exclude" ]] && printf '%s\n' "$project_exclude" | grep -qxF "$name"; then
+    continue
+  fi
+  enabled="${enabled}${enabled:+$'\n'}${name}"
+done <<< "$all_presets"
+
+if [[ -z "$enabled" ]]; then
+  exit 0
+fi
+
+# Extract and output RULES zone from each enabled preset
+while IFS= read -r name; do
+  [[ -z "$name" ]] && continue
+  preset_file="$PRESETS_DIR/$name.md"
+  if [[ -f "$preset_file" ]]; then
+    sed -n '/^<!-- RULES -->/,/^<!-- \/RULES -->/{/^<!-- /d; p;}' "$preset_file"
+    printf '\n'
+  fi
+done <<< "$enabled"

--- a/plugins/playbook/skills/playbook-browse/SKILL.md
+++ b/plugins/playbook/skills/playbook-browse/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: playbook-browse
+description: >
+  Browse and read playbook preset guidelines on demand.
+  Invoked automatically when full reference is needed for documentation principles,
+  GitHub workflow, or other configured guidelines.
+  Do NOT skip this when RULES zone references it.
+  Keywords: guidelines, documentation rules, commit checklist, ADR, PR workflow, playbook.
+---
+
+# Playbook Browse
+
+Display the full reference content of a playbook preset.
+
+## Steps
+
+### 1. Determine which preset to show
+
+If the user or a RULES zone specified a preset name — use it directly.
+
+Otherwise, list all available presets by reading `${SKILL_DIR}/../../presets/*.md` and extracting YAML frontmatter (`name`, `description`). Ask the user which one to view.
+
+### 2. Read the preset file
+
+Read `${SKILL_DIR}/../../presets/<name>.md`.
+
+### 3. Extract and display REFERENCE zone
+
+Extract the content between `<!-- REFERENCE -->` and `<!-- /REFERENCE -->` markers. Display it to the user as formatted markdown.
+
+If the preset has no REFERENCE zone, display the entire file content (excluding YAML frontmatter and RULES zone).


### PR DESCRIPTION
## Summary

- New `playbook` plugin: curated coding guideline presets injected into Claude Code sessions on demand
- Two-zone preset format: short **RULES** (~100-150 tokens, SessionStart) + full **REFERENCE** (on-demand via `/playbook-browse`)
- Two-level config with union + exclude merge: `~/.claude/playbook.json` (global) + `.claude/playbook.json` (project)
- Initial presets: `documentation-principles` (commit checklist, ADR policy, hierarchy) and `github-workflow` (PR merge, PR description updates, issue linking)
- Interactive setup via `/playbook-setup`, on-demand browsing via `/playbook-browse`
- Registered in marketplace.json

## Test plan

- [x] `inject-rules.sh` with project config → both presets extracted
- [x] `inject-rules.sh` with no config → silent exit (zero output)
- [x] `inject-rules.sh` with exclude logic → excluded preset filtered out
- [x] `inject-rules.sh` deduplication → same preset from both configs outputs once
- [x] bash 3.2 compatibility (no associative arrays)
- [ ] Manual: install plugin, run `/playbook-setup`, verify SessionStart injection in fresh session
- [ ] Manual: run `/playbook-browse`, verify REFERENCE zone display

🤖 Generated with [Claude Code](https://claude.com/claude-code)