### PR TITLE
chore: add semver config and tighten branch naming enforcement

### DIFF
--- a/.claude-plugin/git-branch-naming.json
+++ b/.claude-plugin/git-branch-naming.json
@@ -6,7 +6,7 @@
   "requireKebabCase": true,
   "warnOnContentMismatch": true,
   "enforcement": {
-    "invalidName": "ask",
+    "invalidName": "deny",
     "protectedBranch": "ask",
     "contentMismatch": "ask"
   }

--- a/.claude-plugin/semver.json
+++ b/.claude-plugin/semver.json
@@ -1,0 +1,18 @@
+{
+  "versionFiles": [
+    { "path": "plugins/statusline/.claude-plugin/plugin.json", "field": "version", "format": "json" },
+    { "path": "plugins/statusline-compact/.claude-plugin/plugin.json", "field": "version", "format": "json" },
+    { "path": "plugins/plantuml/.claude-plugin/plugin.json", "field": "version", "format": "json" },
+    { "path": "plugins/git-branch-naming/.claude-plugin/plugin.json", "field": "version", "format": "json" },
+    { "path": "plugins/playbook/.claude-plugin/plugin.json", "field": "version", "format": "json" },
+    { "path": "plugins/semver/.claude-plugin/plugin.json", "field": "version", "format": "json" },
+    { "path": "plugins/retroscope/.claude-plugin/plugin.json", "field": "version", "format": "json" }
+  ],
+  "triggerStrategy": "auto",
+  "baseBranch": "main",
+  "enforcement": {
+    "missingBump": "ask"
+  },
+  "commitFormat": "chore: bump version to {version}",
+  "excludePatterns": ["README.md", "CHANGELOG.md", "LICENSE", ".gitignore", "*.md", "docs/**", ".claude/**", ".claude-plugin/**"]
+}


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/semver.json`: track `version` field in all 7 plugin `plugin.json` files, trigger=auto, enforcement=ask
- Update `.claude-plugin/git-branch-naming.json`: change `invalidName` enforcement from `ask` to `deny`

## Test plan

- [ ] Verify `/semver:semver-setup` reads config correctly
- [ ] Verify invalid branch names are blocked (not just warned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)