### PR TITLE
docs(readme): overhaul root README as landing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,12 @@ Thank you for contributing to the Tribe Coding plugin marketplace! This guide wi
 - [Version Bump Requirements](CLAUDE.md#version-bump-requirements) — **CRITICAL**
 - [Acceptance Test Standard](CLAUDE.md#acceptance-test-documentation-standard)
 
+## Plugin Concepts
+
+- **hook** — runs automatically in response to events (`PostToolUse`, `PreToolUse`, `SessionStart`, `SessionEnd`). No user action needed.
+- **command** — a `/slash-command` that the user invokes explicitly when needed.
+- **skill** — reference material that Claude loads on-demand when it decides the context is relevant.
+
 ## Before You Start
 
 1. Read [CLAUDE.md](CLAUDE.md) — contains all technical guidelines
@@ -66,7 +72,7 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
 
 See [Version Bump Requirements](CLAUDE.md#version-bump-requirements) for detailed examples.
 
-**Why this matters:** Without version bump, `claude-marketplace-sync` won't update plugin cache and users won't see your changes.
+**Why this matters:** Without a version bump, the plugin cache won't be updated and users won't see your changes.
 
 ### 5. Create Pull Request
 
@@ -93,17 +99,9 @@ After merge:
 # Sync your local main
 git checkout main
 git pull origin main
-
-# Update plugin cache to test
-claude-marketplace-sync --force --verbose
-
-# Verify new version
-ls ~/.claude/plugins/cache/tribe-coding/<plugin-name>/
-
-# Test in fresh Claude Code session
-cd /tmp/test-plugin
-claude code
 ```
+
+Then restart Claude Code to pick up the updated plugin cache.
 
 ## Common Tasks
 
@@ -127,8 +125,7 @@ claude code
 1. Make changes
 2. Update acceptance tests if behavior changed
 3. **Bump version** (MAJOR/MINOR/PATCH based on change type)
-4. Test with `claude-marketplace-sync --force`
-5. Create PR
+4. Create PR
 
 ### Fixing Bugs
 
@@ -184,9 +181,8 @@ Run the acceptance tests from plugins/<name>/docs/ACCEPTANCE_TESTS.md
 ### Manual Testing
 
 For SessionStart hooks and fresh session behavior:
-1. Update plugin cache: `claude-marketplace-sync --force`
-2. Start fresh session in test directory
-3. Follow manual test procedures in ACCEPTANCE_TESTS.md
+1. Restart Claude Code (triggers cache refresh + SessionStart hooks)
+2. Follow manual test procedures in ACCEPTANCE_TESTS.md
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -1,241 +1,44 @@
 # Tribe Coding — Claude Code Plugins
 
-A marketplace of reusable plugins for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+> Good habits, better output.
 
-## Quick Reference
+A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that automate the routines good developers follow anyway — consistent diagrams, clean branches, version discipline, session awareness.
 
-| Plugin | Type | Name | Invocation | Description |
-|--------|------|------|------------|-------------|
-| **plantuml** | hook | PostToolUse | *automatic* | Auto-sync PlantUML image URLs on `.md` edits |
-| | hook | SessionStart | *automatic* | Inject base formatting rules + install pre-commit hook |
-| | command | [`plantuml-validate`](plugins/plantuml/commands/plantuml-validate/SKILL.md) | `/plantuml:plantuml-validate` | Check all diagram URLs are in sync |
-| | skill | [`plantuml-diagram-guide`](plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md) | *on-demand* | Full catalog of 16 diagram types with selection guide |
-| **statusline** | hook | SessionStart | *automatic* | Install statusline script to `~/.claude/` |
-| | command | [`statusline-setup`](plugins/statusline/commands/statusline-setup/SKILL.md) | `/statusline:statusline-setup` | Configure statusline in `~/.claude/settings.json` |
-| **statusline-compact** | hook | SessionStart | *automatic* | Install compact statusline script to `~/.claude/` |
-| | command | [`statusline-setup`](plugins/statusline-compact/commands/statusline-setup/SKILL.md) | `/statusline-compact:statusline-setup` | Configure compact statusline |
+> **Scroll to: [📦 Installation](#installation) · [🤝 Contributing](#contributing)**
 
-> - **hook** — runs automatically in response to events (e.g. after every file edit or on session start). No user action needed.
-> - **command** — a `/slash-command` that the user invokes explicitly when needed.
-> - **skill** — reference material that Claude loads on-demand when it decides the context is relevant.
+## 🧩 Plugins
 
-## Installation
+| Plugin | What it does |
+|--------|-------------|
+| [**context**](plugins/context/README.md) | Show everything loaded into your session — CLAUDE.md files, memory, hooks — with a per-source token breakdown |
+| [**git-branch-naming**](plugins/git-branch-naming/README.md) | Enforce branch naming conventions automatically; warns before push if the name or staged content doesn't match |
+| [**plantuml**](plugins/plantuml/README.md) | Proactively add rendered diagrams to docs (image URLs auto-synced); draw ASCII diagrams inline during terminal conversations |
+| [**playbook**](plugins/playbook/README.md) | Inject team coding conventions into every session — git workflow, documentation standards, platform quirks |
+| [**retroscope**](plugins/retroscope/README.md) | Capture what happened each session and generate structured daily retrospective reports |
+| [**semver**](plugins/semver/README.md) | Validate that a version bump is staged before every commit, push, and PR — with configurable enforcement |
+| [**statusline**](plugins/statusline/README.md) | Two-line statusline showing API rate limits, context window usage, git branch, and model |
+| [**statusline-compact**](plugins/statusline-compact/README.md) | Single-line statusline with brightness-coded values — the minimal-footprint option |
 
-### Add the marketplace
+## 📦 Installation
+
+### 1. Add the marketplace
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins
 ```
 
-### Install a plugin
+### 2. Install a plugin
 
 ```bash
 /plugin install plantuml@tribe-coding
-/plugin install statusline@tribe-coding
-/plugin install statusline-compact@tribe-coding
 ```
 
-### Enable auto-updates
+Repeat for each plugin you want.
 
-After installing, enable automatic updates so plugins stay in sync with the latest fixes:
+### 3. Enable auto-updates
 
-```bash
-/plugin
-```
+Open `/plugin`, select each installed plugin, and enable **auto-update**.
 
-Then select the installed plugin and enable **auto-update**. Updates are applied automatically on the next Claude Code restart.
+## 🤝 Contributing
 
-## Available Plugins
-
-### plantuml
-
-PlantUML diagram automation for markdown documentation.
-
-**Features:**
-
-- Auto-sync PlantUML image URLs after every Write/Edit (PostToolUse hook)
-- ASCII text diagrams in terminal via PlantUML text renderer API
-- Git pre-commit hook blocks commits with stale diagram URLs
-- Base formatting rules injected on session start (~200 tokens)
-- Full diagram type catalog available on-demand via skill
-- Validation command: `/plantuml:plantuml-validate`
-- GitHub Actions CI workflow template
-
-**What it does:**
-
-- **In markdown files**: Every PlantUML diagram has two parts — a fenced code block with raw source and an image link pointing to plantuml.com. This plugin keeps them in sync automatically.
-- **In terminal**: When you ask Claude to explain architecture or flows, it uses PlantUML's ASCII text renderer (`https://www.plantuml.com/plantuml/txt/<encoded>`) to show perfectly aligned ASCII diagrams instead of pasting raw PlantUML source or manually drawing ASCII art.
-
-### statusline
-
-Custom Claude Code statusline with real-time API usage info.
-
-**Features:**
-
-- Current directory and git branch (yellow when dirty)
-- Model name, color-coded (Opus=red, Sonnet=green, Haiku=blue)
-- Context window usage with thresholds (yellow >=60%, red >=80%)
-- 5-hour and 7-day rate limit progress bars with time remaining
-- Extra usage (monthly billing) progress bar with money spent
-- Anthropic OAuth usage API integration (cached 60s)
-- Setup command: `/statusline:statusline-setup`
-
-**Progress bar resolution:**
-
-- 5h: 15 min/block (20 blocks) - updates every 15 minutes
-- 7d: 8 hours/block (21 blocks) - updates every 8 hours
-- Extra: 1 day/block (28-31 blocks) - updates daily
-- Cache: 60s refresh rate (all bars)
-
-### statusline-compact
-
-Compact single-line Claude Code statusline with brightness-coded API usage values.
-
-**Example:**
-
-```
-5h 92% 50m !!   7d 22% ~5d   extra $4.79   Sonnet 4.5   context 30%   my-project/   main*
-```
-
-**Features:**
-
-- Single-line layout - most space-efficient option
-- 5-hour and 7-day rate limit tracking with time-to-reset
-- Extra usage (monthly billing) with dollar amount
-- Context window usage percentage
-- Current directory and git branch (yellow when dirty)
-- Model name with brightness = capability tier (Opus bright, Sonnet default, Haiku dim)
-- Brightness-coded values: dim at low usage, brighter as they climb, yellow >90%, red at 100%
-- Text indicators: `!!` warning, `XX` exhausted
-- Anthropic OAuth usage API integration (cached 60s)
-- Setup command: `/statusline-compact:statusline-setup`
-
-## Plugin Structure
-
-Each plugin follows the Claude Code plugin spec:
-
-```
-plugins/<name>/
-├── .claude-plugin/
-│   └── plugin.json          # Plugin manifest
-├── commands/                 # User-invocable /commands
-│   └── <command>/
-│       └── SKILL.md
-├── skills/                   # On-demand skills (context-efficient)
-│   └── <skill>/
-│       └── SKILL.md
-├── hooks/
-│   └── hooks.json            # PostToolUse / SessionStart hooks
-├── scripts/                  # Hook and utility scripts
-└── templates/                # Project templates (pre-commit, CI)
-```
-
-> **Note:** `plugin.json` **must** include both `"commands"` and `"skills"` fields for Claude Code to expose SKILL.md files to the skill system. If your plugin only has `commands/`, point both fields at the same directory:
-> ```json
-> { "commands": ["./commands/"], "skills": ["./commands/"] }
-> ```
-
-## Requirements
-
-### plantuml
-
-- Python 3.x (for the encoder script)
-- Git (for pre-commit hook)
-
-### statusline / statusline-compact
-
-- `jq` — JSON processing
-- `curl` — API requests
-- `python3` — OAuth token parsing (macOS)
-- macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
-
-## Plugin Cache Sync
-
-### The problem
-
-Claude Code has a bug where auto-updating a marketplace does not invalidate the plugin cache. `CLAUDE_PLUGIN_ROOT` continues to point at stale cached files, so updated scripts, skills, and commands are not picked up.
-
-**Upstream issues:**
-
-- [anthropics/claude-code#14061](https://github.com/anthropics/claude-code/issues/14061) — `/plugin update` doesn't invalidate cache
-- [anthropics/claude-code#15621](https://github.com/anthropics/claude-code/issues/15621) — old versions not removed, their hooks still run
-- [anthropics/claude-code#15642](https://github.com/anthropics/claude-code/issues/15642) — `CLAUDE_PLUGIN_ROOT` points to stale version
-
-### The fix: `claude-marketplace-sync`
-
-A standalone script that runs *before* Claude Code starts. It pulls marketplace repos with `autoUpdate: true` and rsyncs their plugin directories into the cache.
-
-**Install:**
-
-```bash
-# From the marketplace repo
-./scripts/install-sync.sh
-```
-
-This creates a symlink from `~/.local/bin/claude-marketplace-sync` to the script in the repo, adds it to `PATH`, and configures a shell alias so that `claude` automatically syncs before starting. Because it's a symlink, changes to the script in the repo are picked up immediately — no reinstall needed.
-
-**Usage:**
-
-```bash
-claude-marketplace-sync              # Sync (skips if ran in last 5 min)
-claude-marketplace-sync --force      # Ignore freshness window; also re-runs SessionStart hooks
-claude-marketplace-sync --all        # Sync all marketplaces, not just autoUpdate ones
-claude-marketplace-sync --verbose    # Print detailed progress
-```
-
-**Output:**
-
-By default, `claude-marketplace-sync` shows:
-
-- Sync status (`🔄 Syncing...` or `⏭️ Skipping...`)
-- Plugin version updates (`✅ Updated: plugin@marketplace version X.Y.Z`)
-- Sync errors (`❌ Failed to sync...`)
-
-With `--verbose`, also shows git pull and rsync operations.
-
-For silent operation: `claude-marketplace-sync 2>/dev/null`
-
-### Troubleshooting
-
-Both `claude-marketplace-sync` and plugin SessionStart hooks log detailed operations to a shared log file:
-
-```bash
-cat /tmp/claude-plugin-sync.log
-```
-
-The log records: sync decisions (version/SHA comparison), rsync operations, SessionStart hook execution (expanded commands, exit codes, output), and `setup-statusline.sh` operations (`CLAUDE_PLUGIN_ROOT` value, source/target file states, diff results).
-
-To diagnose a stale plugin after sync:
-1. Restart Claude Code (triggers `claude-marketplace-sync` + SessionStart hooks)
-2. Check the log: `cat /tmp/claude-plugin-sync.log`
-3. Look for `[setup-statusline]` entries showing `CLAUDE_PLUGIN_ROOT` path — if it points to an old version directory, Claude Code hasn't picked up the new cache entry
-
-The workaround will be removed once the upstream bugs are fixed.
-
-## Contributing
-
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
-
-**Quick links:**
-
-- [CONTRIBUTING.md](CONTRIBUTING.md) — Full contribution workflow
-- [CLAUDE.md](CLAUDE.md) — Complete technical guidelines
-- [Version Bump Requirements](CLAUDE.md#version-bump-requirements) — **CRITICAL**: Required before merge
-- [Acceptance Test Standard](CLAUDE.md#acceptance-test-documentation-standard)
-- [PR Template](.github/pull_request_template.md) — Use this when creating PRs
-
-**Quick start:**
-
-1. Create `plugins/<name>/` with the standard structure (see [CLAUDE.md](CLAUDE.md))
-2. Add `.claude-plugin/plugin.json` manifest (version `0.1.0`)
-3. All SKILL.md files must include YAML frontmatter ([agentskills.io spec](https://agentskills.io/specification))
-4. Create `docs/ACCEPTANCE_TESTS.md` with comprehensive tests
-5. Register in `.claude-plugin/marketplace.json`
-6. **Bump version before merge** (see [Version Bump Requirements](CLAUDE.md#version-bump-requirements))
-7. Submit PR using the [template](.github/pull_request_template.md)
-
-**Important:** Version bumps are **required** before merging any PR that changes plugin code. Without version bumps, `claude-marketplace-sync` won't pick up your changes. See [CLAUDE.md](CLAUDE.md#version-bump-requirements) for semantic versioning rules.
-
-## License
-
-MIT — see [LICENSE](LICENSE).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow, plugin structure, and code standards.

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -12,7 +12,7 @@ Reports include: task outcomes, decisions made, open questions, GitHub/PR refere
 
 ## Quick Start
 
-1. Install the plugin (via claude-marketplace-sync or manually)
+1. Install the plugin: `/plugin install retroscope@tribe-coding`
 2. Start a Claude Code session
 3. Run `/retro` — if no config is found, it will offer to run setup automatically
 4. Work normally in Claude Code
@@ -142,4 +142,4 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin
 
 **Plugin not loading:**
 - Verify `retroscope` is in your enabled plugins in `~/.claude/settings.json`
-- Run `claude-marketplace-sync --force` to refresh plugin cache
+- Restart Claude Code to pick up the latest plugin cache

--- a/plugins/semver/README.md
+++ b/plugins/semver/README.md
@@ -1,0 +1,89 @@
+# semver
+
+> Never ship without a version bump — Claude enforces SemVer before every commit, push, and PR.
+
+Semantic versioning enforcement for Claude Code. Validates that a version bump is staged before `git commit`, `git push`, and PR creation. Injects SemVer rules into every session so Claude knows when and how to increment versions automatically.
+
+## 🎬 Demo
+
+```
+You: commit the auth service refactor
+
+Claude: ⚠️  No version bump detected.
+
+The staged changes include source file modifications in src/auth/.
+According to SemVer, this refactor (backwards-compatible) requires a MINOR bump.
+
+Current version in package.json: 2.3.1
+Suggested: 2.4.0
+
+Bump version now, or commit anyway?
+```
+
+## ⚙️ How it works
+
+| Trigger | What happens |
+|---------|-------------|
+| SessionStart | Injects SemVer rules — Claude evaluates each commit automatically |
+| PreToolUse (`git commit`, `git push`, PR creation) | Validates a version bump is staged; warns if missing |
+
+**Trigger strategies:**
+
+| Strategy | Behaviour |
+|----------|-----------|
+| `auto` (default) | Evaluate each commit: feature → MINOR, fix → PATCH, breaking → MAJOR, docs/config only → skip |
+| `always` | Every commit with source changes requires a bump — no exceptions |
+
+**Excluded from bump checks by default:** `*.md`, `docs/**`, `LICENSE`, `.gitignore`, `.claude-plugin/**`
+
+## 📦 Installation
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install semver@tribe-coding
+```
+
+Then run the setup wizard to configure your version files and trigger strategy:
+
+```bash
+/semver:semver-setup
+```
+
+Select **semver** in `/plugin` → enable **auto-update**. Restart your session — done.
+
+## ⚙️ Configuration
+
+Config lives at `.claude-plugin/semver.json` (project, committed to git) and `~/.claude/semver.json` (global fallback). Project config takes priority.
+
+**Example `.claude-plugin/semver.json`:**
+
+```json
+{
+  "versionFiles": [
+    { "path": "package.json", "field": "version", "format": "json" }
+  ],
+  "triggerStrategy": "auto",
+  "baseBranch": "main",
+  "enforcement": { "missingBump": "ask" },
+  "commitFormat": "chore: bump version to {version}",
+  "excludePatterns": ["README.md", "docs/**", "*.md"]
+}
+```
+
+**Supported version file formats:** `package.json`, `pyproject.toml`, `plugin.json`, or any JSON/TOML file with a version field. Multiple files supported.
+
+**Enforcement levels:**
+
+| `missingBump` | Behaviour |
+|---------------|-----------|
+| `ask` (default) | Prompt the user before proceeding |
+| `warn` | Log a warning, continue anyway |
+| `block` | Refuse to commit/push until version is bumped |
+
+## Skills (on-demand)
+
+`semver-guide` — loaded automatically when Claude needs to decide MAJOR/MINOR/PATCH. Covers SemVer 2.0.0 decision tree, conflict resolution when rebasing, and common mistakes.
+
+## Reference
+
+- [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) — test suite

--- a/plugins/statusline-compact/README.md
+++ b/plugins/statusline-compact/README.md
@@ -1,0 +1,57 @@
+# statusline-compact
+
+> All the essentials in one line — the most space-efficient Claude Code statusline.
+
+Single-line statusline with brightness-coded API usage values.
+
+## 🎬 Demo
+
+```
+5h 92% 50m !!   7d 22% ~5d   extra $4.79   Sonnet 4.6   context 30%   my-project/   main*
+```
+
+Values dim at low usage and brighten as they climb: yellow above 90%, red at 100%.
+`!!` = warning, `XX` = exhausted.
+
+## ⚙️ How it works
+
+| Trigger | What happens |
+|---------|-------------|
+| SessionStart | Installs compact statusline script to `~/.claude/` |
+| Every prompt | Reads API usage from Anthropic OAuth API (cached 60s) |
+
+**Brightness coding:**
+- Model brightness = capability tier: Opus bright, Sonnet default, Haiku dim
+- Usage values: dim at low, brighten as they climb, yellow > 90%, red at 100%
+
+**Tracked values:** 5h rate limit · 7d rate limit · extra usage ($ amount) · context % · directory · git branch · model name
+
+## 📦 Installation
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install statusline-compact@tribe-coding
+```
+
+Then run the setup command to configure `~/.claude/settings.json`:
+
+```bash
+/statusline-compact:statusline-setup
+```
+
+Select **statusline-compact** in `/plugin` → enable **auto-update**. Restart your session — done.
+
+**Requirements:** `jq`, `curl`, `python3`; macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
+
+## Compared to statusline
+
+| | statusline | statusline-compact |
+|-|------------|-------------------|
+| Layout | 2 lines | 1 line |
+| Progress bars | Yes (visual) | No (% only) |
+| Space usage | More | Less |
+| Choose when | You want visual progress bars | You want minimal terminal footprint |
+
+## Reference
+
+- [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) — test suite

--- a/plugins/statusline/README.md
+++ b/plugins/statusline/README.md
@@ -1,0 +1,58 @@
+# statusline
+
+> Know your API limits, context, and git state at a glance — without leaving Claude Code.
+
+Two-line Claude Code statusline with real-time API usage, progress bars, and session info.
+
+## 🎬 Demo
+
+```
+⏳ [████████░░░░░░░░░░░░] 3h 42m   📅 [████░░░░░░░░░░░░░░░░░] ~5d 8h   💸 [██░░░░░░░░░░░░░] $4.79
+📁 my-project/   🌿 main*   🤖 claude-sonnet-4-6   📚 32%
+```
+
+**Line 1:** 5-hour limit · 7-day limit · extra usage (monthly billing with $ spent)
+**Line 2:** directory · git branch (yellow when dirty) · model · context window %
+
+## ⚙️ How it works
+
+| Trigger | What happens |
+|---------|-------------|
+| SessionStart | Installs `statusline.sh` to `~/.claude/` |
+| Every prompt | Reads API usage from Anthropic OAuth API (cached 60s) |
+
+Model color-coding: Opus = red, Sonnet = green, Haiku = blue.
+Context warning thresholds: yellow ≥ 60%, red ≥ 80%.
+Warning icons: ⚠️ above 90%, ❌ at 100%.
+
+**Progress bar resolution:**
+
+| Bar | Blocks | Resolution |
+|-----|--------|-----------|
+| 5h | 20 | 15 min/block |
+| 7d | 21 | 8 h/block |
+| Extra | days in month | 1 day/block |
+
+Cache refresh: 60s (all bars).
+
+## 📦 Installation
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install statusline@tribe-coding
+```
+
+Then run the setup command to configure `~/.claude/settings.json`:
+
+```bash
+/statusline:statusline-setup
+```
+
+Select **statusline** in `/plugin` → enable **auto-update**. Restart your session — done.
+
+**Requirements:** `jq`, `curl`, `python3`; macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
+
+## Reference
+
+- [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) — test suite
+- [`docs/STDIN_JSON.md`](docs/STDIN_JSON.md) — all JSON fields piped by Claude Code to `statusline.sh`


### PR DESCRIPTION
## Summary

Rewrites root `README.md` from a reference manual (~240 lines) into a compact landing page (44 lines) for visitors arriving via external links.

Closes #137. Related: #119.

## Problem

The README was accurate but written as a reference document — it answered "how does this work internally" rather than "should I install this". Quick Reference table with merged cells, implementation details (progress bar resolution in blocks/minutes, cache TTL, OAuth parsing notes), and a 60-line Plugin Cache Sync section were useful for maintainers but wrong for a first-time visitor.

## Changes

**Root README** (242 → 44 lines):
- Tagline, intro paragraph, emoji headings, nav line (readme playbook preset)
- Compact plugin index — outcome-oriented descriptions, links to per-plugin READMEs
- All implementation detail removed (lives in per-plugin READMEs)
- Plugin Cache Sync section removed (internal tooling, lives in `CLAUDE.md`)
- License section removed (anti-pattern per readme preset)

**New per-plugin READMEs:**
- `plugins/statusline/README.md`
- `plugins/statusline-compact/README.md`
- `plugins/semver/README.md`

**`CONTRIBUTING.md`:**
- Added "Plugin Concepts" section (hook / command / skill definitions)
- Removed `claude-marketplace-sync` references

## Test plan

- [ ] Read README cold — does it answer "what is this / who is it for / how do I start" within the first screen?
- [ ] Click each plugin link in the table — all 8 resolve to existing README files
- [ ] Nav line anchors work on GitHub
- [ ] No broken links in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)