### PR TITLE
chore: migrate .claude/git-branch-naming.json to .claude-plugin/

### DIFF
--- a/.claude-plugin/git-branch-naming.json
+++ b/.claude-plugin/git-branch-naming.json
@@ -1,0 +1,13 @@
+{
+  "prefixes": ["feature", "bugfix", "docs", "test", "chore", "refactor"],
+  "ticketPattern": "",
+  "maxLength": 60,
+  "protectedBranches": ["main", "master", "develop"],
+  "requireKebabCase": true,
+  "warnOnContentMismatch": true,
+  "enforcement": {
+    "invalidName": "ask",
+    "protectedBranch": "ask",
+    "contentMismatch": "ask"
+  }
+}


### PR DESCRIPTION
## Summary

- Moves the repo's own `git-branch-naming.json` config from `.claude/` to `.claude-plugin/` (the new canonical location per PR #97)
- After this is merged, `.claude/git-branch-naming.json` can be removed locally

Depends on: #97 (plugin must support new path before config is moved)

## Test plan

- [ ] Merge PR #97 first
- [ ] Verify plugin reads config from `.claude-plugin/git-branch-naming.json`
- [ ] Confirm branch naming rules still enforced in fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)