### PR TITLE
feat(retroscope): store project config in .claude-plugin/ (v0.2.0)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -78,7 +78,7 @@ Reports are saved as git-tracked markdown files:
 
 ## Configuration
 
-Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude/retroscope.json` (project-level overrides).
+Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin/retroscope.json` (project-level overrides).
 
 | Field | Default | Description |
 |-------|---------|-------------|

--- a/plugins/retroscope/commands/retro/SKILL.md
+++ b/plugins/retroscope/commands/retro/SKILL.md
@@ -24,8 +24,9 @@ Add `--force` to any mode to regenerate even if a cached report exists (e.g., `/
 ## Step 1: Load Config
 
 Look for config in this order:
-1. `{CLAUDE_PROJECT_DIR}/.claude/retroscope.json` (project-level)
-2. `~/.claude/retroscope.json` (user-level)
+1. `{CLAUDE_PROJECT_DIR}/.claude-plugin/retroscope.json` (project-level, preferred)
+2. `{CLAUDE_PROJECT_DIR}/.claude/retroscope.json` (project-level, legacy fallback)
+3. `~/.claude/retroscope.json` (user-level)
 
 **If no config found:** ask the user whether to run setup now using AskUserQuestion:
 - Option A: "Yes, run setup now" → invoke `/retroscope:setup` skill and **stop**.

--- a/plugins/retroscope/commands/retroscope-setup/SKILL.md
+++ b/plugins/retroscope/commands/retroscope-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: retroscope-setup
 description: >
   Interactive setup wizard for retroscope retrospective reports.
-  Creates or updates ~/.claude/retroscope.json and .claude/retroscope.json.
+  Creates or updates ~/.claude/retroscope.json and .claude-plugin/retroscope.json.
   Run this command to configure storage directory, language, model, and options.
   Keywords: retroscope setup, configure retro, retroscope config, setup retrospective.
 ---
@@ -23,7 +23,7 @@ Interactive wizard to configure the retroscope plugin for your environment and p
 
 Read existing configs (show current values as defaults):
 - `~/.claude/retroscope.json` — user-level (global defaults)
-- `.claude/retroscope.json` — project-level (overrides)
+- `.claude-plugin/retroscope.json` — project-level (overrides)
 
 ## Step 2: Ask Configuration Questions
 
@@ -118,9 +118,9 @@ python3 -c "import datetime; print(datetime.datetime.now().astimezone().tzname()
 readlink /etc/localtime | sed 's|.*/zoneinfo/||'
 ```
 
-### Project-level config: `.claude/retroscope.json`
+### Project-level config: `.claude-plugin/retroscope.json`
 
-Create `.claude/` if needed, write project-level overrides. By default, identical to user-level config (user can manually edit to override per project later).
+Create `.claude-plugin/` if needed, write project-level overrides. By default, identical to user-level config (user can manually edit to override per project later).
 
 ## Step 4: Initialize Storage Repository
 

--- a/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
@@ -296,7 +296,7 @@ When retroscope config is absent, `/retro` must ask about setup **before** offer
 1. Ensure no config exists:
    ```bash
    ls ~/.claude/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
-   ls .claude/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
+   ls .claude-plugin/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
    ```
 2. Run any `/retro` command (with or without mode argument):
    ```
@@ -428,10 +428,10 @@ git -C "$STORAGE_DIR" log --oneline -3
 ```bash
 SCRIPT="/Users/artem/devel/claude-plugins/plugins/retroscope/scripts/session-end.sh"
 
-# Create temp config with suggestRetroOnExit=true
+# Create temp config with suggestRetroOnExit=true (new path .claude-plugin/)
 TMPDIR=$(mktemp -d)
-mkdir -p "$TMPDIR/.claude"
-printf '%s' '{"suggestRetroOnExit": true}' > "$TMPDIR/.claude/retroscope.json"
+mkdir -p "$TMPDIR/.claude-plugin"
+printf '%s' '{"suggestRetroOnExit": true}' > "$TMPDIR/.claude-plugin/retroscope.json"
 
 env CLAUDE_PROJECT_DIR="$TMPDIR" bash "$SCRIPT"
 rm -rf "$TMPDIR"
@@ -446,8 +446,8 @@ rm -rf "$TMPDIR"
 SCRIPT="/Users/artem/devel/claude-plugins/plugins/retroscope/scripts/session-end.sh"
 
 TMPDIR=$(mktemp -d)
-mkdir -p "$TMPDIR/.claude"
-printf '%s' '{"suggestRetroOnExit": false}' > "$TMPDIR/.claude/retroscope.json"
+mkdir -p "$TMPDIR/.claude-plugin"
+printf '%s' '{"suggestRetroOnExit": false}' > "$TMPDIR/.claude-plugin/retroscope.json"
 
 OUTPUT=$(env CLAUDE_PROJECT_DIR="$TMPDIR" bash "$SCRIPT")
 if [ -z "$(echo "$OUTPUT" | tr -d '[:space:]')" ]; then
@@ -488,7 +488,7 @@ env CLAUDE_PROJECT_DIR="/tmp/nonexistent-project-xyz-retroscope" bash "$SCRIPT"
 **Step 2:** Ensure no existing retroscope config:
 ```bash
 ls ~/.claude/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
-ls .claude/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
+ls .claude-plugin/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
 ```
 
 **Step 3:** Run setup wizard:
@@ -508,7 +508,7 @@ ls .claude/retroscope.json 2>/dev/null && echo "exists" || echo "not found"
 **Step 5:** Verify config files created:
 ```bash
 cat ~/.claude/retroscope.json
-cat .claude/retroscope.json
+cat .claude-plugin/retroscope.json
 ```
 
 **Step 6:** Verify storage repo initialized:

--- a/plugins/retroscope/docs/INITIAL_PLAN.md
+++ b/plugins/retroscope/docs/INITIAL_PLAN.md
@@ -73,7 +73,7 @@ Extract mode pre-processes JSONL via Python script, outputting only user text + 
 ### SessionEnd Hook
 
 `SessionEnd` hook fires with query `prompt_input_exit` when user types `exit`. The hook script:
-1. Reads project config `.claude/retroscope.json`
+1. Reads project config `.claude-plugin/retroscope.json`
 2. If `suggestRetroOnExit: true` → outputs suggestion message
 3. Output is shown to user before session closes
 
@@ -141,7 +141,7 @@ Pattern: follows `plugins/plantuml/scripts/inject-base-rules.sh` (PLUGIN_ROOT re
 ### 4. `plugins/retroscope/scripts/session-end.sh`
 
 SessionEnd hook:
-1. Read `.claude/retroscope.json` from `$CLAUDE_PROJECT_DIR`
+1. Read `.claude-plugin/retroscope.json` (or `.claude/retroscope.json` fallback) from `$CLAUDE_PROJECT_DIR`
 2. If `suggestRetroOnExit` is true → output suggestion text
 3. Silent if option is off or config doesn't exist
 
@@ -185,7 +185,7 @@ Main command (~100 lines, hybrid skill with references).
 3. Display in console only, do NOT save
 
 **Mode: `today` / `yesterday`**
-1. Read config: `.claude/retroscope.json` → fallback `~/.claude/retroscope.json`
+1. Read config: `.claude-plugin/retroscope.json` → fallback `.claude/retroscope.json` → fallback `~/.claude/retroscope.json`
 2. If no config → suggest `/retroscope:setup`
 3. Run `find-sessions.py <today|yesterday>` → session file paths
 4. Check cached report `{storageDir}/reports/{project}/daily/{YYYY}/{MM}/{DD}/summary.md`:

--- a/plugins/retroscope/scripts/session-end.sh
+++ b/plugins/retroscope/scripts/session-end.sh
@@ -5,12 +5,15 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Find config — project-level takes precedence
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-PROJECT_CONFIG="${PROJECT_DIR}/.claude/retroscope.json"
+_new="${PROJECT_DIR}/.claude-plugin/retroscope.json"
+_old="${PROJECT_DIR}/.claude/retroscope.json"
 USER_CONFIG="${HOME}/.claude/retroscope.json"
 
 CONFIG=""
-if [ -f "$PROJECT_CONFIG" ]; then
-  CONFIG="$PROJECT_CONFIG"
+if [ -f "$_new" ]; then
+  CONFIG="$_new"
+elif [ -f "$_old" ]; then
+  CONFIG="$_old"
 elif [ -f "$USER_CONFIG" ]; then
   CONFIG="$USER_CONFIG"
 fi


### PR DESCRIPTION
## Summary

- Migrates project-level `retroscope.json` config from `.claude/` to `.claude-plugin/` so it gets committed and shared with team
- Backwards-compatible: `session-end.sh` checks `.claude-plugin/` → `.claude/` → `~/.claude/` in order
- Updates `retro` and `retroscope-setup` SKILL.md, README.md, ACCEPTANCE_TESTS.md, INITIAL_PLAN.md

## Test plan

- [ ] Run acceptance tests 7.1, 7.2 with config at `.claude-plugin/retroscope.json`
- [ ] Verify `session-end.sh` reads from new path
- [ ] Verify old path `.claude/retroscope.json` still works as fallback
- [ ] Verify global `~/.claude/retroscope.json` still works when no project config found

🤖 Generated with [Claude Code](https://claude.com/claude-code)