### PR TITLE
feat(playbook): rewrite documentation-principles RULES zone (v0.4.1)

### DIFF
--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/documentation-principles.md
+++ b/plugins/playbook/presets/documentation-principles.md
@@ -9,16 +9,16 @@ tags: [docs, commits]
 
 MANDATORY: Documentation is part of the codebase. A change is not complete until docs reflect it.
 
-- Before EVERY commit → run the documentation checklist:
-  1. Architecture changed? → update `docs/architecture.md`
-  2. API changed? → update `docs/api/`
-  3. Significant decision? → create/update `docs/adr/`
-  4. Coding conventions affected? → update `docs/conventions.md`
-  5. Cross-links still valid?
-- If none apply → state why in commit message
-- NEVER leave `TODO: document this` in code
+- After adding, removing, or renaming a module/component → update `docs/architecture.md`
+- After changing a public function/method signature or API endpoint → update its entry in `docs/api/`
+- After choosing between two viable approaches or deviating from a convention → create `docs/adr/NNNN-title.md` (Context → Decision → Consequences)
+- After changing coding patterns, naming conventions, or tooling → update `docs/conventions.md`
+- After adding or updating any doc → verify all cross-links to/from it are valid
+- ALWAYS keep `CLAUDE.md` minimal — build/test commands + links to docs only; details live in `docs/`; user-facing project overview belongs in `README.md`
+- NEVER leave `TODO: document this` in code — write the doc now or create a tracked issue
 - NEVER duplicate info across docs — single source of truth, link instead
-- For full principles: invoke `/playbook-browse` and select "documentation-principles"
+- NEVER use inline comments as a substitute for documentation
+- For full reference: invoke `/playbook-browse` and select "documentation-principles"
 <!-- /RULES -->
 
 <!-- REFERENCE -->


### PR DESCRIPTION
## Summary

Rewrites the RULES zone of `documentation-principles` preset applying the patterns from `docs/AUTHORING.md` (added in #114).

## Problem

The existing RULES zone had 3 anti-patterns (per `docs/AUTHORING.md §4`):
- Checklist with judgment calls: "Architecture changed?", "Significant decision?" — Claude can't evaluate these consistently
- Overly broad trigger: "Before EVERY commit" — noise, most commits don't touch docs
- `/playbook-browse` as fallback — Claude rarely self-invokes skills

## Changes

**Before:**
```
- Before EVERY commit → run the documentation checklist:
  1. Architecture changed? → update docs/architecture.md
  2. API changed? → update docs/api/
  3. Significant decision? → create/update docs/adr/
  ...
```

**After (trigger-action pairs with observable triggers):**
```
- After adding, removing, or renaming a module/component → update docs/architecture.md
- After changing a public function/method signature or API endpoint → update its entry in docs/api/
- After choosing between two viable approaches or deviating from a convention → create docs/adr/...
- After changing coding patterns, naming conventions, or tooling → update docs/conventions.md
- After adding or updating any doc → verify all cross-links to/from it are valid
- ALWAYS keep CLAUDE.md minimal — build/test + links; user-facing overview belongs in README.md
- NEVER leave TODO: document this in code
- NEVER duplicate info across docs
- NEVER use inline comments as a substitute for documentation
```

Uses **Critical budget** (~200 tokens, 18 lines ≤ 20) — justified for a daily-use preset.

REFERENCE zone is unchanged.

## Quality Checklist (AUTHORING.md §7)

- ✅ Every bullet answers "What exactly does Claude do, and when?"
- ✅ Every trigger is an observable event, not a judgment call
- ✅ Every action is concrete
- ✅ No RULES rule depends on reading REFERENCE zone
- ✅ No vague language
- ✅ Within critical budget (18 lines ≤ 20)
- ✅ Works correctly if `/playbook-browse` is never invoked

Part of #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)