### PR TITLE
feat(playbook): store project config in .claude-plugin/ (v0.3.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,10 +95,27 @@ plugins/<name>/
 ├── scripts/                      # shell/python scripts called by hooks
 ├── commands/<cmd>/SKILL.md       # user-invocable slash commands
 ├── skills/<skill>/SKILL.md       # on-demand context-efficient skills
-├── templates/                    # project templates (pre-commit, CI)
+├── templates/                    # project templates (pre-commit, CI, default config)
 └── docs/
     └── ACCEPTANCE_TESTS.md       # comprehensive test documentation (REQUIRED)
 ```
+
+## Plugin Config Convention
+
+Plugins that need project-level configuration store config files in `.claude-plugin/`:
+
+| Scope | Path | Committed? | Example |
+|-------|------|-----------|---------|
+| **Project** (shared with team) | `{project}/.claude-plugin/<name>.json` | ✅ Yes | `.claude-plugin/playbook.json` |
+| **Global** (personal) | `~/.claude/<name>.json` | ❌ No | `~/.claude/playbook.json` |
+
+**Resolution order:** Project config takes priority over global. If both exist, project wins.
+
+**Backwards compatibility:** Scripts also check `{project}/.claude/<name>.json` as fallback for configs created before this convention.
+
+**Setup wizards** (`/playbook-setup`, `/semver-setup`, `/git-branch-naming-setup`, `/retroscope-setup`) write to `.claude-plugin/<name>.json` by default.
+
+---
 
 **IMPORTANT: `plugin.json` MUST include both `"commands"` and `"skills"` fields** for Claude Code to expose SKILL.md files to the skill system. Without the `"skills"` field, commands are not discoverable via `/skill-name` even if their SKILL.md files exist.
 
@@ -374,6 +391,10 @@ Claude Code has a bug where the plugin cache is not invalidated on auto-update (
 4. In hooks.json, use `${CLAUDE_PLUGIN_ROOT}` for script paths (see Hook Scripts Convention)
 5. Register in `.claude-plugin/marketplace.json`
 6. **Create acceptance test documentation** in `plugins/<name>/docs/ACCEPTANCE_TESTS.md`
+7. **If plugin needs project-level config:**
+   - Store default config template in `templates/<name>.json`
+   - Setup wizard writes to `{project}/.claude-plugin/<name>.json`
+   - Scripts read from `.claude-plugin/<name>.json` first, fall back to `.claude/<name>.json`
 
 ## Version Bump Requirements
 

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/commands/playbook-setup/SKILL.md
+++ b/plugins/playbook/commands/playbook-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: playbook-setup
 description: >
   Interactive setup wizard for playbook presets. Creates or updates
-  ~/.claude/playbook.json (global) or .claude/playbook.json (project).
+  ~/.claude/playbook.json (global) or .claude-plugin/playbook.json (project).
   Run this command to choose which coding guideline presets to enable.
   Keywords: playbook setup, configure guidelines, enable presets.
 ---
@@ -21,7 +21,7 @@ Read all `.md` files in `${SKILL_DIR}/../../presets/`. For each file, extract th
 
 Check both config files and display current state:
 - Global (`~/.claude/playbook.json`): list enabled presets
-- Project (`.claude/playbook.json` in repo root): list enabled presets and excludes
+- Project (`.claude-plugin/playbook.json` in repo root): list enabled presets and excludes
 - If neither exists, say "No presets configured yet."
 
 ### 3. Ask which presets to enable
@@ -32,7 +32,7 @@ Use `AskUserQuestion` with `multiSelect: true`. List all available presets with 
 
 Use `AskUserQuestion`:
 - **Global** (`~/.claude/playbook.json`) — applies to all projects by default
-- **Project** (`.claude/playbook.json`) — applies only to this project, committed to git
+- **Project** (`.claude-plugin/playbook.json`) — applies only to this project, committed to git
 
 ### 5. Handle excludes (project level only)
 

--- a/plugins/playbook/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/playbook/docs/ACCEPTANCE_TESTS.md
@@ -68,9 +68,9 @@ done
 SCRIPT="/Users/artem/devel/claude-plugins/plugins/playbook/scripts/inject-rules.sh"
 PLUGIN="/Users/artem/devel/claude-plugins/plugins/playbook"
 
-# Test 2.1: Project config with both presets
-mkdir -p /tmp/playbook-test-2/.claude
-printf '{"presets":["documentation-principles","github-workflow"]}' > /tmp/playbook-test-2/.claude/playbook.json
+# Test 2.1: Project config with both presets (new path .claude-plugin/)
+mkdir -p /tmp/playbook-test-2/.claude-plugin
+printf '{"presets":["documentation-principles","github-workflow"]}' > /tmp/playbook-test-2/.claude-plugin/playbook.json
 output=$(env CLAUDE_PROJECT_DIR=/tmp/playbook-test-2 CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
 echo "$output" | grep -q "MANDATORY" && echo "✅ 2.1: RULES extracted" || echo "❌ 2.1: RULES not found"
 echo "$output" | grep -q "Documentation" && echo "✅ 2.1: doc preset" || echo "❌ 2.1: doc preset missing"
@@ -81,13 +81,27 @@ output=$(env HOME=/tmp/nonexistent CLAUDE_PROJECT_DIR=/tmp/nonexistent CLAUDE_PL
 [[ -z "$output" ]] && echo "✅ 2.2: Silent exit" || echo "❌ 2.2: Unexpected output: $output"
 
 # Test 2.3: Nonexistent preset name (graceful skip)
-mkdir -p /tmp/playbook-test-3/.claude
-printf '{"presets":["nonexistent-preset"]}' > /tmp/playbook-test-3/.claude/playbook.json
+mkdir -p /tmp/playbook-test-3/.claude-plugin
+printf '{"presets":["nonexistent-preset"]}' > /tmp/playbook-test-3/.claude-plugin/playbook.json
 output=$(env CLAUDE_PROJECT_DIR=/tmp/playbook-test-3 HOME=/tmp/nonexistent CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
 [[ -z "$output" ]] && echo "✅ 2.3: Nonexistent preset skipped silently" || echo "❌ 2.3: Unexpected output"
 
+# Test 2.4: Backwards compatibility — old path .claude/ still works
+mkdir -p /tmp/playbook-test-4/.claude
+printf '{"presets":["documentation-principles"]}' > /tmp/playbook-test-4/.claude/playbook.json
+output=$(env CLAUDE_PROJECT_DIR=/tmp/playbook-test-4 CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
+echo "$output" | grep -q "MANDATORY" && echo "✅ 2.4: Old path fallback works" || echo "❌ 2.4: Old path fallback broken"
+
+# Test 2.5: New path takes priority over old path
+mkdir -p /tmp/playbook-test-5/.claude-plugin /tmp/playbook-test-5/.claude
+printf '{"presets":["documentation-principles"]}' > /tmp/playbook-test-5/.claude-plugin/playbook.json
+printf '{"presets":["github-workflow"]}' > /tmp/playbook-test-5/.claude/playbook.json
+output=$(env CLAUDE_PROJECT_DIR=/tmp/playbook-test-5 CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
+echo "$output" | grep -q "Documentation" && echo "✅ 2.5: New path wins" || echo "❌ 2.5: New path not prioritized"
+echo "$output" | grep -q "GitHub Workflow" && echo "❌ 2.5: Old path should not win" || echo "✅ 2.5: Old path correctly ignored"
+
 # Cleanup
-rm -rf /tmp/playbook-test-2 /tmp/playbook-test-3
+rm -rf /tmp/playbook-test-2 /tmp/playbook-test-3 /tmp/playbook-test-4 /tmp/playbook-test-5
 ```
 
 **Expected result:**
@@ -120,14 +134,14 @@ echo "$output" | grep -q "Documentation" && echo "✅ 3.1: Global doc preset" ||
 echo "$output" | grep -q "GitHub Workflow" && echo "✅ 3.1: Global github preset" || echo "❌ 3.1"
 
 # Test 3.2: Project excludes one global preset
-mkdir -p /tmp/playbook-proj-test/.claude
-printf '{"presets":[],"exclude":["documentation-principles"]}' > /tmp/playbook-proj-test/.claude/playbook.json
+mkdir -p /tmp/playbook-proj-test/.claude-plugin
+printf '{"presets":[],"exclude":["documentation-principles"]}' > /tmp/playbook-proj-test/.claude-plugin/playbook.json
 output=$(env HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR=/tmp/playbook-proj-test CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
 echo "$output" | grep -q "Documentation" && echo "❌ 3.2: Doc should be excluded" || echo "✅ 3.2: Doc excluded"
 echo "$output" | grep -q "GitHub Workflow" && echo "✅ 3.2: Github kept" || echo "❌ 3.2: Github missing"
 
 # Test 3.3: Deduplication (same preset in both configs)
-printf '{"presets":["documentation-principles"]}' > /tmp/playbook-proj-test/.claude/playbook.json
+printf '{"presets":["documentation-principles"]}' > /tmp/playbook-proj-test/.claude-plugin/playbook.json
 output=$(env HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR=/tmp/playbook-proj-test CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$SCRIPT")
 count=$(echo "$output" | grep -c "Documentation — Base Rules")
 [[ "$count" -eq 1 ]] && echo "✅ 3.3: No duplication" || echo "❌ 3.3: Duplicated ($count times)"

--- a/plugins/playbook/scripts/inject-rules.sh
+++ b/plugins/playbook/scripts/inject-rules.sh
@@ -9,7 +9,15 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 PRESETS_DIR="$PLUGIN_ROOT/presets"
 
 GLOBAL_CONFIG="$HOME/.claude/playbook.json"
-PROJECT_CONFIG="${CLAUDE_PROJECT_DIR:-.}/.claude/playbook.json"
+_new="${CLAUDE_PROJECT_DIR:-.}/.claude-plugin/playbook.json"
+_old="${CLAUDE_PROJECT_DIR:-.}/.claude/playbook.json"
+if [[ -f "$_new" ]]; then
+  PROJECT_CONFIG="$_new"
+elif [[ -f "$_old" ]]; then
+  PROJECT_CONFIG="$_old"
+else
+  PROJECT_CONFIG="$_new"
+fi
 
 # Collect preset names from both configs
 global_presets=""


### PR DESCRIPTION
## Summary

- Migrates project-level `playbook.json` config from `.claude/` to `.claude-plugin/` so it gets committed and shared with team
- Backwards-compatible: `inject-rules.sh` checks `.claude-plugin/playbook.json` first, falls back to `.claude/playbook.json`
- Updates setup wizard and docs to reference new path
- Adds backwards-compatibility tests (2.4, 2.5) to ACCEPTANCE_TESTS.md
- Adds **Plugin Config Convention** section to root `CLAUDE.md`

## Test plan

- [ ] Run acceptance tests 2.1–2.5: `bash plugins/playbook/docs/ACCEPTANCE_TESTS.md` (copy commands from file)
- [ ] Verify new path works: create `.claude-plugin/playbook.json` with preset, confirm rules injected
- [ ] Verify old path fallback: create `.claude/playbook.json`, confirm still works
- [ ] Verify new path wins when both exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)