### PR TITLE
feat(semver): add semver plugin with version bump enforcement (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,6 +32,11 @@
       "name": "playbook",
       "source": "./plugins/playbook",
       "description": "Curated presets of coding guidelines injected into sessions on demand"
+    },
+    {
+      "name": "semver",
+      "source": "./plugins/semver",
+      "description": "Semantic versioning enforcement: validates version bumps before commit/push/PR, supports multiple version files"
     }
   ]
 }

--- a/plugins/semver/.claude-plugin/plugin.json
+++ b/plugins/semver/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "semver",
+  "version": "0.1.0",
+  "description": "Semantic versioning enforcement: validates version bumps before commit/push/PR, supports multiple version files",
+  "author": { "name": "Tribe Coding" },
+  "license": "MIT",
+  "commands": ["./commands/"],
+  "skills": ["./skills/"]
+}

--- a/plugins/semver/commands/semver-setup/SKILL.md
+++ b/plugins/semver/commands/semver-setup/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: semver-setup
+description: >
+  Interactive setup wizard for semantic versioning enforcement.
+  Creates or updates .claude/semver.json with version files, trigger strategy, and enforcement rules.
+  Run this command to configure SemVer for your project.
+  Keywords: setup semver, configure versioning, version config, semver setup, version bump config.
+---
+
+# Semver Setup
+
+Configure semantic versioning enforcement for this project.
+
+## Steps
+
+### 1. Detect existing config and version files
+
+Check for existing configuration:
+- Read `.claude/semver.json` if present (use as defaults for all questions)
+- Auto-detect common version files in the project root: `package.json`, `pyproject.toml`, `Cargo.toml`, `.claude-plugin/plugin.json`, `version.txt`
+- For monorepos: also scan one level deep (e.g., `packages/*/package.json`)
+
+Show the user what was found.
+
+### 2. Ask: which version files to track
+
+Use `AskUserQuestion` with `multiSelect: true`. List detected files with descriptions:
+- `package.json` — npm/Node.js projects
+- `pyproject.toml` — Python projects (field: `project.version` or `tool.poetry.version`)
+- `Cargo.toml` — Rust projects (field: `package.version`)
+- `.claude-plugin/plugin.json` — Claude Code plugins (field: `version`)
+- Other: ask user to enter path manually
+
+For each selected file, ask:
+- **Field path** (dot notation for nested) — default by file type: `version` for JSON, `project.version` for pyproject.toml, `package.version` for Cargo.toml
+- **Format** — `json` / `toml` / `yaml` / `text` (auto-detected from extension if possible)
+
+### 3. Ask: trigger strategy
+
+Use `AskUserQuestion` (single select):
+
+- **`auto`** — Claude evaluates each change and decides. New feature → MINOR, bug fix → PATCH, breaking change → MAJOR, docs/config only → skip. *(Recommended)*
+- **`always`** — Every commit with source file changes must include a version bump. No exceptions. Good for strict release workflows.
+
+### 4. Ask: enforcement level
+
+Use `AskUserQuestion` (single select):
+
+- **`ask`** — Warn and ask for confirmation before proceeding without a bump. *(Default)*
+- **`deny`** — Block commit/push/PR until a version bump is staged.
+- **`allow`** — No enforcement. Only session rules, no hook blocking.
+
+### 5. Ask: base branch
+
+Use `AskUserQuestion` (single select):
+
+- `main` *(Default)*
+- `master`
+- `develop`
+- Other (user enters custom name)
+
+### 6. Ask: exclude patterns
+
+Show default patterns and let user customize:
+
+Default exclusions (files that never require a version bump):
+```
+README.md, CHANGELOG.md, LICENSE, .gitignore, *.md, docs/**, .claude/**
+```
+
+Use `AskUserQuestion` — ask if user wants to add or remove any patterns.
+
+### 7. Write config
+
+Write `.claude/semver.json` with all chosen settings:
+
+```json
+{
+  "versionFiles": [
+    { "path": "package.json", "field": "version", "format": "json" }
+  ],
+  "triggerStrategy": "auto",
+  "baseBranch": "main",
+  "enforcement": {
+    "missingBump": "ask"
+  },
+  "commitFormat": "chore: bump version to {version}",
+  "excludePatterns": ["README.md", "CHANGELOG.md", "LICENSE", ".gitignore", "*.md", "docs/**", ".claude/**"]
+}
+```
+
+Create `.claude/` directory if it doesn't exist.
+
+### 8. Show confirmation
+
+Display:
+- Path written: `.claude/semver.json`
+- Summary of settings (version files, strategy, enforcement, base branch)
+- Next steps:
+
+```
+Next steps:
+1. git add .claude/semver.json && git commit -m "chore: add semver config"
+2. Push to share enforcement rules with your team
+3. Run /semver:guide for the full SemVer 2.0.0 reference
+```

--- a/plugins/semver/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/semver/docs/ACCEPTANCE_TESTS.md
@@ -1,0 +1,257 @@
+# Semver Plugin Acceptance Tests
+
+## Purpose
+
+The semver plugin enforces semantic versioning before commits, pushes, and PR creation/merge. These tests verify that the PreToolUse hook correctly detects missing version bumps, passes through valid scenarios, and that SessionStart rules inject correctly.
+
+## Test Execution Order
+
+1. Static checks (automated)
+2. Script unit tests — inject-rules.sh (automated)
+3. Script unit tests — validate-bump.sh (automated)
+4. Integration tests — config loading (automated)
+5. Behavioral tests — SessionStart rules (manual, fresh session)
+6. End-to-end — full workflow (manual)
+
+## Automation Status
+
+- ✅ Fully automated: Tests 1–4
+- ⚠️ Manual only: Tests 5–6 (require fresh session or real git operations)
+
+---
+
+## Test Categories
+
+### 1. Static Checks
+
+**Objective:** Verify file structure, YAML frontmatter, and JSON schema validity.
+
+**Automation:** ✅
+
+```bash
+PLUGIN="/Users/artem/devel/claude-plugins/plugins/semver"
+
+# 1.1 Check all required files exist
+for f in \
+  ".claude-plugin/plugin.json" \
+  "hooks/hooks.json" \
+  "scripts/inject-rules.sh" \
+  "scripts/validate-bump.sh" \
+  "commands/semver-setup/SKILL.md" \
+  "skills/semver-guide/SKILL.md" \
+  "templates/semver.json" \
+  "docs/ACCEPTANCE_TESTS.md"; do
+  test -f "$PLUGIN/$f" && echo "✅ $f" || echo "❌ MISSING: $f"
+done
+
+# 1.2 Validate JSON files
+for f in ".claude-plugin/plugin.json" "hooks/hooks.json" "templates/semver.json"; do
+  jq empty "$PLUGIN/$f" 2>/dev/null && echo "✅ JSON valid: $f" || echo "❌ Invalid JSON: $f"
+done
+
+# 1.3 Validate YAML frontmatter in SKILL.md files
+for f in "commands/semver-setup/SKILL.md" "skills/semver-guide/SKILL.md"; do
+  PYTHONPATH="" python3 -c "
+import re
+content = open('$PLUGIN/$f').read()
+m = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+print('✅ frontmatter OK' if m else '❌ no frontmatter')
+"
+done
+
+# 1.4 Check scripts are executable
+for s in inject-rules.sh validate-bump.sh; do
+  test -x "$PLUGIN/scripts/$s" && echo "✅ executable: $s" || echo "❌ not executable: $s"
+done
+```
+
+**Acceptance criteria:**
+- ✅ All required files exist
+- ✅ All JSON files parse without error
+- ✅ Both SKILL.md files have valid YAML frontmatter
+- ✅ Both scripts are executable
+
+---
+
+### 2. inject-rules.sh Unit Tests
+
+**Objective:** Verify SessionStart output for both trigger strategies.
+
+**Automation:** ✅
+
+```bash
+SCRIPT="/Users/artem/devel/claude-plugins/plugins/semver/scripts/inject-rules.sh"
+
+# 2.1 No config — defaults to "auto" strategy
+output=$(env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver \
+  CLAUDE_PROJECT_DIR=/tmp bash "$SCRIPT")
+echo "$output" | grep -q "auto" && echo "✅ auto strategy in output" || echo "❌ strategy missing"
+echo "$output" | grep -q "MANDATORY" && echo "✅ MANDATORY keyword present" || echo "❌ MANDATORY missing"
+echo "$output" | grep -q "semver:setup" && echo "✅ setup pointer present" || echo "❌ setup pointer missing"
+
+# 2.2 Config with "always" strategy
+mkdir -p /tmp/semver-test/.claude
+printf '%s' '{"triggerStrategy":"always"}' > /tmp/semver-test/.claude/semver.json
+output=$(env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver \
+  CLAUDE_PROJECT_DIR=/tmp/semver-test bash "$SCRIPT")
+echo "$output" | grep -q "always" && echo "✅ always strategy in output" || echo "❌ always strategy missing"
+echo "$output" | grep -q "no exceptions" && echo "✅ strict rule present" || echo "❌ strict rule missing"
+rm -rf /tmp/semver-test
+```
+
+**Acceptance criteria:**
+- ✅ Outputs ~150 tokens with MANDATORY keyword
+- ✅ Strategy-specific rule line changes based on config
+- ✅ Both setup and guide pointers present
+
+---
+
+### 3. validate-bump.sh Unit Tests
+
+**Automation:** ✅
+
+These tests simulate PreToolUse JSON input and check the output.
+
+```bash
+SCRIPT="/Users/artem/devel/claude-plugins/plugins/semver/scripts/validate-bump.sh"
+
+# 3.1 Passthrough: non-git command
+result=$(printf '%s' '{"tool_input":{"command":"npm install"}}' | \
+  env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver bash "$SCRIPT"; echo "exit:$?")
+echo "$result" | grep -q "exit:0" && echo "✅ non-git passes through" || echo "❌ unexpected block"
+
+# 3.2 Passthrough: irrelevant git subcommand
+result=$(printf '%s' '{"tool_input":{"command":"git status"}}' | \
+  env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver bash "$SCRIPT"; echo "exit:$?")
+echo "$result" | grep -q "exit:0" && ! echo "$result" | grep -q "permissionDecision" && \
+  echo "✅ git status passes through" || echo "❌ unexpected output"
+
+# 3.3 Passthrough: enforcement "allow"
+mkdir -p /tmp/semver-test2/.claude
+printf '%s' '{"versionFiles":[{"path":"package.json","field":"version","format":"json"}],"enforcement":{"missingBump":"allow"}}' \
+  > /tmp/semver-test2/.claude/semver.json
+result=$(printf '%s' '{"tool_input":{"command":"git commit -m \"test\""}}' | \
+  env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver \
+      CLAUDE_PROJECT_DIR=/tmp/semver-test2 bash "$SCRIPT"; echo "exit:$?")
+echo "$result" | grep -q "exit:0" && ! echo "$result" | grep -q "permissionDecision" && \
+  echo "✅ enforcement=allow passes through" || echo "❌ unexpected block"
+rm -rf /tmp/semver-test2
+```
+
+**Acceptance criteria:**
+- ✅ Non-git commands pass through silently (exit 0, no output)
+- ✅ Irrelevant git commands (status, fetch, log) pass through
+- ✅ `enforcement: allow` suppresses all checks
+- ✅ `git commit` without staged version file → `ask` response with message
+
+---
+
+### 4. Config Loading Tests
+
+**Objective:** Verify project config takes priority over global config.
+
+**Automation:** ✅
+
+```bash
+SCRIPT="/Users/artem/devel/claude-plugins/plugins/semver/scripts/inject-rules.sh"
+
+# 4.1 Global config used when no project config
+mkdir -p /tmp/semver-global-test
+printf '%s' '{"triggerStrategy":"always"}' > /tmp/semver-global-test/semver.json
+
+output=$(env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver \
+  CLAUDE_PROJECT_DIR=/tmp/semver-no-project HOME=/tmp/semver-global-test bash "$SCRIPT")
+echo "$output" | grep -q "always" && echo "✅ global config used" || echo "❌ global config not picked up"
+
+# 4.2 Project config overrides global
+mkdir -p /tmp/semver-project-test/.claude
+printf '%s' '{"triggerStrategy":"auto"}' > /tmp/semver-project-test/.claude/semver.json
+
+output=$(env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver \
+  CLAUDE_PROJECT_DIR=/tmp/semver-project-test HOME=/tmp/semver-global-test bash "$SCRIPT")
+echo "$output" | grep -q "auto" && echo "✅ project config overrides global" || echo "❌ project config not used"
+
+rm -rf /tmp/semver-global-test /tmp/semver-project-test
+```
+
+---
+
+### 5. SessionStart Rules — Manual Test
+
+**Automation:** ⚠️ Manual only (requires fresh session)
+
+#### Manual Test Procedure
+
+**Step 1:** Ensure semver plugin is synced to cache:
+```bash
+claude-marketplace-sync --force --verbose 2>&1 | grep semver
+```
+
+**Step 2:** Start fresh Claude Code session in any project:
+```bash
+mkdir /tmp/semver-session-test && cd /tmp/semver-session-test && git init && claude
+```
+
+**Step 3:** Ask Claude: "What are the SemVer rules I should follow in this session?"
+
+**Expected:** Claude mentions MANDATORY SemVer rules, MAJOR/MINOR/PATCH, and trigger strategy.
+
+**Step 4:** Ask Claude: "How do I set up versioning for this project?"
+
+**Expected:** Claude mentions `/semver:setup` command.
+
+**Known failure modes:**
+
+| Symptom | Root Cause | Fix |
+|---------|-----------|-----|
+| No SemVer rules mentioned | Plugin not in cache | Run `claude-marketplace-sync --force` |
+| Rules appear but strategy is wrong | Old config cached | Delete `/tmp/claude-plugin-sync.log`, restart session |
+| SessionStart hook error | Script not executable | `chmod +x plugins/semver/scripts/*.sh` |
+
+---
+
+### 6. End-to-End Workflow — Manual Test
+
+**Automation:** ⚠️ Manual only (requires real git repo with version file)
+
+#### Procedure
+
+**Setup:**
+```bash
+mkdir /tmp/e2e-semver && cd /tmp/e2e-semver && git init
+printf '%s' '{"name":"test","version":"1.0.0"}' > package.json
+git add . && git commit -m "initial"
+git checkout -b feature/test-semver
+echo "// new feature" > src.js
+git add src.js
+```
+
+**Run `/semver:setup`** in Claude → configure: `package.json`, strategy `auto`, enforcement `ask`, base branch `main`.
+
+**Attempt commit without bump:**
+Ask Claude: "commit with message 'feat: add new feature'"
+
+**Expected:** Claude's PreToolUse hook fires, warns about missing version bump. Claude asks user whether to bump first.
+
+**Attempt commit with bump:**
+Ask Claude: "bump version to 1.1.0 and commit"
+
+**Expected:** Claude updates `package.json` version, stages it, and commits. No hook warning.
+
+---
+
+## Regression Testing Guide
+
+Run automated tests (categories 1–4) before:
+- Any release to main
+- After modifying `inject-rules.sh` or `validate-bump.sh`
+- After changing config schema
+
+Run the full suite including manual tests (5–6) when:
+- Upgrading to a new Claude Code version
+- After significant structural changes to the plugin
+
+To run all automated tests in one session:
+```
+Run all acceptance tests for the semver plugin at /Users/artem/devel/claude-plugins/plugins/semver — categories 1 through 4 from docs/ACCEPTANCE_TESTS.md
+```

--- a/plugins/semver/hooks/hooks.json
+++ b/plugins/semver/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/validate-bump.sh\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/inject-rules.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/semver/scripts/inject-rules.sh
+++ b/plugins/semver/scripts/inject-rules.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# SessionStart hook: inject SemVer rules into Claude's context.
+# Outputs ~150 tokens so Claude enforces version bumps automatically.
+# Silent on errors — never block session start.
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+PROJECT_CONFIG="${CLAUDE_PROJECT_DIR:-.}/.claude/semver.json"
+GLOBAL_CONFIG="$HOME/.claude/semver.json"
+
+# Read trigger strategy from config (project takes priority over global)
+TRIGGER="auto"
+if [[ -f "$PROJECT_CONFIG" ]]; then
+  _t=$(jq -r '.triggerStrategy // empty' "$PROJECT_CONFIG" 2>/dev/null || true)
+  [[ -n "$_t" ]] && TRIGGER="$_t"
+elif [[ -f "$GLOBAL_CONFIG" ]]; then
+  _t=$(jq -r '.triggerStrategy // empty' "$GLOBAL_CONFIG" 2>/dev/null || true)
+  [[ -n "$_t" ]] && TRIGGER="$_t"
+fi
+
+# Build strategy-specific rule line
+case "$TRIGGER" in
+  always)
+    STRATEGY_RULE="- Every commit with source changes MUST include a version bump — no exceptions"
+    ;;
+  *)
+    STRATEGY_RULE="- Evaluate each commit: new feature → MINOR, bug fix → PATCH, breaking change → MAJOR, docs/config only → skip"
+    ;;
+esac
+
+cat <<RULES
+## Semantic Versioning — Base Rules
+
+MANDATORY: Follow SemVer 2.0.0 when modifying project code.
+
+**Version format:** MAJOR.MINOR.PATCH
+- MAJOR: breaking changes (incompatible API changes)
+- MINOR: new features (backwards-compatible)
+- PATCH: bug fixes (backwards-compatible)
+
+**Trigger strategy: ${TRIGGER}**
+${STRATEGY_RULE}
+
+**Before committing or pushing:**
+1. Check \`.claude/semver.json\` for version file location(s) and base branch
+2. Run \`git diff <baseBranch>...HEAD --name-only -- <versionFile>\` to see if already bumped
+3. If not bumped and changes warrant it — bump, stage, and commit together with source changes
+4. On rebase conflict: check base branch version first, increment from there (not your original)
+
+- Run \`/semver:setup\` to configure versioning for this project
+- Run \`/semver:guide\` for full SemVer 2.0.0 reference and decision tree
+RULES

--- a/plugins/semver/scripts/validate-bump.sh
+++ b/plugins/semver/scripts/validate-bump.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# PreToolUse hook: validate version bumps before commit/push/PR creation.
+# Intercepts: git commit, git push, gh pr create, gh pr merge
+#
+# Input:  JSON from stdin with tool_input.command
+# Output: JSON with permissionDecision (allow/ask/deny) or exit 0 for passthrough
+
+set -euo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Read tool input from stdin
+INPUT=$(cat)
+
+# Extract the command
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+# Fast exit: empty or not git/gh command
+if [[ -z "$COMMAND" ]] || ! echo "$COMMAND" | grep -qE '^\s*(git\s|gh\s)'; then
+  exit 0
+fi
+
+# Fast exit: not a relevant subcommand
+if ! echo "$COMMAND" | grep -qE '\b(commit|push|pr)\b'; then
+  exit 0
+fi
+
+# For gh commands, only intercept pr create/merge
+if echo "$COMMAND" | grep -qE '^\s*gh\s'; then
+  if ! echo "$COMMAND" | grep -qE '\bpr\s+(create|merge)\b'; then
+    exit 0
+  fi
+fi
+
+# ─── Config loading ──────────────────────────────────────────────────────────
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+CONFIG_FILE="$PROJECT_DIR/.claude/semver.json"
+GLOBAL_CONFIG="$HOME/.claude/semver.json"
+
+# Defaults
+TRIGGER_STRATEGY="auto"
+BASE_BRANCH="main"
+ENFORCEMENT_MISSING_BUMP="ask"
+
+# Version files: newline-separated paths
+VERSION_FILE_PATHS=""
+
+# Exclude patterns: newline-separated
+EXCLUDE_PATTERNS="README.md
+CHANGELOG.md
+LICENSE
+.gitignore
+*.md
+docs/**
+.claude/**"
+
+load_config() {
+  local cfg="$1"
+  [[ ! -f "$cfg" ]] && return
+
+  _trigger=$(jq -r '.triggerStrategy // empty' "$cfg" 2>/dev/null || true)
+  [[ -n "$_trigger" ]] && TRIGGER_STRATEGY="$_trigger" || true
+
+  _base=$(jq -r '.baseBranch // empty' "$cfg" 2>/dev/null || true)
+  [[ -n "$_base" ]] && BASE_BRANCH="$_base" || true
+
+  _enforcement=$(jq -r '.enforcement.missingBump // empty' "$cfg" 2>/dev/null || true)
+  [[ -n "$_enforcement" ]] && ENFORCEMENT_MISSING_BUMP="$_enforcement" || true
+
+  _paths=$(jq -r '.versionFiles[]?.path // empty' "$cfg" 2>/dev/null || true)
+  [[ -n "$_paths" ]] && VERSION_FILE_PATHS="$_paths" || true
+
+  _excludes=$(jq -r '.excludePatterns[]? // empty' "$cfg" 2>/dev/null || true)
+  [[ -n "$_excludes" ]] && EXCLUDE_PATTERNS="$_excludes" || true
+
+  return 0
+}
+
+# Project config takes priority, fall back to global
+if [[ -f "$CONFIG_FILE" ]]; then
+  load_config "$CONFIG_FILE"
+elif [[ -f "$GLOBAL_CONFIG" ]]; then
+  load_config "$GLOBAL_CONFIG"
+fi
+
+# If enforcement is "allow", nothing to check
+if [[ "$ENFORCEMENT_MISSING_BUMP" == "allow" ]]; then
+  exit 0
+fi
+
+# Auto-detect version files if none configured
+if [[ -z "$VERSION_FILE_PATHS" ]]; then
+  for candidate in "package.json" "pyproject.toml" "Cargo.toml" ".claude-plugin/plugin.json" "version.txt"; do
+    if [[ -f "$PROJECT_DIR/$candidate" ]]; then
+      VERSION_FILE_PATHS="$candidate"
+      break
+    fi
+  done
+fi
+
+# If still no version files found — nothing to enforce
+if [[ -z "$VERSION_FILE_PATHS" ]]; then
+  exit 0
+fi
+
+# Not in a git repo — pass through silently
+if ! git -C "$PROJECT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+permission_response() {
+  local decision="$1"
+  local reason="$2"
+  # Use python3 to build valid JSON — handles newlines and special chars reliably
+  PYTHONPATH="" python3 -c "
+import sys, json
+d = sys.argv[1]
+r = sys.argv[2]
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': d, 'permissionDecisionReason': r}}))
+" "$decision" "$reason"
+  exit 0
+}
+
+# Check if any version file appears in git diff output.
+# Mode: "staged" (--cached) or "branch" (baseBranch...HEAD)
+check_version_bumped() {
+  local mode="$1"
+  while IFS= read -r vf; do
+    [[ -z "$vf" ]] && continue
+    local diff_out=""
+    if [[ "$mode" == "staged" ]]; then
+      diff_out=$(git -C "$PROJECT_DIR" diff --cached --name-only -- "$vf" 2>/dev/null || true)
+    else
+      diff_out=$(git -C "$PROJECT_DIR" diff "${BASE_BRANCH}...HEAD" --name-only -- "$vf" 2>/dev/null || true)
+    fi
+    if [[ -n "$diff_out" ]]; then
+      echo "bumped"
+      return
+    fi
+  done <<< "$VERSION_FILE_PATHS"
+  echo "not_bumped"
+}
+
+# Check if all changed files match exclude patterns.
+# Returns "excluded_only" or "has_source_changes".
+check_changes_excluded() {
+  local mode="$1"
+  local changed=""
+  if [[ "$mode" == "staged" ]]; then
+    changed=$(git -C "$PROJECT_DIR" diff --cached --name-only 2>/dev/null || true)
+  else
+    changed=$(git -C "$PROJECT_DIR" diff "${BASE_BRANCH}...HEAD" --name-only 2>/dev/null || true)
+  fi
+
+  [[ -z "$changed" ]] && echo "excluded_only" && return
+
+  local has_source=false
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    local excluded=false
+    while IFS= read -r pattern; do
+      [[ -z "$pattern" ]] && continue
+      # Match via bash glob — handle ** by stripping it to a prefix check
+      local simple_pattern="${pattern//\*\*/\*}"
+      if [[ "$f" == $simple_pattern ]] || [[ "$f" == $pattern ]]; then
+        excluded=true
+        break
+      fi
+    done <<< "$EXCLUDE_PATTERNS"
+    if [[ "$excluded" == "false" ]]; then
+      has_source=true
+      break
+    fi
+  done <<< "$changed"
+
+  if [[ "$has_source" == "true" ]]; then
+    echo "has_source_changes"
+  else
+    echo "excluded_only"
+  fi
+}
+
+# ─── Command dispatch ────────────────────────────────────────────────────────
+
+CMD=$(echo "$COMMAND" | sed 's/^[[:space:]]*//' | tr -s ' ')
+
+# Format version files list for messages
+VF_LIST=$(echo "$VERSION_FILE_PATHS" | tr '\n' ' ' | sed 's/ $//')
+
+# ── git commit ───────────────────────────────────────────────────────────────
+if echo "$CMD" | grep -qE '^git\s+commit(\s|$)'; then
+  # Skip detached HEAD
+  CURRENT_BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  [[ -z "$CURRENT_BRANCH" ]] || [[ "$CURRENT_BRANCH" == "HEAD" ]] && exit 0
+
+  bump=$(check_version_bumped "staged")
+  [[ "$bump" == "bumped" ]] && exit 0
+
+  changes=$(check_changes_excluded "staged")
+  [[ "$changes" == "excluded_only" ]] && exit 0
+
+  if [[ "$TRIGGER_STRATEGY" == "always" ]]; then
+    permission_response "$ENFORCEMENT_MISSING_BUMP" \
+"Version bump required but not found in staged files.
+
+Version file(s): $VF_LIST
+Strategy: always — every commit with source changes must include a version bump.
+
+Please update the version in $VF_LIST, stage it, and commit together with your changes."
+  else
+    permission_response "$ENFORCEMENT_MISSING_BUMP" \
+"No version bump detected in staged files.
+
+Version file(s): $VF_LIST
+Strategy: auto — evaluate whether these changes warrant a version bump:
+  - New feature or capability → MINOR (x.Y.0)
+  - Bug fix → PATCH (x.y.Z)
+  - Breaking change → MAJOR (X.0.0)
+  - Docs, config, refactor with no API change → skip
+
+If a bump is needed, update $VF_LIST and stage it before committing.
+Run /semver:guide for the full decision tree."
+  fi
+fi
+
+# ── git push ─────────────────────────────────────────────────────────────────
+if echo "$CMD" | grep -qE '^git\s+push(\s|$)'; then
+  CURRENT_BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  [[ -z "$CURRENT_BRANCH" ]] || [[ "$CURRENT_BRANCH" == "HEAD" ]] && exit 0
+
+  bump=$(check_version_bumped "branch")
+  [[ "$bump" == "bumped" ]] && exit 0
+
+  changes=$(check_changes_excluded "branch")
+  [[ "$changes" == "excluded_only" ]] && exit 0
+
+  permission_response "$ENFORCEMENT_MISSING_BUMP" \
+"Pushing branch without a version bump.
+
+Version file(s): $VF_LIST
+No version file was modified compared to '${BASE_BRANCH}'.
+
+If this branch contains meaningful changes, bump the version before pushing.
+Run /semver:guide for SemVer decision rules."
+fi
+
+# ── gh pr create / gh pr merge ───────────────────────────────────────────────
+if echo "$CMD" | grep -qE '^gh\s+pr\s+(create|merge)(\s|$)'; then
+  bump=$(check_version_bumped "branch")
+  [[ "$bump" == "bumped" ]] && exit 0
+
+  changes=$(check_changes_excluded "branch")
+  [[ "$changes" == "excluded_only" ]] && exit 0
+
+  permission_response "$ENFORCEMENT_MISSING_BUMP" \
+"Creating/merging PR without a version bump.
+
+Version file(s): $VF_LIST
+No version file was modified compared to '${BASE_BRANCH}'.
+
+Without a version bump, caches and package managers may not pick up your changes.
+Please bump the version before proceeding. Run /semver:guide for help."
+fi
+
+# Passthrough: let normal permission system handle everything else
+exit 0

--- a/plugins/semver/skills/semver-guide/SKILL.md
+++ b/plugins/semver/skills/semver-guide/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: semver-guide
+description: >
+  Invoked automatically when deciding version bumps to determine correct MAJOR/MINOR/PATCH increment.
+  Covers SemVer 2.0.0: version format, decision tree, conflict resolution, common mistakes.
+  Do NOT bump versions without consulting this guide for non-obvious cases.
+  Keywords: semver, version bump, major minor patch, breaking change, version conflict, semantic versioning.
+---
+
+# SemVer 2.0.0 Quick Reference
+
+## Version Format
+
+`MAJOR.MINOR.PATCH` — e.g., `2.1.0`
+
+When to reset: incrementing MINOR resets PATCH to 0; incrementing MAJOR resets both.
+
+## When to Increment
+
+### PATCH (x.y.**Z**)
+Backwards-compatible bug fixes. No new API surface.
+
+- Fixed crash on empty input
+- Corrected typo in error message
+- Performance optimization (same behavior)
+- Fixed race condition
+
+### MINOR (x.**Y**.0)
+New features, backwards-compatible. Reset PATCH to 0.
+
+- Added new API endpoint / function / command
+- Added optional parameter with default value
+- New configuration option (with sensible default)
+- Deprecated old API (still works)
+
+### MAJOR (**X**.0.0)
+Breaking changes. Reset MINOR and PATCH to 0.
+
+- Removed public API / function / command
+- Changed function signature (added required params)
+- Renamed public interface
+- Changed default behavior incompatibly
+- Dropped platform or dependency support
+
+## Decision Tree
+
+```
+Changed files → excluded (docs, LICENSE, .gitignore)? → YES → No bump needed
+                                                       → NO ↓
+Did you remove / rename / break existing API?  → YES → MAJOR
+Did you add new public API or feature?         → YES → MINOR (at minimum)
+Did you fix a bug?                             → YES → PATCH
+Refactoring, internal restructure only?        → PATCH (or skip if truly zero user impact)
+```
+
+## Initial Development (0.x.y)
+
+`0.x.y` signals the API is not yet stable — anything may change.
+- Start at `0.1.0`
+- Use `0.x.y` freely during development
+- Declare `1.0.0` for the first stable public release
+
+## Pre-release Versions
+
+Format: `1.0.0-alpha`, `1.0.0-alpha.1`, `1.0.0-beta.2`, `1.0.0-rc.1`
+
+Precedence: `alpha < alpha.1 < beta < rc.1 < release`
+
+Use for unstable or pre-release testing builds.
+
+## Conflict Resolution (Rebase / Merge)
+
+When you rebase and find a version conflict:
+
+1. Check base branch version:
+   ```bash
+   git show <baseBranch>:<versionFile> | jq -r '.version'
+   ```
+2. Compare with your bumped version:
+   - Base is **higher** → increment from base (not your original)
+   - Base is **same** → increment again (concurrent PR)
+   - Base is **lower** → keep yours (already correct)
+
+Example: You bumped `1.1.0 → 1.1.1`. Base is now `1.2.0` → yours becomes `1.2.1`.
+
+## Common Mistakes
+
+| Mistake | Correct approach |
+|---------|-----------------|
+| MAJOR for every change | MAJOR only for breaking changes |
+| No bump for bug fixes | PATCH for every bug fix |
+| Bumping for docs-only changes | Usually skip (unless docs are your product) |
+| Skipping versions (1.0.0 → 1.0.5) | Increment by 1 per release |
+| Adding MAJOR bump for new optional feature | Optional feature with default = MINOR |

--- a/plugins/semver/templates/semver.json
+++ b/plugins/semver/templates/semver.json
@@ -1,0 +1,24 @@
+{
+  "versionFiles": [
+    {
+      "path": "package.json",
+      "field": "version",
+      "format": "json"
+    }
+  ],
+  "triggerStrategy": "auto",
+  "baseBranch": "main",
+  "enforcement": {
+    "missingBump": "ask"
+  },
+  "commitFormat": "chore: bump version to {version}",
+  "excludePatterns": [
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    ".gitignore",
+    ".claude/**",
+    "docs/**",
+    "*.md"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add new **semver** plugin: enforces semantic versioning before commits, pushes, and PR creation/merge
- Generalizes the claude-plugins-specific versioning rules from CLAUDE.md into a reusable, config-driven plugin for any project
- Supports multiple version files, two trigger strategies, configurable enforcement levels

## How it works

**SessionStart hook** injects ~150 tokens of SemVer 2.0.0 rules adapted to the configured trigger strategy (`auto` or `always`).

**PreToolUse hook** intercepts `git commit`, `git push`, `gh pr create`, `gh pr merge` and checks whether a version file was modified. Returns `ask` or `deny` with guidance if bump is missing.

## Config (`.claude/semver.json`)

```json
{
  "versionFiles": [
    { "path": "package.json", "field": "version", "format": "json" }
  ],
  "triggerStrategy": "auto",
  "baseBranch": "main",
  "enforcement": { "missingBump": "ask" },
  "excludePatterns": ["*.md", "docs/**", ".claude/**"]
}
```

## Trigger strategies

| Strategy | Behavior |
|----------|---------|
| `auto` | Claude evaluates changes; skips bump for docs/config-only commits |
| `always` | Every commit with source changes must include a version bump |

## Skills

- **`/semver:setup`** — 7-step interactive wizard to configure version files, trigger strategy, enforcement, base branch, and exclude patterns
- **`/semver:guide`** — on-demand SemVer 2.0.0 reference: MAJOR/MINOR/PATCH definitions, decision tree, conflict resolution, common mistakes

## Test plan

- [ ] Run static checks: file existence, JSON validity, YAML frontmatter (see `docs/ACCEPTANCE_TESTS.md` test 1)
- [ ] Run `inject-rules.sh` unit tests: verify ~150 tokens output, strategy-specific rules (test 2)
- [ ] Run `validate-bump.sh` unit tests: passthrough, enforcement=allow, missing bump → ask (test 3)
- [ ] Run config loading tests: project config overrides global (test 4)
- [ ] Manual: fresh session → verify SemVer rules appear in context (test 5)
- [ ] Manual: end-to-end workflow with real git repo (test 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)