### PR TITLE
docs(playbook): improve readme preset and authoring guide (v0.5.6)

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -110,7 +110,7 @@ Format: **ALWAYS invoke the `<skill-name> [args]` skill BEFORE <trigger>** to <p
 
 **Good** (from `playbook/presets/readme.md`):
 ```
-- **ALWAYS invoke the `playbook-browse readme` skill BEFORE creating or improving any README** to load full guidelines. This is MANDATORY — do not skip this step.
+- **ALWAYS invoke the `playbook-browse readme` skill BEFORE writing or modifying any README.md file** to load full guidelines. This is MANDATORY — do not skip even when executing a plan or implementing a task that produces a README.
 ```
 
 **Bad:**
@@ -118,7 +118,19 @@ Format: **ALWAYS invoke the `<skill-name> [args]` skill BEFORE <trigger>** to <p
 - For full reference: invoke `/playbook-browse` and select "readme"
 ```
 
-Why it works: the soft form reads as an optional hint and is skipped under context pressure. The MANDATORY form with bold formatting matches the strength of other ALWAYS/NEVER rules in the same zone.
+```
+- **ALWAYS invoke the `playbook-browse readme` skill BEFORE creating or improving any README**
+```
+
+Why the second bad example fails: `"creating or improving"` describes a **direct user request** but misses **indirect triggers** — when the user says "implement the plan" or "execute this task" and a README is one of the artifacts produced. Claude does not re-evaluate the trigger for each artifact; it evaluates the top-level intent.
+
+**Trigger scope rule:** write triggers that match the **artifact**, not the **user's intent**:
+
+| Narrow (misses indirect triggers) | Broad (catches all cases) |
+|-----------------------------------|--------------------------|
+| `BEFORE creating or improving any README` | `BEFORE writing or modifying any README.md file` |
+| `When user asks to add a diagram` | `Before creating any PlantUML diagram` |
+| `When committing documentation changes` | `After modifying any file in docs/` |
 
 **Important:** this pattern is a reinforcement, not a substitute for self-contained RULES. The RULES zone must still work if the skill is not invoked (e.g., offline, timeout). Use this pattern when the REFERENCE zone adds significant value beyond what fits in the RULES budget.
 
@@ -159,6 +171,7 @@ The decomposed version provides observable triggers (Claude can detect them mech
 | Soft browse line: "For full reference: invoke..." | Reads as optional hint, skipped under context pressure | Use MANDATORY pattern: `**ALWAYS invoke the \`playbook-browse <preset>\` skill BEFORE...**` |
 | Overly broad triggers: "before every commit" | Becomes noise — most commits don't match | Narrow to specific change types |
 | Rules outside Claude's scope: "update the team" | Claude cannot email or message | Scope to actions Claude can actually perform |
+| Trigger matches user intent, not artifact: "when user asks to create a README" | Misses indirect triggers — plan execution, task implementation — where README is just one artifact | Write triggers that match the artifact: "before writing or modifying any README.md file" |
 
 ---
 
@@ -229,7 +242,7 @@ NEVER have the same `name:` frontmatter in both `commands/foo/SKILL.md` and `ski
 Before submitting a preset or SKILL.md, verify:
 
 1. Every RULES bullet answers: "What exactly does Claude do, and when?"
-2. Every trigger is an observable event, not a judgment call
+2. Every trigger is an observable event, not a judgment call; triggers match the **artifact** produced, not the user's stated intent (see §3 Pattern 5 — Trigger scope rule)
 3. Every action is concrete — Claude can execute it without further clarification
 4. No RULES rule depends on reading the REFERENCE zone to be understood
 5. No vague language: "consider", "may", "recommended", "try to", "when appropriate"

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -10,7 +10,7 @@ tags: [docs, readme]
 MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "what is this?" and "why would I use it?".
 
 - When creating/editing README.md → first 5 lines: project name, one-line description, problem it solves, target audience
-- After header block → add a nav line as blockquote: `> **Scroll to: [⚙️ How it works](#how-it-works) · [📦 Installation](#installation)**` — exclude the first section, use ` · ` as separator
+- After header block → add a nav line as blockquote with ALL sections except the first one (usually Demo). Use ` · ` as separator. Example: `> **Scroll to: [⚙️ How it works](#how-it-works) · [📋 Sources](#sources) · [⚡ Commands](#commands) · [📦 Installation](#installation)**`. GitHub strips emoji from anchors: `## ⚙️ How it works` → `#how-it-works`
 - Use emoji in headings (🚀 📦 ⚡ ⚙️) unless user explicitly forbids it
 - For tools/CLIs/plugins → lead with a concrete demo (real input → real output), NOT a feature list
 - Installation: official method only — no workarounds; merge Quick Start + Installation into one section
@@ -20,19 +20,29 @@ MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "w
 - After adding/removing a public API, CLI command, or major feature → remind: "README may need updating"
 - When user asks to create/improve README → start with audience interview: who reads this? what's their level?
 - NEVER leave outdated examples — if code changed, update or remove them
-- **ALWAYS invoke the `playbook-browse readme` skill BEFORE creating or improving any README** to load full guidelines. This is MANDATORY — do not skip this step.
+- **ALWAYS invoke the `playbook-browse readme` skill BEFORE writing or modifying any README.md file** to load full guidelines. This is MANDATORY — do not skip even when executing a plan or implementing a task that produces a README.
 <!-- /RULES -->
 
 <!-- REFERENCE -->
 ## Navigation Line
 
-Add a nav line as a blockquote after the header block (tagline + intro paragraph). Exclude the first section (usually Demo) — it's already visible. Use ` · ` as separator. Prefix with `Scroll to:` for clarity:
+Add a nav line as a blockquote after the header block (tagline + intro paragraph). Include ALL sections except the first one (usually Demo — it's already visible above the fold). Use ` · ` as separator. Prefix with `Scroll to:` for clarity:
 
 ```markdown
-> **Scroll to: [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [License](#license)**
+> **Scroll to: [⚙️ How it works](#how-it-works) · [📋 Sources](#sources) · [⚡ Commands](#commands) · [📦 Installation](#installation)**
 ```
 
 This gives regulars instant access to any section without scrolling. Keep it on one line — no bullets, no numbering.
+
+**GitHub anchor rules for emoji headings:** GitHub strips emoji when generating anchors — use only the text part in lowercase kebab-case:
+
+| Heading | Correct anchor | Wrong |
+|---------|---------------|-------|
+| `## ⚙️ How it works` | `#how-it-works` | `#️⃣-how-it-works`, `#%EF%B8%8F-how-it-works` |
+| `## 📦 Installation` | `#installation` | `#-installation` |
+| `## 🎬 Demo` | `#demo` | `#-demo` |
+
+Never use percent-encoded emoji or emoji characters in anchor links.
 
 ## Emoji
 


### PR DESCRIPTION
## Summary

Based on session analysis — three gaps identified when creating `context/README.md`:

**readme preset (RULES):**
- Nav line rule: "ALL sections except first" + GitHub anchor rule inline (emoji stripped: `## ⚙️` → `#how-it-works`)
- Mandatory skill invocation trigger broadened: `"writing or modifying any README.md file"` — catches indirect triggers (plan execution, task implementation), not just direct user requests

**readme preset (REFERENCE):**
- Navigation Line section: full anchor rules table, multi-section nav example

**AUTHORING.md:**
- §3 Pattern 5: new "Trigger scope rule" — artifact-based vs intent-based triggers with comparison table
- §4 Anti-patterns: new entry "Trigger matches user intent, not artifact"
- §7 Quality Checklist item 2: reference to trigger scope rule

## Test plan

- [ ] Fresh session: ask Claude to "implement a plan that includes creating a README" — verify `playbook-browse readme` is invoked before writing
- [ ] Verify nav line in new READMEs includes all sections (not just 2)
- [ ] Verify anchor links use text-only format (no emoji encoding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)