### PR TITLE
feat(semver): store project config in .claude-plugin/ (v0.2.0)

### DIFF
--- a/plugins/semver/.claude-plugin/plugin.json
+++ b/plugins/semver/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semver",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Semantic versioning enforcement: validates version bumps before commit/push/PR, supports multiple version files",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/semver/commands/semver-setup/SKILL.md
+++ b/plugins/semver/commands/semver-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: semver-setup
 description: >
   Interactive setup wizard for semantic versioning enforcement.
-  Creates or updates .claude/semver.json with version files, trigger strategy, and enforcement rules.
+  Creates or updates .claude-plugin/semver.json with version files, trigger strategy, and enforcement rules.
   Run this command to configure SemVer for your project.
   Keywords: setup semver, configure versioning, version config, semver setup, version bump config.
 ---
@@ -16,7 +16,7 @@ Configure semantic versioning enforcement for this project.
 ### 1. Detect existing config and version files
 
 Check for existing configuration:
-- Read `.claude/semver.json` if present (use as defaults for all questions)
+- Read `.claude-plugin/semver.json` if present (use as defaults for all questions)
 - Auto-detect common version files in the project root: `package.json`, `pyproject.toml`, `Cargo.toml`, `.claude-plugin/plugin.json`, `version.txt`
 - For monorepos: also scan one level deep (e.g., `packages/*/package.json`)
 
@@ -65,14 +65,14 @@ Show default patterns and let user customize:
 
 Default exclusions (files that never require a version bump):
 ```
-README.md, CHANGELOG.md, LICENSE, .gitignore, *.md, docs/**, .claude/**
+README.md, CHANGELOG.md, LICENSE, .gitignore, *.md, docs/**, .claude/**, .claude-plugin/**
 ```
 
 Use `AskUserQuestion` — ask if user wants to add or remove any patterns.
 
 ### 7. Write config
 
-Write `.claude/semver.json` with all chosen settings:
+Write `.claude-plugin/semver.json` with all chosen settings:
 
 ```json
 {
@@ -85,22 +85,22 @@ Write `.claude/semver.json` with all chosen settings:
     "missingBump": "ask"
   },
   "commitFormat": "chore: bump version to {version}",
-  "excludePatterns": ["README.md", "CHANGELOG.md", "LICENSE", ".gitignore", "*.md", "docs/**", ".claude/**"]
+  "excludePatterns": ["README.md", "CHANGELOG.md", "LICENSE", ".gitignore", "*.md", "docs/**", ".claude/**", ".claude-plugin/**"]
 }
 ```
 
-Create `.claude/` directory if it doesn't exist.
+Create `.claude-plugin/` directory if it doesn't exist.
 
 ### 8. Show confirmation
 
 Display:
-- Path written: `.claude/semver.json`
+- Path written: `.claude-plugin/semver.json`
 - Summary of settings (version files, strategy, enforcement, base branch)
 - Next steps:
 
 ```
 Next steps:
-1. git add .claude/semver.json && git commit -m "chore: add semver config"
+1. git add .claude-plugin/semver.json && git commit -m "chore: add semver config"
 2. Push to share enforcement rules with your team
 3. Run /semver:guide for the full SemVer 2.0.0 reference
 ```

--- a/plugins/semver/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/semver/docs/ACCEPTANCE_TESTS.md
@@ -89,9 +89,9 @@ echo "$output" | grep -q "auto" && echo "✅ auto strategy in output" || echo "�
 echo "$output" | grep -q "MANDATORY" && echo "✅ MANDATORY keyword present" || echo "❌ MANDATORY missing"
 echo "$output" | grep -q "semver:setup" && echo "✅ setup pointer present" || echo "❌ setup pointer missing"
 
-# 2.2 Config with "always" strategy
-mkdir -p /tmp/semver-test/.claude
-printf '%s' '{"triggerStrategy":"always"}' > /tmp/semver-test/.claude/semver.json
+# 2.2 Config with "always" strategy (new path .claude-plugin/)
+mkdir -p /tmp/semver-test/.claude-plugin
+printf '%s' '{"triggerStrategy":"always"}' > /tmp/semver-test/.claude-plugin/semver.json
 output=$(env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver \
   CLAUDE_PROJECT_DIR=/tmp/semver-test bash "$SCRIPT")
 echo "$output" | grep -q "always" && echo "✅ always strategy in output" || echo "❌ always strategy missing"
@@ -127,9 +127,9 @@ echo "$result" | grep -q "exit:0" && ! echo "$result" | grep -q "permissionDecis
   echo "✅ git status passes through" || echo "❌ unexpected output"
 
 # 3.3 Passthrough: enforcement "allow"
-mkdir -p /tmp/semver-test2/.claude
+mkdir -p /tmp/semver-test2/.claude-plugin
 printf '%s' '{"versionFiles":[{"path":"package.json","field":"version","format":"json"}],"enforcement":{"missingBump":"allow"}}' \
-  > /tmp/semver-test2/.claude/semver.json
+  > /tmp/semver-test2/.claude-plugin/semver.json
 result=$(printf '%s' '{"tool_input":{"command":"git commit -m \"test\""}}' | \
   env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver \
       CLAUDE_PROJECT_DIR=/tmp/semver-test2 bash "$SCRIPT"; echo "exit:$?")
@@ -163,9 +163,9 @@ output=$(env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver
   CLAUDE_PROJECT_DIR=/tmp/semver-no-project HOME=/tmp/semver-global-test bash "$SCRIPT")
 echo "$output" | grep -q "always" && echo "✅ global config used" || echo "❌ global config not picked up"
 
-# 4.2 Project config overrides global
-mkdir -p /tmp/semver-project-test/.claude
-printf '%s' '{"triggerStrategy":"auto"}' > /tmp/semver-project-test/.claude/semver.json
+# 4.2 Project config overrides global (new path .claude-plugin/)
+mkdir -p /tmp/semver-project-test/.claude-plugin
+printf '%s' '{"triggerStrategy":"auto"}' > /tmp/semver-project-test/.claude-plugin/semver.json
 
 output=$(env CLAUDE_PLUGIN_ROOT=/Users/artem/devel/claude-plugins/plugins/semver \
   CLAUDE_PROJECT_DIR=/tmp/semver-project-test HOME=/tmp/semver-global-test bash "$SCRIPT")

--- a/plugins/semver/scripts/inject-rules.sh
+++ b/plugins/semver/scripts/inject-rules.sh
@@ -5,7 +5,15 @@
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
-PROJECT_CONFIG="${CLAUDE_PROJECT_DIR:-.}/.claude/semver.json"
+_new="${CLAUDE_PROJECT_DIR:-.}/.claude-plugin/semver.json"
+_old="${CLAUDE_PROJECT_DIR:-.}/.claude/semver.json"
+if [[ -f "$_new" ]]; then
+  PROJECT_CONFIG="$_new"
+elif [[ -f "$_old" ]]; then
+  PROJECT_CONFIG="$_old"
+else
+  PROJECT_CONFIG="$_new"
+fi
 GLOBAL_CONFIG="$HOME/.claude/semver.json"
 
 # Read trigger strategy from config (project takes priority over global)
@@ -42,7 +50,7 @@ MANDATORY: Follow SemVer 2.0.0 when modifying project code.
 ${STRATEGY_RULE}
 
 **Before committing or pushing:**
-1. Check \`.claude/semver.json\` for version file location(s) and base branch
+1. Check \`.claude-plugin/semver.json\` for version file location(s) and base branch
 2. Run \`git diff <baseBranch>...HEAD --name-only -- <versionFile>\` to see if already bumped
 3. If not bumped and changes warrant it — bump, stage, and commit together with source changes
 4. On rebase conflict: check base branch version first, increment from there (not your original)

--- a/plugins/semver/scripts/validate-bump.sh
+++ b/plugins/semver/scripts/validate-bump.sh
@@ -35,7 +35,15 @@ fi
 # ─── Config loading ──────────────────────────────────────────────────────────
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
-CONFIG_FILE="$PROJECT_DIR/.claude/semver.json"
+_new="$PROJECT_DIR/.claude-plugin/semver.json"
+_old="$PROJECT_DIR/.claude/semver.json"
+if [[ -f "$_new" ]]; then
+  CONFIG_FILE="$_new"
+elif [[ -f "$_old" ]]; then
+  CONFIG_FILE="$_old"
+else
+  CONFIG_FILE="$_new"
+fi
 GLOBAL_CONFIG="$HOME/.claude/semver.json"
 
 # Defaults
@@ -53,7 +61,8 @@ LICENSE
 .gitignore
 *.md
 docs/**
-.claude/**"
+.claude/**
+.claude-plugin/**"
 
 load_config() {
   local cfg="$1"

--- a/plugins/semver/templates/semver.json
+++ b/plugins/semver/templates/semver.json
@@ -18,6 +18,7 @@
     "LICENSE",
     ".gitignore",
     ".claude/**",
+    ".claude-plugin/**",
     "docs/**",
     "*.md"
   ]


### PR DESCRIPTION
## Summary

- Migrates project-level `semver.json` config from `.claude/` to `.claude-plugin/` so it gets committed and shared with team
- Backwards-compatible: both `inject-rules.sh` and `validate-bump.sh` check `.claude-plugin/semver.json` first, fall back to `.claude/semver.json`
- Updates setup wizard and docs to reference new path
- Adds `.claude-plugin/**` to default `excludePatterns` in template and SKILL.md
- Updates ACCEPTANCE_TESTS.md test paths

## Test plan

- [ ] Run acceptance tests 2.2, 3.3, 4.2 with new path `.claude-plugin/semver.json`
- [ ] Verify `validate-bump.sh` reads config from new path
- [ ] Verify old path `.claude/semver.json` still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)