### PR TITLE
fix(retroscope): separate skills/ dir to fix duplicate skills in /context (v0.2.1)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"
@@ -10,6 +10,6 @@
     "./commands/"
   ],
   "skills": [
-    "./commands/"
+    "./skills/"
   ]
 }

--- a/plugins/retroscope/skills/retro/SKILL.md
+++ b/plugins/retroscope/skills/retro/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: retro
+description: >
+  Generate retrospective summaries of Claude Code sessions.
+  Use /retro session to summarize the current session (display only).
+  Use /retro today or /retro yesterday to generate saved daily reports.
+  Keywords: retro, retrospective, session summary, what did I do, daily report, productivity.
+---
+
+# /retro — Session Retrospective Report
+
+Generate a retrospective summary of Claude Code session(s).
+
+## Modes
+
+| Mode | Description | Storage |
+|------|-------------|---------|
+| `session` | Summarize current session from context | Display only (not saved) |
+| `today` | Aggregate all today's sessions | Saved to storage repo + git commit |
+| `yesterday` | Aggregate all yesterday's sessions | Saved to storage repo + git commit |
+
+Add `--force` to any mode to regenerate even if a cached report exists (e.g., `/retro today --force`).
+
+## Step 1: Load Config
+
+Look for config in this order:
+1. `{CLAUDE_PROJECT_DIR}/.claude-plugin/retroscope.json` (project-level, preferred)
+2. `{CLAUDE_PROJECT_DIR}/.claude/retroscope.json` (project-level, legacy fallback)
+3. `~/.claude/retroscope.json` (user-level)
+
+**If no config found:** ask the user whether to run setup now using AskUserQuestion:
+- Option A: "Yes, run setup now" → invoke `/retroscope:setup` skill and **stop**.
+- Option B: "No, continue without config" → continue with defaults (`sessionSource: logs`, display-only, no storage).
+
+## Step 2: Determine Mode
+
+**You MUST ask the user which mode they want. Do NOT skip this step or assume a default.**
+
+If the user provided a mode argument (e.g., `/retro session`, `/retro today`), use it.
+Otherwise use AskUserQuestion with options: `session`, `today`, `yesterday`.
+
+Parse the user's argument for both mode and flags. If `--force` is present, set `force = true` and strip it from the mode argument before further processing.
+
+**If no config was found** (user chose to continue without config):
+- Only `session` mode is available (no storage configured for today/yesterday).
+- Skip the mode question and use `session` mode directly, showing a note: "💡 Tip: Run `/retroscope:setup` to enable daily reports (today/yesterday)."
+
+Config fields used:
+- `storageDir` — where to save reports (REQUIRED for today/yesterday)
+- `language` — report language (default: English)
+- `model` — report generation model: `haiku`, `sonnet`, or `inherit` (default: `haiku`)
+- `extractMode` — pre-filter sessions to text-only (default: `true`)
+- `sessionSource` — data source for `/retro session`: `logs` (default) or `context`
+- `autoPush` — git push after commit (default: `false`)
+- `timezone` — timezone for date calculations (default: system)
+
+## Step 3: Session Mode
+
+**ONLY for `session` mode.**
+
+### 3a. Determine session data source
+
+Read `sessionSource` from config (default: `logs`).
+
+| Value | Behavior |
+|-------|----------|
+| `logs` (default) | Read JSONL session file — complete and reliable even if context was compressed or cleared |
+| `context` | Use current conversation context — faster, no file I/O, but may miss earlier turns if context was compressed (`/compact`) or cleared (`/clear`) |
+
+### 3b. Source: `logs`
+
+Find the JSONL file for the current session:
+
+1. Get current session ID — read `$CLAUDE_SESSION_ID` env var, or fall back to finding the most recently modified JSONL file under the encoded current project path:
+   ```bash
+   ls -t ~/.claude/projects/<encoded-project-dir>/*.jsonl | head -1
+   ```
+   **Never use the Read tool on `.jsonl` files — they can exceed 256 KB. Always use Bash commands.**
+
+2. Resolve script path — `SCRIPT_DIR` = `${SKILL_DIR}/../../scripts` (i.e., `scripts/` at the plugin root).
+
+3. Run stats first:
+   ```bash
+   PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --stats "{session_file}"
+   ```
+
+4. Extract conversation text:
+   ```bash
+   PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --extract "{session_file}"
+   ```
+   (No `--date` filter — include all messages regardless of when session started.)
+
+5. Read `${SKILL_DIR}/references/report-template.md`
+
+6. Generate the report from the extracted text. Use `inherit` model (generate directly, no subagent — session reports don't benefit from a haiku subagent since Claude already has context).
+
+7. Display in terminal. **Do NOT save to disk** — session reports are display-only.
+
+### 3c. Source: `context`
+
+> ⚠️ **Note:** Context may be incomplete if the conversation was compacted or cleared. Use `logs` for reliable coverage of the full session.
+
+1. Read `${SKILL_DIR}/references/report-template.md`
+2. Fill in the template from the current conversation history in context:
+   - Review all visible conversation turns
+   - Project = current working directory name
+   - Date = today's date
+   - Session count = 1 (current session)
+3. Display in terminal. **Do NOT save to disk.**
+
+Stop here for `session` mode.
+
+## Step 4: Find Sessions (today/yesterday)
+
+Run `find-sessions.py` to locate matching session files:
+
+```bash
+PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py {today|yesterday} \
+  --project-dir "{CLAUDE_PROJECT_DIR}" \
+  --tz "{config.timezone}"
+```
+
+Where `{SCRIPT_DIR}` = `${SKILL_DIR}/../../scripts`.
+
+If no sessions found: inform user and stop.
+
+## Step 5: Check Cache
+
+Determine report output path:
+```
+{storageDir}/reports/{project_name}/daily/{YYYY}/{MM}/{DD}/summary.md
+```
+
+Where `{project_name}` = basename of `CLAUDE_PROJECT_DIR`.
+
+If `force` is set: skip cache check entirely, always regenerate.
+
+Otherwise, if the file exists:
+- Get modification time of summary.md
+- Get modification times of all session files
+- If summary.md is newer than ALL session files → display cached report and stop
+
+## Step 6: Gather Stats
+
+For each session file, run:
+```bash
+PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --stats "{session_file}"
+```
+
+Collect: token totals, tool counts, duration, branches, models.
+
+From each stats JSON, collect both `estimated_cost_usd` (actual cost with cache discounts) and `naive_cost_usd` (all input tokens at full rate, matches Claude Code UI display). Show both in the Productivity Metrics section.
+
+Aggregate across all sessions for the Overview and Productivity Metrics sections.
+
+## Step 7: Extract Session Content
+
+**If `extractMode: true` (default):**
+
+For each session file, run:
+```bash
+PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --extract "{session_file}" --date "{YYYY-MM-DD}"
+```
+
+Concatenate all extracted text (with session separators).
+
+**If `extractMode: false`:**
+
+Parse JSONL files via Bash — **never use the Read tool on `.jsonl` files** (they can exceed 256 KB / 25K tokens):
+```bash
+PYTHONPATH="" python3 -c "
+import json, sys
+for line in open(sys.argv[1]):
+    obj = json.loads(line)
+    if obj.get('type') in ('user', 'assistant'):
+        print(json.dumps(obj))
+" "{session_file}"
+```
+
+**If combined content exceeds ~100K tokens:**
+- Warn user about large session size
+- Process only the most recent 50% of exchanges
+
+## Step 8: Generate Report
+
+1. Read `${SKILL_DIR}/references/report-template.md`
+2. Generate report content based on the template and extracted session data
+3. **If config `model` is `haiku`**: use the Task tool with `subagent_type: general-purpose` and `model: haiku` to generate the report body. Pass the extracted session text and template as context.
+4. **If config `model` is `sonnet`**: use the Task tool with `subagent_type: general-purpose` and `model: sonnet` to generate the report body. Pass the extracted session text and template as context.
+5. **If config `model` is `inherit`**: generate directly (current session model)
+
+## Step 9: Save Report
+
+1. Create directory structure:
+   ```bash
+   mkdir -p "{storageDir}/reports/{project_name}/daily/{YYYY}/{MM}/{DD}"
+   ```
+
+2. Write report to `summary.md`:
+   ```
+   {storageDir}/reports/{project_name}/daily/{YYYY}/{MM}/{DD}/summary.md
+   ```
+   **If the file already exists: Read it first, then use Edit to replace the content.** The Write tool blocks overwriting an unread file. Never skip the Read step when the file may exist from a previous run.
+
+3. Git commit in storage repo:
+   ```bash
+   git -C "{storageDir}" add reports/{project_name}/daily/{YYYY}/{MM}/{DD}/summary.md
+   git -C "{storageDir}" commit -m "retro({project_name}): {YYYY-MM-DD} daily summary"
+   ```
+
+4. If `autoPush: true`:
+   ```bash
+   git -C "{storageDir}" push
+   ```
+
+## Step 10: Display
+
+Show the generated report in the terminal. Include the file path where it was saved.
+
+## Error Handling
+
+- **No sessions found**: `No {today|yesterday} sessions found for project {name}. Sessions are stored per-project directory.`
+- **Storage dir doesn't exist**: `Storage directory '{dir}' not found. Run /retroscope:setup to configure.`
+- **Git not initialized**: `Storage directory is not a git repo. Run: git -C '{dir}' init`
+- **Large session**: warn and offer to process with extract mode ON even if configured OFF

--- a/plugins/retroscope/skills/retroscope-setup/SKILL.md
+++ b/plugins/retroscope/skills/retroscope-setup/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: retroscope-setup
+description: >
+  Interactive setup wizard for retroscope retrospective reports.
+  Creates or updates ~/.claude/retroscope.json and .claude-plugin/retroscope.json.
+  Run this command to configure storage directory, language, model, and options.
+  Keywords: retroscope setup, configure retro, retroscope config, setup retrospective.
+---
+
+# /retroscope:setup — Retroscope Configuration Wizard
+
+Interactive wizard to configure the retroscope plugin for your environment and project.
+
+## What this command does
+
+1. Checks for existing configuration
+2. Asks setup questions via dialog
+3. Creates/updates config files
+4. Initializes storage repository if needed
+5. Shows next steps
+
+## Step 1: Check Existing Config
+
+Read existing configs (show current values as defaults):
+- `~/.claude/retroscope.json` — user-level (global defaults)
+- `.claude-plugin/retroscope.json` — project-level (overrides)
+
+## Step 2: Ask Configuration Questions
+
+Use `AskUserQuestion` to collect settings.
+
+**Question 1 — Storage directory:**
+
+Ask: "Where should retroscope store reports?"
+
+Provide a text input field. Suggest: `/Users/<username>/devel/retroscope` or `~/retroscope`.
+
+If the directory doesn't exist: offer to create it and run `git init`.
+
+**Question 2 — Remote URL (optional):**
+
+Detect GitHub username:
+```bash
+gh api user -q .login 2>/dev/null
+```
+
+Options:
+- `https://github.com/{username}/retroscope` — use detected GitHub repo (if username found)
+- Enter custom URL
+- Skip (no remote)
+
+**Question 3 — Report language:**
+
+Options:
+- System default (from `~/.claude/settings.json` locale or `$LANG`) — Recommended
+- English
+- Custom (ask for language name)
+
+**Question 4 — Report generation model:**
+
+Options:
+- `haiku` — Claude Haiku (fastest, cheapest; ~$0.01–0.03 per daily report) — Recommended
+- `sonnet` — Claude Sonnet (higher quality; ~$0.05–0.15 per daily report)
+- `inherit` — Use current session model (no subagent spawned)
+
+**Question 5 — Extract mode:**
+
+Options:
+- On (default) — Pre-filter sessions to user prompts + assistant responses only. Reduces tokens by ~80–90%. Good for task tracking, decisions, and status overviews.
+- Off — Send complete session data including tool inputs/outputs, file contents, error messages. ~5–10x more tokens. Better for detailed debugging insights and nuanced communication analysis.
+
+**Question 5b — /retro session data source:**
+
+This setting controls how `/retro session` reads data about the current session.
+
+Claude Code automatically compresses long conversations (`/compact`) and users may run `/clear` to reset context. When this happens, earlier turns are no longer visible in memory — so a report based on "what Claude can see right now" will be incomplete.
+
+Options:
+- **Session logs** (default, recommended) — Always reads the full JSONL session file from `~/.claude/projects/`. Complete and reliable regardless of context compression or `/clear`. Slightly slower due to file I/O.
+- **Current context** — Uses whatever Claude can see in the active conversation. Faster and simpler, but will produce incomplete reports if context was compressed or cleared earlier in the session.
+
+**Question 6 — Suggest /retro on exit?**
+
+Options:
+- Yes — SessionEnd hook shows reminder before exiting (default)
+- No — Silent exit
+
+**Question 7 — Auto-push reports?**
+
+Options:
+- No — Commit locally only (default, recommended)
+- Yes — Push to remote after each report commit
+
+## Step 3: Write Config Files
+
+### User-level config: `~/.claude/retroscope.json`
+
+Write global defaults (storageDir, language, timezone):
+
+```json
+{
+  "storageDir": "{chosen_path}",
+  "remoteUrl": "{remote_url_or_empty}",
+  "language": "{language}",
+  "timezone": "{detected_timezone}",
+  "model": "{haiku|sonnet|inherit}",
+  "extractMode": {true|false},
+  "sessionSource": "{logs|context}",
+  "suggestRetroOnExit": {true|false},
+  "autoPush": {false|true}
+}
+```
+
+Detect timezone:
+```bash
+python3 -c "import datetime; print(datetime.datetime.now().astimezone().tzname())"
+# or on macOS:
+readlink /etc/localtime | sed 's|.*/zoneinfo/||'
+```
+
+### Project-level config: `.claude-plugin/retroscope.json`
+
+Create `.claude-plugin/` if needed, write project-level overrides. By default, identical to user-level config (user can manually edit to override per project later).
+
+## Step 4: Initialize Storage Repository
+
+If storage directory doesn't exist:
+```bash
+mkdir -p "{storageDir}"
+git -C "{storageDir}" init
+```
+
+If remote URL provided:
+```bash
+git -C "{storageDir}" remote add origin "{remoteUrl}"
+```
+
+Create initial `.gitignore` in storage dir (if it doesn't exist):
+```
+.DS_Store
+*.tmp
+```
+
+Create initial commit if repo is empty:
+```bash
+git -C "{storageDir}" add .gitignore
+git -C "{storageDir}" commit -m "chore: initialize retroscope storage"
+```
+
+## Step 5: Show Confirmation
+
+```
+✅ Retroscope configured successfully!
+
+Storage:        {storageDir}
+Remote:         {remoteUrl or "none (local only)"}
+Language:       {language}
+Model:          {model}
+Extract mode:   {on/off}
+Session source: {logs/context}
+
+Next steps:
+1. Run /retro session — summarize current session (display only)
+2. Run /retro today — generate today's report (saved to storage)
+3. Run /retro yesterday — generate yesterday's report
+
+Tip: Reports are saved to:
+  {storageDir}/reports/{project}/daily/{YYYY}/{MM}/{DD}/summary.md
+```
+
+## Config Schema Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `storageDir` | string | — | Absolute path to storage git repo (REQUIRED) |
+| `remoteUrl` | string | `""` | Git remote URL for pushing reports |
+| `language` | string | `"en"` | Report language code (e.g. "en", "uk", "de") |
+| `timezone` | string | system TZ | IANA timezone name (e.g. "Europe/Kyiv") |
+| `model` | string | `"haiku"` | Report model: `haiku`, `sonnet`, or `inherit` |
+| `extractMode` | boolean | `true` | Pre-filter sessions to text-only content |
+| `sessionSource` | string | `"logs"` | `/retro session` data source: `logs` (full JSONL, reliable) or `context` (current conversation, fast but may be incomplete) |
+| `suggestRetroOnExit` | boolean | `true` | Show /retro reminder in SessionEnd hook |
+| `autoPush` | boolean | `false` | Git push after each report commit |


### PR DESCRIPTION
## Problem

`retroscope` skills appeared twice in `/context` because `plugin.json` had `skills` and `commands` pointing to the same `./commands/` directory. Claude Code loads skills from both `cache/` and `marketplaces/` — when the paths are identical, deduplication fails.

Fixes #100.

## Root cause

All other plugins (plantuml, semver, playbook, git-branch-naming) use separate `skills/` and `commands/` directories — and they do NOT have duplicate skills. Only retroscope used `"skills": ["./commands/"]`.

## Fix

Created a separate `skills/` directory matching the convention of other plugins:

```
plugins/retroscope/
├── commands/
│   ├── retro/SKILL.md          ← for /retro command execution
│   └── retroscope-setup/SKILL.md
└── skills/                     ← NEW: for skill discovery
    ├── retro/SKILL.md
    └── retroscope-setup/SKILL.md
```

`plugin.json` updated: `"skills": ["./skills/"]`

## Test plan

- [ ] Run `/plugin` to sync
- [ ] Check `/context` — `retroscope-setup` and `retro` appear exactly once each
- [ ] Verify `/retro session` still works
- [ ] Verify `/retroscope:setup` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)