### PR TITLE
refactor: replace soft skill-invocation hints with MANDATORY pattern

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -100,6 +100,30 @@ Why it works: maps symptom → fix in one line. Claude pattern-matches the error
 
 ---
 
+### Pattern 5: Mandatory Skill Invocation
+
+**Best for:** presets with a REFERENCE zone too large for RULES — forces Claude to load full guidelines before acting.
+
+```
+Format: **ALWAYS invoke the `<skill-name> [args]` skill BEFORE <trigger>** to <purpose>. This is MANDATORY — do not skip this step.
+```
+
+**Good** (from `playbook/presets/readme.md`):
+```
+- **ALWAYS invoke the `playbook-browse readme` skill BEFORE creating or improving any README** to load full guidelines. This is MANDATORY — do not skip this step.
+```
+
+**Bad:**
+```
+- For full reference: invoke `/playbook-browse` and select "readme"
+```
+
+Why it works: the soft form reads as an optional hint and is skipped under context pressure. The MANDATORY form with bold formatting matches the strength of other ALWAYS/NEVER rules in the same zone.
+
+**Important:** this pattern is a reinforcement, not a substitute for self-contained RULES. The RULES zone must still work if the skill is not invoked (e.g., offline, timeout). Use this pattern when the REFERENCE zone adds significant value beyond what fits in the RULES budget.
+
+---
+
 ### Pattern 4: Checklist
 
 **Use sparingly.** Checklists are the weakest pattern because each item requires a judgment call ("Did the architecture change?") that Claude must evaluate without clear criteria.
@@ -131,7 +155,8 @@ The decomposed version provides observable triggers (Claude can detect them mech
 | Vague verbs: "consider", "you may", "recommended" | Claude treats as optional, skips under context pressure | Use ALWAYS / NEVER / MUST |
 | Abstract goals: "keep docs up to date" | No observable trigger, no specific action | Decompose into trigger-action pairs |
 | Judgment without criteria: "if significant change" | Claude cannot evaluate "significant" consistently | Replace with observable conditions |
-| `/playbook-browse` as the primary action | Claude rarely self-invokes skills | Make RULES self-contained; browse is a bonus |
+| `/playbook-browse` as the **only** mechanism | Claude rarely self-invokes skills without explicit instruction | Make RULES self-contained; add MANDATORY browse line as reinforcement (see §3 Pattern 5) |
+| Soft browse line: "For full reference: invoke..." | Reads as optional hint, skipped under context pressure | Use MANDATORY pattern: `**ALWAYS invoke the \`playbook-browse <preset>\` skill BEFORE...**` |
 | Overly broad triggers: "before every commit" | Becomes noise — most commits don't match | Narrow to specific change types |
 | Rules outside Claude's scope: "update the team" | Claude cannot email or message | Scope to actions Claude can actually perform |
 
@@ -209,7 +234,8 @@ Before submitting a preset or SKILL.md, verify:
 4. No RULES rule depends on reading the REFERENCE zone to be understood
 5. No vague language: "consider", "may", "recommended", "try to", "when appropriate"
 6. RULES zone is within budget (standard: ≤14 lines; critical: ≤20 lines)
-7. The preset works correctly if `/playbook-browse` is never invoked
+7. The preset works correctly if `/playbook-browse` is never invoked (RULES must be self-contained)
+8. If the preset has a REFERENCE zone with significant additional content → last RULES line uses the MANDATORY skill invocation pattern (§3 Pattern 5), not the soft "For full reference" form
 
 ---
 
@@ -230,7 +256,7 @@ MANDATORY: One-sentence scope declaration.
 - ALWAYS/NEVER <specific action> — <reason or alternative>
 - When/After <observable event> → <specific action>
 - <error symptom> → root cause is <X> — fix with <Y>
-- For full reference: invoke `/playbook-browse` and select "preset-name"
+- **ALWAYS invoke the `playbook-browse preset-name` skill BEFORE <trigger>** to load full guidelines. This is MANDATORY — do not skip this step.
 <!-- /RULES -->
 
 <!-- REFERENCE -->

--- a/plugins/git-branch-naming/.claude-plugin/plugin.json
+++ b/plugins/git-branch-naming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-branch-naming",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Git branch naming convention enforcement: validates names, warns on content mismatch before push",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/git-branch-naming/scripts/inject-rules.sh
+++ b/plugins/git-branch-naming/scripts/inject-rules.sh
@@ -29,4 +29,5 @@ Rules:
 - Check `.claude-plugin/git-branch-naming.json` for project-specific rules (ticket patterns, custom prefixes, enforcement levels)
 - Before commit/push, verify your staged files match the branch type (e.g., `docs/` branch should not contain only code files)
 - Run `/git-branch-naming:setup` to create or update project configuration
+- **ALWAYS invoke the `branch-naming-guide` skill BEFORE creating or renaming any git branch** to load full naming guidelines. This is MANDATORY — do not skip this step.
 RULES

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/documentation-principles.md
+++ b/plugins/playbook/presets/documentation-principles.md
@@ -18,7 +18,7 @@ MANDATORY: Documentation is part of the codebase. A change is not complete until
 - NEVER leave `TODO: document this` in code — write the doc now or create a tracked issue
 - NEVER duplicate info across docs — single source of truth, link instead
 - NEVER use inline comments as a substitute for documentation
-- For full reference: invoke `/playbook-browse` and select "documentation-principles"
+- **ALWAYS invoke the `playbook-browse documentation-principles` skill BEFORE making documentation decisions** to load full guidelines. This is MANDATORY — do not skip this step.
 <!-- /RULES -->
 
 <!-- REFERENCE -->

--- a/plugins/playbook/presets/github-workflow.md
+++ b/plugins/playbook/presets/github-workflow.md
@@ -14,7 +14,7 @@ MANDATORY: Follow these rules for all PR and branch operations.
 - After committing on a PR branch → offer to update the PR description
 - When creating PR without linked issue → ask user to create one first
 - "Not mergeable" after another PR merged → `git fetch origin main && git rebase origin/main && git push --force-with-lease`
-- For full workflow: invoke `/playbook-browse` and select "github-workflow"
+- **ALWAYS invoke the `playbook-browse github-workflow` skill BEFORE performing PR or branch operations** to load full guidelines. This is MANDATORY — do not skip this step.
 <!-- /RULES -->
 
 <!-- REFERENCE -->

--- a/plugins/playbook/presets/macos-python.md
+++ b/plugins/playbook/presets/macos-python.md
@@ -15,7 +15,7 @@ MANDATORY: Target Python 3.12 exclusively. System Python 3.9 will break modern s
 - Modern type syntax is valid: `str | None`, `X | Y`, `tuple[X, Y]`, `list[str]`
 - When running Python from Bash tool: ALWAYS prefix with `PYTHONPATH=""` to isolate from CWD
 - If CWD has `__init__.py` or `__main__.py`, Python may treat it as a package — `PYTHONPATH=""` prevents this
-- For full reference: invoke `/playbook-browse` and select "macos-python"
+- **ALWAYS invoke the `playbook-browse macos-python` skill BEFORE writing Python scripts** to load full guidelines. This is MANDATORY — do not skip this step.
 <!-- /RULES -->
 
 <!-- REFERENCE -->

--- a/plugins/playbook/presets/macos-zsh-quirks.md
+++ b/plugins/playbook/presets/macos-zsh-quirks.md
@@ -15,7 +15,7 @@ MANDATORY: Shell is `/bin/zsh` 5.9. CWD does NOT persist between Bash tool calls
 - ALWAYS use `env VAR=val command` for environment variable injection (not `VAR=val command`)
 - Root cause of most "No such file" errors: CWD not set + relative path — fix with absolute paths
 - When running Python scripts: ALWAYS prefix with `PYTHONPATH=""` (see macos-python preset)
-- For full reference: invoke `/playbook-browse` and select "macos-zsh-quirks"
+- **ALWAYS invoke the `playbook-browse macos-zsh-quirks` skill BEFORE writing Bash tool commands** to load full guidelines. This is MANDATORY — do not skip this step.
 <!-- /RULES -->
 
 <!-- REFERENCE -->

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -20,7 +20,7 @@ MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "w
 - After adding/removing a public API, CLI command, or major feature → remind: "README may need updating"
 - When user asks to create/improve README → start with audience interview: who reads this? what's their level?
 - NEVER leave outdated examples — if code changed, update or remove them
-- For full reference: invoke `/playbook-browse` and select "readme"
+- **ALWAYS invoke the `playbook-browse readme` skill BEFORE creating or improving any README** to load full guidelines. This is MANDATORY — do not skip this step.
 <!-- /RULES -->
 
 <!-- REFERENCE -->

--- a/plugins/semver/.claude-plugin/plugin.json
+++ b/plugins/semver/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semver",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Semantic versioning enforcement: validates version bumps before commit/push/PR, supports multiple version files",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/semver/scripts/inject-rules.sh
+++ b/plugins/semver/scripts/inject-rules.sh
@@ -56,5 +56,5 @@ ${STRATEGY_RULE}
 4. On rebase conflict: check base branch version first, increment from there (not your original)
 
 - Run \`/semver:setup\` to configure versioning for this project
-- Run \`/semver:guide\` for full SemVer 2.0.0 reference and decision tree
+- **ALWAYS invoke the \`semver-guide\` skill BEFORE deciding version bump increment** to load full SemVer 2.0.0 reference and decision tree. This is MANDATORY — do not skip this step.
 RULES


### PR DESCRIPTION
## Summary

- All preset RULES zones previously ended with a soft `For full reference: invoke /playbook-browse...` line — Claude treats it as optional and skips it under context pressure
- Replaced with `**ALWAYS invoke the \`playbook-browse <preset>\` skill BEFORE... This is MANDATORY**` pattern that matches the strength of other ALWAYS/NEVER rules
- Same fix applied to `semver` and `git-branch-naming` inject-rules scripts
- Documented the pattern in `docs/AUTHORING.md` as §3 Pattern 5 so future presets follow the same convention

## Changes

| File | Change |
|------|--------|
| `playbook/presets/*.md` (5 files) | soft hint → MANDATORY invoke line |
| `playbook/.claude-plugin/plugin.json` | v0.5.2 → v0.5.3 |
| `semver/scripts/inject-rules.sh` | soft `/semver:guide` hint → MANDATORY invoke |
| `semver/.claude-plugin/plugin.json` | v0.2.0 → v0.2.1 |
| `git-branch-naming/scripts/inject-rules.sh` | added missing MANDATORY invoke for `branch-naming-guide` |
| `git-branch-naming/.claude-plugin/plugin.json` | v0.2.0 → v0.2.1 |
| `docs/AUTHORING.md` | §3 Pattern 5, §4 anti-patterns, §7 checklist, §8 template |

## Test plan

- [ ] Start fresh Claude Code session with updated plugins
- [ ] Ask Claude to improve a README — verify it invokes `playbook-browse readme` before responding
- [ ] Ask Claude to create a PR — verify it invokes `playbook-browse github-workflow`
- [ ] Ask Claude to bump a version — verify it invokes `semver-guide`
- [ ] Ask Claude to create a branch — verify it invokes `branch-naming-guide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)