### PR TITLE
feat(git-branch-naming): store project config in .claude-plugin/ (v0.2.0)

### DIFF
--- a/plugins/git-branch-naming/.claude-plugin/plugin.json
+++ b/plugins/git-branch-naming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-branch-naming",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Git branch naming convention enforcement: validates names, warns on content mismatch before push",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/git-branch-naming/README.md
+++ b/plugins/git-branch-naming/README.md
@@ -8,7 +8,7 @@ A Claude Code plugin that enforces git branch naming conventions. Validates bran
 - **Warns on content mismatch** before `git commit` (staged files) and `git push` (full branch diff)
 - **Protects main branches** from direct pushes
 - **Injects naming rules** into every Claude Code session (zero extra user prompts)
-- **Configurable per project** via `.claude/git-branch-naming.json` — committed to git and shared team-wide
+- **Configurable per project** via `.claude-plugin/git-branch-naming.json` — committed to git and shared team-wide
 
 ## Why This Plugin Exists
 
@@ -114,7 +114,7 @@ This is usually done via a pull request instead of a direct push. Are you sure?
 
 ### Scenario 6: Team-wide conventions via committed config
 
-Your team uses JIRA and wants strict enforcement. One dev runs `/git-branch-naming:setup`, commits `.claude/git-branch-naming.json`, and from that point every teammate's Claude Code session enforces the same rules — no onboarding docs required.
+Your team uses JIRA and wants strict enforcement. One dev runs `/git-branch-naming:setup`, commits `.claude-plugin/git-branch-naming.json`, and from that point every teammate's Claude Code session enforces the same rules — no onboarding docs required.
 
 ## Branch Name Format
 
@@ -152,11 +152,11 @@ In a Claude Code session:
 /git-branch-naming:setup
 ```
 
-This creates `.claude/git-branch-naming.json` with your project's conventions. Commit it to git to share with your team.
+This creates `.claude-plugin/git-branch-naming.json` with your project's conventions. Commit it to git to share with your team.
 
 ## Configuration
 
-Configuration lives in `.claude/git-branch-naming.json` (committed to git, team-wide).
+Configuration lives in `.claude-plugin/git-branch-naming.json` (committed to git, team-wide).
 
 ### Schema
 
@@ -224,7 +224,7 @@ This requires ticket numbers: `feature/PROJ-123-add-login`
 
 2. **Commit both files:**
    ```bash
-   git add .claude/settings.json .claude/git-branch-naming.json
+   git add .claude/settings.json .claude-plugin/git-branch-naming.json
    git commit -m "chore: add git branch naming conventions"
    git push
    ```
@@ -274,7 +274,7 @@ git config core.hooksPath .githooks
 
 Or let the setup wizard install it: `/git-branch-naming:setup` → answer "Yes" to hook installation.
 
-The hook reads the same `.claude/git-branch-naming.json` config file.
+The hook reads `.claude-plugin/git-branch-naming.json` (falls back to `.claude/git-branch-naming.json` for backwards compatibility).
 
 ## Architecture
 

--- a/plugins/git-branch-naming/commands/git-branch-naming-setup/SKILL.md
+++ b/plugins/git-branch-naming/commands/git-branch-naming-setup/SKILL.md
@@ -2,14 +2,14 @@
 name: git-branch-naming-setup
 description: >
   Interactive setup wizard for git branch naming conventions.
-  Creates or updates .claude/git-branch-naming.json with project-specific rules.
+  Creates or updates .claude-plugin/git-branch-naming.json with project-specific rules.
   Run this command to configure prefixes, ticket patterns, enforcement levels, and protected branches.
   Keywords: setup branch naming, configure conventions, branch config, git naming setup.
 ---
 
 # Git Branch Naming Setup
 
-Interactive wizard to create or update `.claude/git-branch-naming.json` for your project.
+Interactive wizard to create or update `.claude-plugin/git-branch-naming.json` for your project.
 
 ## What this command does
 
@@ -22,7 +22,7 @@ Interactive wizard to create or update `.claude/git-branch-naming.json` for your
 
 ### Step 1: Check existing config
 
-Read `.claude/git-branch-naming.json` if it exists (show current values as defaults).
+Read `.claude-plugin/git-branch-naming.json` if it exists (show current values as defaults).
 Otherwise use defaults from `${SKILL_DIR}/../../templates/git-branch-naming.json`.
 
 ### Step 2: Ask configuration questions
@@ -63,7 +63,7 @@ Use `AskUserQuestion` to collect:
 
 ### Step 3: Write config file
 
-Create `.claude/` directory if needed, then write `.claude/git-branch-naming.json`:
+Create `.claude-plugin/` directory if needed, then write `.claude-plugin/git-branch-naming.json`:
 
 ```json
 {
@@ -92,10 +92,10 @@ git config core.hooksPath .githooks
 ### Step 5: Show next steps to user
 
 ```
-✅ Configuration saved to .claude/git-branch-naming.json
+✅ Configuration saved to .claude-plugin/git-branch-naming.json
 
 Next steps:
-1. Commit this file: git add .claude/git-branch-naming.json && git commit -m "chore: add branch naming config"
+1. Commit this file: git add .claude-plugin/git-branch-naming.json && git commit -m "chore: add branch naming config"
 2. Add plugin to .claude/settings.json: { "enabledPlugins": { "git-branch-naming@tribe-coding": true } }
 3. Push to share conventions with your team
 

--- a/plugins/git-branch-naming/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/git-branch-naming/docs/ACCEPTANCE_TESTS.md
@@ -4,7 +4,7 @@
 
 The `git-branch-naming` plugin enforces git branch naming conventions via PreToolUse hooks and injected SessionStart rules. These tests verify:
 - Branch name validation (format, prefix, kebab-case, ticket, length)
-- Config loading from `.claude/git-branch-naming.json`
+- Config loading from `.claude-plugin/git-branch-naming.json`
 - Protected branch warnings before push
 - Content mismatch detection at `git commit` and `git push`
 - SessionStart rules injection
@@ -161,15 +161,15 @@ printf '%s' '{"tool_input":{"command":"git push origin main"}}' \
 
 ## 4. Config Loading Tests
 
-**Objective:** Verify config loading from `.claude/git-branch-naming.json`.
+**Objective:** Verify config loading from `.claude-plugin/git-branch-naming.json`.
 
 **Automation:** ✅
 
 **Setup:**
 ```bash
-# Create test config
-mkdir -p /tmp/test-project/.claude
-cat > /tmp/test-project/.claude/git-branch-naming.json <<'EOF'
+# Create test config (new path .claude-plugin/)
+mkdir -p /tmp/test-project/.claude-plugin
+cat > /tmp/test-project/.claude-plugin/git-branch-naming.json <<'EOF'
 {
   "prefixes": ["feat", "fix"],
   "maxLength": 30,
@@ -303,7 +303,8 @@ bash .githooks/pre-push
 echo "Exit: $?"  # Expected: 0 (ask = warn, don't block)
 
 # Test: deny enforcement → exit 1
-cat > .claude/git-branch-naming.json <<'EOF'
+mkdir -p .claude-plugin
+cat > .claude-plugin/git-branch-naming.json <<'EOF'
 {"prefixes":["feature"],"enforcement":{"invalidName":"deny","protectedBranch":"deny","contentMismatch":"ask"}}
 EOF
 git checkout -q -b my-bad-branch2
@@ -333,7 +334,7 @@ echo "Exit: $?"  # Expected: 1 (deny = block)
 
 2. Verify rules loaded:
    Ask: "What are the rules for git branch naming in this session?"
-   Expected: Claude mentions prefixes, kebab-case, and `.claude/git-branch-naming.json`
+   Expected: Claude mentions prefixes, kebab-case, and `.claude-plugin/git-branch-naming.json`
 
 3. Test proactive enforcement — invalid branch name:
    Ask: "Create a git branch called `my-new-feature`"
@@ -385,12 +386,12 @@ If rules are NOT enforced in your test session:
 4. When prompted for max length: select 60
 5. When prompted for enforcement: select "Ask (warn)"
 6. When prompted for pre-push hook: select "No"
-7. Verify file created: `cat .claude/git-branch-naming.json`
-8. Verify JSON is valid: `jq . .claude/git-branch-naming.json`
+7. Verify file created: `cat .claude-plugin/git-branch-naming.json`
+8. Verify JSON is valid: `jq . .claude-plugin/git-branch-naming.json`
 
 **Acceptance criteria:**
 - ✅ Wizard asks all 7 questions
-- ✅ Config file created at `.claude/git-branch-naming.json`
+- ✅ Config file created at `.claude-plugin/git-branch-naming.json`
 - ✅ File is valid JSON
 - ✅ All selected values appear in output
 - ✅ Summary with "next steps" shown after completion
@@ -438,7 +439,7 @@ docker run --rm -v $(pwd):/plugins alpine sh -c \
 5. Verify same enforcement levels apply
 
 **Acceptance criteria:**
-- ✅ Cloned repo has `.claude/git-branch-naming.json`
+- ✅ Cloned repo has `.claude-plugin/git-branch-naming.json`
 - ✅ Plugin reads config from cloned repo
 - ✅ Same enforcement levels apply in both repos
 

--- a/plugins/git-branch-naming/scripts/inject-rules.sh
+++ b/plugins/git-branch-naming/scripts/inject-rules.sh
@@ -26,7 +26,7 @@ Rules:
 - ALWAYS use kebab-case (lowercase, hyphens only — no underscores, no spaces)
 - NEVER commit directly to `main`, `master`, or `develop` — always use a feature branch
 - NEVER push directly to `main`, `master`, or `develop` without confirmation
-- Check `.claude/git-branch-naming.json` for project-specific rules (ticket patterns, custom prefixes, enforcement levels)
+- Check `.claude-plugin/git-branch-naming.json` for project-specific rules (ticket patterns, custom prefixes, enforcement levels)
 - Before commit/push, verify your staged files match the branch type (e.g., `docs/` branch should not contain only code files)
 - Run `/git-branch-naming:setup` to create or update project configuration
 RULES

--- a/plugins/git-branch-naming/scripts/validate-branch.sh
+++ b/plugins/git-branch-naming/scripts/validate-branch.sh
@@ -27,7 +27,15 @@ fi
 
 # ─── Config loading ─────────────────────────────────────────────────────────
 
-CONFIG_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/git-branch-naming.json"
+_new="${CLAUDE_PROJECT_DIR:-.}/.claude-plugin/git-branch-naming.json"
+_old="${CLAUDE_PROJECT_DIR:-.}/.claude/git-branch-naming.json"
+if [[ -f "$_new" ]]; then
+  CONFIG_FILE="$_new"
+elif [[ -f "$_old" ]]; then
+  CONFIG_FILE="$_old"
+else
+  CONFIG_FILE="$_new"
+fi
 
 # Defaults
 PREFIXES="feature|bugfix|hotfix|release|docs|test|chore|refactor"

--- a/plugins/git-branch-naming/skills/branch-naming-guide/SKILL.md
+++ b/plugins/git-branch-naming/skills/branch-naming-guide/SKILL.md
@@ -54,7 +54,7 @@ description: >
 
 ## Checking Project Config
 
-If `.claude/git-branch-naming.json` exists in the project, it may override:
+If `.claude-plugin/git-branch-naming.json` exists in the project, it may override:
 - Allowed prefixes
 - Required ticket pattern (e.g., `JIRA-\d+`, `#\d+`)
 - Max branch name length

--- a/plugins/git-branch-naming/templates/pre-push
+++ b/plugins/git-branch-naming/templates/pre-push
@@ -10,7 +10,15 @@ set -euo pipefail
 
 # Find project root (directory containing .git)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-CONFIG_FILE="$REPO_ROOT/.claude/git-branch-naming.json"
+_new="$REPO_ROOT/.claude-plugin/git-branch-naming.json"
+_old="$REPO_ROOT/.claude/git-branch-naming.json"
+if [[ -f "$_new" ]]; then
+  CONFIG_FILE="$_new"
+elif [[ -f "$_old" ]]; then
+  CONFIG_FILE="$_old"
+else
+  CONFIG_FILE="$_new"
+fi
 
 # ─── Load config ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Migrates project-level `git-branch-naming.json` config from `.claude/` to `.claude-plugin/` so it gets committed and shared with team
- Backwards-compatible: `validate-branch.sh` and `templates/pre-push` check `.claude-plugin/` first, fall back to `.claude/`
- Updates setup wizard, branch-naming-guide, inject-rules, README, and ACCEPTANCE_TESTS to reference new path

## Test plan

- [ ] Run acceptance test 4 with config at `.claude-plugin/git-branch-naming.json`
- [ ] Verify `validate-branch.sh` reads config from new path
- [ ] Verify `templates/pre-push` reads from new path
- [ ] Verify old path `.claude/git-branch-naming.json` still works as fallback
- [ ] Test team sharing: commit config to `.claude-plugin/`, clone repo, verify rules enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)