### PR TITLE
docs: add README files for plantuml and playbook plugins

### DIFF
--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -1,183 +1,129 @@
-# PlantUML Plugin
+# PlantUML
 
-PlantUML diagram automation for Claude Code: auto-sync markdown URLs, ASCII rendering in terminal, validation, and diagram type guide.
+> Add diagrams to your docs and conversations — Claude picks the type, draws, and keeps them in sync.
 
-## Features
+With this plugin, Claude proactively illustrates architecture, flows, and data structures using [PlantUML](https://plantuml.com): in markdown documentation and directly in the terminal during conversations.
 
-### 1. Markdown Diagram Sync (PostToolUse)
-- Automatically updates PlantUML image URLs in markdown files after edits
-- Ensures URLs always match source code blocks
-- No manual encoding needed
+## Demo
 
-### 2. ASCII Terminal Rendering (SessionStart + PreToolUse)
-- Renders diagrams as ASCII art for terminal explanations
-- **Zero permission prompts** — PreToolUse hooks auto-allow all operations
-- **Full diagram display** — WebFetch approach prevents UI collapse
-- Workflow: encode source → WebFetch from plantuml.com/txt/{encoded} → display
+A developer asks Claude to document the login flow. Claude adds a diagram to the docs — then, during the conversation, renders the same diagram as ASCII art in the terminal.
 
-### 3. Diagram Type Guide (Skill)
-- Automatically invoked before creating PlantUML diagrams
-- Covers 17 diagram types with selection guidance
-- Ensures correct diagram type for each use case
+### Step 1 — Claude writes `docs/auth.md` and adds a diagram proactively
 
-### 4. Validation (Command)
-- `/plantuml-validate` command checks all diagrams in markdown files
-- CI/CD integration via `--check` flag
-- Git pre-commit hooks prevent stale URLs
+```
+> Document the login flow for the auth service.
+
+✦ Using skill: plantuml-diagram-guide
+
+I'll create docs/auth.md. The flow involves four actors — I'll use a sequence diagram.
+
+● Write(docs/auth.md)
+  ┌───────────────────────────────────────────────────────────────────┐
+  │ # Auth Service                                                    │
+  │                                                                   │
+  │ ## Login Request Flow                                             │
+  │                                                                   │
+  │ ```plantuml                                                       │
+  │ @startuml                                                         │
+  │ title Login Request Flow                                          │
+  │ hide footbox                                                      │
+  │ skinparam participantBackgroundColor #E8F4FD                      │
+  │ skinparam participantBorderColor #7FB3D8                          │
+  │ skinparam sequenceArrowColor #5B9BD5                              │
+  │ skinparam sequenceLifeLineBorderColor #7FB3D8                     │
+  │                                                                   │
+  │ actor User                                                        │
+  │ participant "Web App" as Web                                      │
+  │ participant "Auth API" as API                                     │
+  │ database "PostgreSQL" as DB                                       │
+  │                                                                   │
+  │ User -> Web : POST /login                                         │
+  │ Web -> API : forward credentials                                  │
+  │ API -> DB : SELECT user WHERE email = ?                           │
+  │ DB --> API : user row                                             │
+  │ API --> Web : 200 OK + token                                      │
+  │ Web --> User : redirect + set cookie                              │
+  │ @enduml                                                           │
+  │ ```                                                               │
+  │                                                                   │
+  │ ![Login Request Flow (PNG image)](https://www.plantuml.com/...)   │
+  └───────────────────────────────────────────────────────────────────┘
+
+⏺ Done — docs/auth.md created. The image URL stays in sync automatically whenever you edit the source block.
+```
+
+![Login Request Flow](https://www.plantuml.com/plantuml/png/TP7HJi8m58Rl-nGdU6c8H2KYYSh6jcXSmWGCrsKxGBFHCzkpuEDxDWd112-sjVs-_l_IJZnhnys-KcouGaXfQopCyQj1pv1KT50xKo1iY7XDtygNnjRQwJt8cqrkQcqvr7cvTTJOOaeLERYAHybz4lqZaolG7SM79BoBHcUYRvjjZe5pT3XAm_0nZ8ONfDHivB5uALBfd6NwwT6fitRehN0DGLttG7kGyLyODBo387lhg7nLeLcljKVePUHvwt3naNOm2fLgmw7_tCR06BBPOWatLNk0gbqH80a2DkGEsXMGEopGij6LLoqH8Gg5B-8qdYwXQTDMh_4y1jnhKy4Jl2WH-gUWpf1p-TrzAhuT363s3jV0LEAnMs3tTsEGKkCmP-4U6NAYqg2Qe2tardy0)
+
+### Step 2 — Later in the conversation, Claude renders it as ASCII in the terminal
+
+```
+> Walk me through the login flow step by step.
+
+✦ Using skill: plantuml-diagram-guide
+
+Here's the full flow:
+
+                                     Login Request Flow
+
+       ┌─┐                                                                    ,.-^^-._
+       ║"│                                                                   |-.____.-|
+       └┬┘                                                                   |        |
+       ┌┼┐                                                                   |        |
+        │                  ┌───────┐           ┌────────┐                    |        |
+       ┌┴┐                 │Web App│           │Auth API│                    '-.____.-'
+      User                 └───┬───┘           └────┬───┘                   PostgreSQL
+        │     POST /login      │                    │                            │
+        │─────────────────────>│                    │                            │
+        │                      │                    │                            │
+        │                      │forward credentials │                            │
+        │                      │───────────────────>│                            │
+        │                      │                    │                            │
+        │                      │                    │SELECT user WHERE email = ? │
+        │                      │                    │───────────────────────────>│
+        │                      │                    │                            │
+        │                      │                    │         user row           │
+        │                      │                    │<─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│
+        │                      │                    │                            │
+        │                      │  200 OK + token    │                            │
+        │                      │<─ ─ ─ ─ ─ ─ ─ ─ ─ ─│                            │
+        │                      │                    │                            │
+        │redirect + set cookie │                    │                            │
+        │<─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│                    │                            │
+        │                      │                    │                            │
+
+![Login Request Flow (PNG image)](https://www.plantuml.com/...)
+```
+
+## Validation
+
+```
+/plantuml:plantuml-validate
+```
+
+Checks all diagram URLs in the project. Also runs automatically as a git pre-commit hook and in GitHub Actions CI.
 
 ## Installation
 
-This plugin is available in the **Tribe Coding** marketplace.
-
-1. Add marketplace to Claude Code:
-   ```bash
-   claude marketplace add tribe-coding https://github.com/Tribe-Coding/claude-plugins.git
-   ```
-
-2. Install plugin:
-   ```bash
-   claude plugin install plantuml@tribe-coding
-   ```
-
-3. (Optional) Install marketplace sync for auto-updates:
-   ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/Tribe-Coding/claude-plugins/main/scripts/install-sync.sh)
-   ```
-
-## Usage
-
-### Markdown Documentation
-When creating `.md` files, Claude will automatically:
-1. Invoke diagram type guide skill
-2. Create PlantUML diagrams with two-part format:
-   - Code block with `plantuml` language tag
-   - Image link to rendered SVG
-3. Auto-update URLs when source changes
-
-Example:
-```markdown
-```plantuml
-@startuml
-Alice -> Bob: Hello
-@enduml
-```
-
-![Sequence Diagram](https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuNBCoKnELT2rKt3AJx9Iy4ZDoSddSaZDIm7A0G00)
-```
-
-### Terminal Explanations
-When explaining architecture or flows, Claude will:
-1. Encode diagram source
-2. Fetch ASCII from PlantUML API
-3. Display full diagram without prompts or UI collapse
-
-No user action needed — fully automatic.
-
-### Validation
-Check all diagrams in project:
 ```bash
-/plantuml-validate
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install plantuml@tribe-coding
+/plugin
 ```
 
-## How It Works
+Select **plantuml** → enable **auto-update**. Restart your session — done.
 
-### SessionStart Hooks
-1. **inject-base-rules.sh** — Outputs formatting rules and ASCII rendering workflow
-2. **setup-project.sh** — Installs git pre-commit hooks
+## Requirements
 
-### PostToolUse Hooks
-- **sync-plantuml.sh** — Runs after Write/Edit on `.md` files, updates diagram URLs
+- Python 3.x
 
-### PreToolUse Hooks
-- **allow-rendering.sh** — Auto-allows PlantUML operations without prompts:
-  - Encoding commands (`plantuml-encode.py`)
-  - Temp file operations (`/tmp/*.puml` via Bash or Write tool)
-  - Cleanup commands (`rm /tmp/*.puml`)
+## How it works
 
-### Skills
-- **plantuml-diagram-guide** — Invoked automatically before diagram creation
-
-### Commands
-- **plantuml-validate** — Manual validation and CI/CD checks
-
-## Technical Details
-
-### ASCII Rendering Architecture (v1.5.6+)
-
-**Problem:** Claude Code UI collapses Bash tool results >40-50 lines.
-
-**Solution:** Use WebFetch instead of Bash commands.
-- WebFetch results are NOT collapsed by UI
-- Versions 1.4.0-1.5.5 used Bash (regression)
-- Version 1.5.6+ reverted to WebFetch (original working approach)
-
-**Workflow:**
-1. Claude encodes PlantUML source via `plantuml-encode.py`
-2. WebFetch ASCII from `https://www.plantuml.com/plantuml/txt/{encoded}`
-3. Full diagram displayed in terminal
-
-**PreToolUse Hook Patterns:**
-```bash
-# Auto-allow encoding
-plantuml-encode.py
-
-# Auto-allow temp file creation
-cat > /tmp/*.puml
-
-# Auto-allow cleanup
-rm /tmp/*.puml
-
-# Auto-allow Write tool
-/tmp/*.puml
-```
-
-**Security:** All patterns restricted to `/tmp` directory and `.puml` extension.
-
-### SessionStart Path Resolution
-
-**Problem:** `${CLAUDE_PLUGIN_ROOT}` doesn't resolve in heredoc output.
-
-**Solution:** Dynamic resolution in script:
-```bash
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-```
-
-Outputs absolute paths like:
-```
-/Users/user/.claude/plugins/cache/tribe-coding/plantuml/1.5.8/scripts/plantuml-encode.py
-```
-
-**Key insight:** `${CLAUDE_PLUGIN_ROOT}` only works in hooks.json `command` fields, NOT in text output.
-
-## Configuration
-
-No configuration needed — works out of the box.
-
-Optional git pre-commit hook installed automatically via SessionStart hook.
-
-## Troubleshooting
-
-### Permission prompts still appearing
-- Ensure version 1.5.8+: `cat ~/.claude/plugins/installed_plugins.json | jq '.plugins["plantuml@tribe-coding"]'`
-- Restart Claude Code session to reload hooks
-- Check PreToolUse hook is active: operations should execute without prompts
-
-### ASCII diagrams collapsed in UI
-- Ensure version 1.5.6+: WebFetch approach prevents collapse
-- If using older version, upgrade: `claude plugin update plantuml@tribe-coding`
-
-### URLs not syncing
-- PostToolUse hook runs automatically on Write/Edit
-- Manual sync: edit any line in `.md` file and save
-- Check hook output for errors in Claude Code console
-
-## Contributing
-
-See [ACCEPTANCE_TESTS.md](docs/ACCEPTANCE_TESTS.md) for comprehensive test documentation.
-
-## Changelog
-
-See [CHANGELOG.md](CHANGELOG.md) for version history.
+| Trigger | What happens |
+|---------|-------------|
+| SessionStart | Injects diagram formatting rules and ASCII rendering workflow |
+| PostToolUse (Write/Edit on `.md`) | Auto-updates image URLs when source changes |
+| PreToolUse | Auto-allows all PlantUML operations — no permission prompts |
+| Before creating any diagram | `plantuml-diagram-guide` skill invoked automatically — picks the right type from 17 options |
 
 ## License
 

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/README.md
+++ b/plugins/playbook/README.md
@@ -1,0 +1,71 @@
+# Playbook
+
+> Inject curated coding guidelines into every Claude Code session — per project, per team.
+
+Playbook lets you define **presets** — sets of coding rules, workflow conventions, and best practices — that Claude follows automatically. No more repeating "always use squash merge" or "update docs after every change" in every conversation.
+
+## How it works
+
+Each preset is a markdown file with two zones:
+
+- **RULES** (~120 tokens) — injected into every session automatically via `SessionStart` hook
+- **REFERENCE** — full reference loaded on demand via `/playbook-browse`
+
+Claude sees the active rules in every session and follows them without being asked.
+
+## Installation
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install playbook@tribe-coding
+/plugin
+```
+
+Select **playbook** → enable **auto-update**.
+
+Then in the next session, run `/playbook-setup` to choose which presets to enable. Restart — done.
+
+> **Auto-update** keeps presets in sync with the latest fixes automatically on each Claude Code restart.
+
+## Available Presets
+
+| Preset | What it enforces |
+|--------|-----------------|
+| [`documentation-principles`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/documentation-principles.md) | Doc hierarchy, commit checklist, ADR policy, no TODO-in-code |
+| [`github-workflow`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/github-workflow.md) | Squash merge, PR description updates, issue linking |
+| [`macos-python`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/macos-python.md) | Python 3.12 targeting, no system Python, CWD isolation |
+| [`macos-zsh-quirks`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/macos-zsh-quirks.md) | Zsh/Bash tool quirks: CWD, `echo` escapes, absolute paths |
+| [`readme`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/readme.md) | README as landing page: 5-second test, compact structure, cross-links |
+
+Use `/playbook-browse` to read the full reference for any preset.
+
+## Commands
+
+| Command | What it does |
+|---------|-------------|
+| `/playbook-setup` | Interactive wizard — enable/disable presets, global or per-project |
+| `/playbook-browse` | Read the full REFERENCE zone of any preset |
+
+## Configuration
+
+**Global** (`~/.claude/playbook.json`) — applies to all projects:
+
+```json
+{ "presets": ["documentation-principles", "github-workflow"] }
+```
+
+**Project** (`.claude-plugin/playbook.json`) — committed to git, applies only here:
+
+```json
+{ "presets": ["readme"], "exclude": ["macos-python"] }
+```
+
+Project config takes priority. Use `"exclude"` to suppress global presets in a specific project.
+
+## Custom Presets
+
+You can write your own presets for team-specific conventions. See [AUTHORING.md](../../docs/AUTHORING.md) for the format, rule patterns, token budget, and anti-patterns.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- **plantuml** (1.6.0 → 1.6.1): new README with demo story — TUI dialogue showing proactive diagram creation in docs + ASCII rendering in terminal; same sequence diagram in both contexts with `hide footbox`
- **playbook** (0.5.0 → 0.5.1): new README with installation guide, preset table with GitHub links, commands reference, configuration examples

## Test plan

- [ ] Open both READMEs on GitHub — verify PNG diagram renders in plantuml README
- [ ] Verify preset names in playbook README link to correct files on main branch
- [ ] Check TUI code block formatting looks correct in monospace

🤖 Generated with [Claude Code](https://claude.com/claude-code)