### PR TITLE
docs: fix emoji heading anchors with explicit <a name> tags

### DIFF
--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Inspect full Claude Code session context: CLAUDE.md files, auto-memory, and SessionStart hook output",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -38,7 +38,7 @@ Summary:
 - Total context load: ~11,400 tokens
 ```
 
-## ⚙️ How it works
+## ⚙️ How it works <a name="how-it-works"></a>
 
 The plugin runs `ctx-show.sh`, which:
 
@@ -52,7 +52,7 @@ The plugin runs `ctx-show.sh`, which:
 
 Missing files are noted but do not cause errors.
 
-## 📋 Sources
+## 📋 Sources <a name="sources"></a>
 
 Collected in load order:
 
@@ -63,7 +63,7 @@ Collected in load order:
 5. Project SessionStart hooks (from `{project}/.claude/settings.json`)
 6. Plugin SessionStart hooks (enabled plugins in `~/.claude/plugins/cache/`)
 
-## 📊 Summary Table Columns
+## 📊 Summary Table Columns <a name="summary-table-columns"></a>
 
 | Column | Description |
 |--------|-------------|
@@ -77,14 +77,14 @@ Collected in load order:
 
 Playbook presets appear as individual rows when using playbook plugin v0.3.1+.
 
-## ⚡ Commands
+## ⚡ Commands <a name="commands"></a>
 
 | Command | Flags | Description |
 |---------|-------|-------------|
 | `/ctx-show` | `--file` (default) | Write context to `/tmp/claude-context-{timestamp}.md` and print path |
 | `/ctx-show` | `--stdout` | Print full context content to terminal |
 
-## 📦 Installation
+## 📦 Installation <a name="installation"></a>
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -10,7 +10,7 @@ tags: [docs, readme]
 MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "what is this?" and "why would I use it?".
 
 - When creating/editing README.md → first 5 lines: project name, one-line description, problem it solves, target audience
-- After header block → add a nav line as blockquote with ALL sections except the first one (usually Demo). Use ` · ` as separator. Example: `> **Scroll to: [⚙️ How it works](#how-it-works) · [📋 Sources](#sources) · [⚡ Commands](#commands) · [📦 Installation](#installation)**`. GitHub strips emoji from anchors: `## ⚙️ How it works` → `#how-it-works`
+- After header block → add a nav line as blockquote with ALL sections except the first one (usually Demo). Use ` · ` as separator. Add explicit `<a name="...">` anchor to each emoji heading: `## ⚙️ How it works <a name="how-it-works"></a>`. Then nav links use the explicit anchor: `[⚙️ How it works](#how-it-works)`
 - Use emoji in headings (🚀 📦 ⚡ ⚙️) unless user explicitly forbids it
 - For tools/CLIs/plugins → lead with a concrete demo (real input → real output), NOT a feature list
 - Installation: official method only — no workarounds; merge Quick Start + Installation into one section
@@ -35,15 +35,21 @@ Add a nav line as a blockquote after the header block (tagline + intro paragraph
 
 This gives regulars instant access to any section without scrolling. Keep it on one line — no bullets, no numbering.
 
-**GitHub anchor rules for emoji headings:** GitHub strips emoji when generating anchors — use only the text part in lowercase kebab-case:
+**GitHub anchor rules for emoji headings:** GitHub's anchor generation for emoji headings is unreliable — the resulting anchor depends on the specific emoji and may include leading dashes or other artifacts. The only reliable approach is explicit `<a name>` anchors:
 
-| Heading | Correct anchor | Wrong |
-|---------|---------------|-------|
-| `## ⚙️ How it works` | `#how-it-works` | `#️⃣-how-it-works`, `#%EF%B8%8F-how-it-works` |
-| `## 📦 Installation` | `#installation` | `#-installation` |
-| `## 🎬 Demo` | `#demo` | `#-demo` |
+```markdown
+## ⚙️ How it works <a name="how-it-works"></a>
+## 📋 Sources <a name="sources"></a>
+## 📦 Installation <a name="installation"></a>
+```
 
-Never use percent-encoded emoji or emoji characters in anchor links.
+Then nav links reference the explicit anchor name directly:
+
+```markdown
+> **Scroll to: [⚙️ How it works](#how-it-works) · [📦 Installation](#installation)**
+```
+
+Never rely on GitHub's auto-generated anchors for emoji headings — they differ per emoji and break silently.
 
 ## Emoji
 


### PR DESCRIPTION
## Summary

- **context/README.md**: added explicit `<a name="...">` anchors to all emoji headings — nav links now scroll correctly on GitHub
- **playbook/presets/readme.md**: fixed incorrect guidance about GitHub emoji anchors; replaced with correct `<a name>` approach

## Root cause

GitHub's auto-generated anchor for emoji headings is unreliable — it strips the emoji but may leave a leading dash depending on the specific emoji. The previous rule said "GitHub strips emoji → `#how-it-works`" which was wrong for some emoji (e.g., `📊` → `#-summary-table-columns`).

## Fix

Explicit `<a name="...">` anchors on each heading are 100% reliable:
```markdown
## ⚙️ How it works <a name="how-it-works"></a>
```

## Bumps

- context `0.3.1` → `0.3.2`
- playbook `0.5.7` → `0.5.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)