### PR TITLE
docs(plantuml): improve README structure and extract validation docs

### DIFF
--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -4,7 +4,9 @@
 
 With this plugin, Claude proactively illustrates architecture, flows, and data structures using [PlantUML](https://plantuml.com): in markdown documentation and directly in the terminal during conversations.
 
-## Demo
+> **Scroll to: [⚙️ How it works](#%EF%B8%8F-how-it-works) · [📦 Installation](#-installation)**
+
+## 🎬 Demo
 
 A developer asks Claude to document the login flow. Claude adds a diagram to the docs — then, during the conversation, renders the same diagram as ASCII art in the terminal.
 
@@ -26,11 +28,6 @@ I'll create docs/auth.md. The flow involves four actors — I'll use a sequence 
   │ ```plantuml                                                       │
   │ @startuml                                                         │
   │ title Login Request Flow                                          │
-  │ hide footbox                                                      │
-  │ skinparam participantBackgroundColor #E8F4FD                      │
-  │ skinparam participantBorderColor #7FB3D8                          │
-  │ skinparam sequenceArrowColor #5B9BD5                              │
-  │ skinparam sequenceLifeLineBorderColor #7FB3D8                     │
   │                                                                   │
   │ actor User                                                        │
   │ participant "Web App" as Web                                      │
@@ -94,15 +91,18 @@ Here's the full flow:
 ![Login Request Flow (PNG image)](https://www.plantuml.com/...)
 ```
 
-## Validation
+## ⚙️ How it works
 
-```
-/plantuml:plantuml-validate
-```
+Every diagram has two parts: a `plantuml` source block and an image URL below it. Claude writes both — you only edit the source. When you save, the URL updates automatically.
 
-Checks all diagram URLs in the project. Also runs automatically as a git pre-commit hook and in GitHub Actions CI.
+| Trigger | What happens |
+|---------|-------------|
+| SessionStart | Injects diagram formatting rules and ASCII rendering workflow |
+| PostToolUse (Write/Edit on `.md`) | Auto-updates image URLs when source changes ([validation & CI](docs/VALIDATION.md)) |
+| PreToolUse | Auto-allows all PlantUML operations — no permission prompts |
+| Before creating any diagram | `plantuml-diagram-guide` skill invoked automatically — picks the right type from 17 options |
 
-## Installation
+## 📦 Installation
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins
@@ -112,18 +112,7 @@ Checks all diagram URLs in the project. Also runs automatically as a git pre-com
 
 Select **plantuml** → enable **auto-update**. Restart your session — done.
 
-## Requirements
-
-- Python 3.x
-
-## How it works
-
-| Trigger | What happens |
-|---------|-------------|
-| SessionStart | Injects diagram formatting rules and ASCII rendering workflow |
-| PostToolUse (Write/Edit on `.md`) | Auto-updates image URLs when source changes |
-| PreToolUse | Auto-allows all PlantUML operations — no permission prompts |
-| Before creating any diagram | `plantuml-diagram-guide` skill invoked automatically — picks the right type from 17 options |
+**Requirements:** Python 3.6+
 
 ## License
 

--- a/plugins/plantuml/docs/VALIDATION.md
+++ b/plugins/plantuml/docs/VALIDATION.md
@@ -1,0 +1,15 @@
+# PlantUML Validation
+
+Every diagram has two parts: a `plantuml` source block and an image URL below it. Validation detects diagrams whose image URL no longer matches the source block (stale URL) or is missing entirely.
+
+## Manual validation
+
+Run `/plantuml:plantuml-validate` in any Claude Code session to check all `.md` files in the project. Claude will list any mismatches and offer to auto-fix them.
+
+## Git pre-commit hook
+
+Installed automatically on session start. Blocks commits when any diagram URL is stale — run `/plantuml:plantuml-validate` to fix before committing.
+
+## GitHub Actions CI
+
+A workflow template is included at `templates/plantuml.yml`. Copy it to `.github/workflows/` to run validation on every PR.


### PR DESCRIPTION
## Summary

- Add navigation line with scroll anchors
- Add emoji to section headings for scannability
- Add intro paragraph to "How it works" explaining the 2-part diagram structure (source block + image URL)
- Merge Requirements into Installation section
- Extract Validation section to `docs/VALIDATION.md` — not a primary workflow, reduces noise in README
- Trim verbose skinparam block from demo code block

## Test plan

- [ ] View README on GitHub — verify navigation anchors work
- [ ] Verify `docs/VALIDATION.md` is reachable via link in How it works table

🤖 Generated with [Claude Code](https://claude.com/claude-code)