### PR TITLE
feat(playbook): add playbook plugin with guideline presets (v0.2.0)

### DIFF
--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/macos-python.md
+++ b/plugins/playbook/presets/macos-python.md
@@ -1,0 +1,99 @@
+---
+name: macos-python
+description: "Python 3.12 targeting on macOS, forbidden system Python, CWD isolation"
+tags: [python, macos]
+---
+
+<!-- RULES -->
+## macOS Python — Base Rules
+
+MANDATORY: Target Python 3.12 exclusively. System Python 3.9 will break modern syntax.
+
+- ALWAYS use `python` or `python3` — both resolve to 3.12 via Homebrew
+- NEVER use `/usr/bin/python3` — it is macOS system Python 3.9
+- NEVER target Python 3.9 or add `from __future__ import annotations`
+- Modern type syntax is valid: `str | None`, `X | Y`, `tuple[X, Y]`, `list[str]`
+- When running Python from Bash tool: ALWAYS prefix with `PYTHONPATH=""` to isolate from CWD
+- If CWD has `__init__.py` or `__main__.py`, Python may treat it as a package — `PYTHONPATH=""` prevents this
+- For full reference: invoke `/playbook-browse` and select "macos-python"
+<!-- /RULES -->
+
+<!-- REFERENCE -->
+## Why Python 3.12
+
+macOS ships with a system Python at `/usr/bin/python3` which is version **3.9**. This version does not support:
+
+- Union type syntax: `str | None`, `X | Y` (requires 3.10+)
+- Built-in generic subscripts: `list[str]`, `tuple[X, Y]`, `dict[str, int]` (3.9+ for basic, 3.10+ for unions)
+- Many stdlib improvements added in 3.10–3.12
+
+The user's environment has Python 3.12 installed via Homebrew (Miniforge):
+
+```
+$ python --version
+Python 3.12.12
+
+$ which python
+/opt/homebrew/Caskroom/miniforge/base/bin/python
+
+$ which python3
+/opt/homebrew/Caskroom/miniforge/base/bin/python3.12
+```
+
+Both `python` and `python3` resolve to 3.12. Use either — no ambiguity.
+
+## Forbidden: System Python
+
+**NEVER** use `/usr/bin/python3` explicitly. It resolves to Python 3.9 and will fail on:
+
+```python
+# FAILS on 3.9 — union type syntax requires 3.10+
+def greet(name: str | None = None) -> str:
+    ...
+
+# FAILS on 3.9 — built-in generics require 3.9+ (list[str] ok) but unions don't
+def process(items: list[str | int]) -> dict[str, int]:
+    ...
+```
+
+**NEVER** add `from __future__ import annotations` — it is unnecessary on 3.12 and signals targeting an older version.
+
+## CWD Isolation with PYTHONPATH
+
+When running Python scripts from the Bash tool, the CWD may be a Python project directory containing `__init__.py` or `__main__.py`. Python adds CWD to `sys.path` by default, which can cause:
+
+- CWD treated as a package, shadowing real imports
+- `ImportError` or `ModuleNotFoundError` from unexpected module resolution
+- Scripts failing with cryptic errors unrelated to their actual code
+
+**Fix:** Always prefix with `PYTHONPATH=""`:
+
+```bash
+# Wrong — may fail if CWD is a Python package
+python3 /absolute/path/to/script.py
+
+# Correct — isolates from CWD
+PYTHONPATH="" python /absolute/path/to/script.py
+```
+
+## Type Syntax Reference
+
+All of the following are valid on Python 3.12 without any imports:
+
+```python
+# Union types (3.10+)
+def process(value: str | int) -> str | None:
+    ...
+
+# Built-in generics
+names: list[str] = []
+mapping: dict[str, int] = {}
+pair: tuple[int, str] = (1, "a")
+
+# Optional shorthand
+def fetch(url: str, timeout: float | None = None) -> bytes:
+    ...
+```
+
+No `from typing import List, Dict, Tuple, Optional, Union` needed.
+<!-- /REFERENCE -->

--- a/plugins/playbook/presets/macos-zsh-quirks.md
+++ b/plugins/playbook/presets/macos-zsh-quirks.md
@@ -1,0 +1,104 @@
+---
+name: macos-zsh-quirks
+description: "Zsh Bash tool quirks: CWD persistence, echo escapes, absolute paths, env vars"
+tags: [bash, zsh, macos]
+---
+
+<!-- RULES -->
+## macOS Zsh Quirks — Base Rules
+
+MANDATORY: Shell is `/bin/zsh` 5.9. CWD does NOT persist between Bash tool calls.
+
+- ALWAYS use absolute paths for files and scripts — CWD resets between calls
+- NEVER use `cd` to set working directory — use `git -C /path` for git, absolute paths for everything else
+- NEVER use `echo` for JSON strings — `echo` interprets `\n` in zsh; use `printf '%s'` instead
+- ALWAYS use `env VAR=val command` for environment variable injection (not `VAR=val command`)
+- Root cause of most "No such file" errors: CWD not set + relative path — fix with absolute paths
+- When running Python scripts: ALWAYS prefix with `PYTHONPATH=""` (see macos-python preset)
+- For full reference: invoke `/playbook-browse` and select "macos-zsh-quirks"
+<!-- /RULES -->
+
+<!-- REFERENCE -->
+## Shell Environment
+
+The Bash tool runs `/bin/zsh` 5.9, not bash. The parent process is `claude`. Key differences from interactive shell usage:
+
+- **CWD does NOT persist** between separate Bash tool calls. Each call may start from the project root or an unpredictable directory.
+- **Shell state is not preserved** — aliases, functions, variables set in one call are gone in the next.
+- Only the working directory is set by the tool framework, but can drift across calls.
+
+## CWD and Absolute Paths
+
+The most common source of errors is assuming CWD is set correctly:
+
+```bash
+# WRONG — CWD may not be what you expect
+cat config.json
+python scripts/run.py
+SCRIPT="plugins/foo/scripts/bar.sh"
+
+# CORRECT — always use absolute paths
+cat /absolute/path/to/config.json
+PYTHONPATH="" python /absolute/path/to/scripts/run.py
+SCRIPT="/absolute/path/to/plugins/foo/scripts/bar.sh"
+```
+
+For git operations, use `-C` instead of `cd`:
+
+```bash
+# WRONG
+cd /path/to/repo && git status
+
+# CORRECT
+git -C /path/to/repo status
+git -C /path/to/repo log --oneline -5
+git -C /path/to/repo diff HEAD
+```
+
+## Echo vs Printf
+
+Zsh's built-in `echo` interprets escape sequences (`\n`, `\t`, `\\`) by default, unlike bash. This silently corrupts JSON strings:
+
+```bash
+# WRONG — zsh echo turns \n into actual newlines
+echo '{"tool_input":{"command":"git commit -m \"msg\""}}'
+# May corrupt if message contains \n-like sequences
+
+# CORRECT — printf '%s' passes strings verbatim
+printf '%s' '{"tool_input":{"command":"git commit -m \"msg\""}}'
+```
+
+**Rule:** Use `printf '%s'` (or `printf '%s\n'` for trailing newline) for any JSON, file paths, or data piped to other commands.
+
+## Environment Variable Injection
+
+When passing environment variables to a command, prefer `env` for reliability:
+
+```bash
+# Works but less reliable in edge cases
+CLAUDE_PROJECT_DIR=/tmp/test bash /path/to/script.sh
+
+# Preferred — explicit, works everywhere
+env CLAUDE_PROJECT_DIR=/tmp/test bash /path/to/script.sh
+```
+
+## Common Error Patterns
+
+| Symptom | Root Cause | Fix |
+|---------|-----------|-----|
+| `bash: No such file or directory` | Relative path + wrong CWD | Use absolute path |
+| `cd: no such file or directory` | CWD from previous call gone | Use absolute paths, not `cd` |
+| JSON output has unexpected newlines | `echo` interpreting `\n` | Use `printf '%s'` |
+| Script works manually but fails in Bash tool | CWD assumption wrong | Add absolute path prefix |
+| Python import errors in Bash tool | CWD is a Python package dir | Prefix with `PYTHONPATH=""` |
+
+## Debugging Checklist
+
+When a Bash tool command fails unexpectedly:
+
+1. **Check path** — Is it absolute? If relative, make it absolute.
+2. **Check echo** — Are you piping JSON through `echo`? Switch to `printf '%s'`.
+3. **Check CWD** — Run `pwd` as a separate call to see where you actually are.
+4. **Check env vars** — Use `env VAR=val` pattern, not inline assignment.
+5. **Check Python** — If running Python, add `PYTHONPATH=""` prefix.
+<!-- /REFERENCE -->


### PR DESCRIPTION
## Summary

- Add new **playbook** plugin: curated coding guideline presets injected into sessions on demand via SessionStart hook
- Initial presets: `documentation-principles`, `github-workflow`, `macos-python`, `macos-zsh-quirks`
- Setup wizard (`/playbook-setup`) and on-demand browser (`/playbook-browse`) skills
- Global/project config merge with exclude support (v0.2.0)

## Presets

| Preset | Description |
|--------|-------------|
| `documentation-principles` | Documentation hierarchy, commit checklist, ADR policy |
| `github-workflow` | PR merge rules, PR description updates, issue linking |
| `macos-python` | Python 3.12 targeting, forbidden system Python, CWD isolation |
| `macos-zsh-quirks` | CWD non-persistence, `printf '%s'` vs `echo`, absolute paths |

## How it works

- **SessionStart hook** (`inject-rules.sh`) reads `~/.claude/playbook.json` (global) and `.claude/playbook.json` (project), merges enabled presets, outputs their `<!-- RULES -->` zones into session context
- Each preset has a **RULES zone** (concise, ~8 lines, mandatory) and **REFERENCE zone** (full details, loaded on demand via `/playbook-browse`)
- **`/playbook-setup`** — interactive wizard to choose presets globally or per-project
- **`/playbook-browse`** — reads full REFERENCE zone of any preset on demand

## Test plan

- [ ] Verify `inject-rules.sh` outputs correct RULES zones for enabled presets
- [ ] Verify YAML frontmatter is valid in all 4 preset files
- [ ] Run `/playbook-setup` and enable presets — restart session and verify rules appear in context
- [ ] Run `/playbook-browse` and select a preset — verify REFERENCE zone is displayed
- [ ] Test global + project config merge with `exclude` field
- [ ] See `plugins/playbook/docs/ACCEPTANCE_TESTS.md` for full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)