### PR TITLE
docs: remove License section from READMEs

### DIFF
--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -113,7 +113,3 @@ Every diagram has two parts: a `plantuml` source block and an image URL below it
 Select **plantuml** → enable **auto-update**. Restart your session — done.
 
 **Requirements:** Python 3.6+
-
-## License
-
-MIT

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -98,7 +98,6 @@ Adapt to the project — not all sections are needed for every project:
 5. **Usage** — concrete examples beyond the demo, covering additional use cases
 6. **Documentation** — links to `docs/` for deeper reference
 7. **Contributing** — link to `CONTRIBUTING.md` or brief guidelines
-8. **License** — one line
 
 Omit sections that don't apply. A 60-line focused README beats a 300-line comprehensive one.
 
@@ -194,4 +193,5 @@ Use answers to decide: section order, technical depth, and how much to explain v
 - **Stale examples** — code that no longer works after a refactor
 - **Placeholder commands** — `npm install <your-package>` without showing the actual package name
 - **Unlinked table items** — listing plugins, modules, or presets by name without linking to their source
+- **License section** — a one-line "MIT" section adds no value; readers who care will check the `LICENSE` file; omit it from README
 <!-- /REFERENCE -->


### PR DESCRIPTION
## Summary

- License sections add no value to README — one-line "MIT" tells nothing useful; readers who care about licensing check the `LICENSE` file
- Remove License section from plantuml README
- Update playbook `readme` preset: remove License from Recommended Sections; add to Anti-Patterns with rationale so Claude stops adding it automatically

## Version bumps

- plantuml: 1.6.2 → 1.6.3
- playbook: 0.5.4 → 0.5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)