### PR TITLE
fix(git-branch-naming): harden pre-push hooks against missing/malformed config (v0.2.2)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -89,10 +89,13 @@ if ! echo "$CURRENT_BRANCH" | grep -qE "^($PROTECTED)$"; then
     elif [[ "$REQUIRE_KEBAB_CASE" == "true" ]] && echo "$DESC" | grep -qE '[A-Z_]'; then
       FIXED=$(echo "$DESC" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
       INVALID_REASON="not kebab-case. Suggested: ${CURRENT_BRANCH%%/*}/$FIXED"
-    elif [[ ${#CURRENT_BRANCH} -gt $MAX_LENGTH ]]; then
-      INVALID_REASON="too long (${#CURRENT_BRANCH} > $MAX_LENGTH characters)"
-    elif [[ -n "$TICKET_PATTERN" ]] && ! echo "$DESC" | grep -qE "$TICKET_PATTERN"; then
-      INVALID_REASON="missing required ticket number (pattern: $TICKET_PATTERN)"
+    else
+      [[ -z "${MAX_LENGTH:-}" || ! "$MAX_LENGTH" =~ ^[0-9]+$ ]] && MAX_LENGTH=60
+      if [[ ${#CURRENT_BRANCH} -gt $MAX_LENGTH ]]; then
+        INVALID_REASON="too long (${#CURRENT_BRANCH} > $MAX_LENGTH characters)"
+      elif [[ -n "$TICKET_PATTERN" ]] && ! echo "$DESC" | grep -qE "$TICKET_PATTERN"; then
+        INVALID_REASON="missing required ticket number (pattern: $TICKET_PATTERN)"
+      fi
     fi
   fi
 

--- a/plugins/git-branch-naming/.claude-plugin/plugin.json
+++ b/plugins/git-branch-naming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-branch-naming",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Git branch naming convention enforcement: validates names, warns on content mismatch before push",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/git-branch-naming/templates/pre-push
+++ b/plugins/git-branch-naming/templates/pre-push
@@ -51,6 +51,8 @@ if [[ -f "$CONFIG_FILE" ]] && command -v jq >/dev/null 2>&1; then
 
   _e_prot=$(jq -r '.enforcement.protectedBranch // empty' "$CONFIG_FILE" 2>/dev/null || true)
   [[ -n "$_e_prot" ]] && ENFORCEMENT_PROTECTED_BRANCH="$_e_prot"
+elif [[ -f "$CONFIG_FILE" ]]; then
+  echo "warning: git-branch-naming config file '$CONFIG_FILE' exists but 'jq' is not installed; using built-in defaults instead." >&2
 fi
 
 # ─── Get current branch ───────────────────────────────────────────────────────
@@ -89,10 +91,13 @@ if ! echo "$CURRENT_BRANCH" | grep -qE "^($PROTECTED)$"; then
     elif [[ "$REQUIRE_KEBAB_CASE" == "true" ]] && echo "$DESC" | grep -qE '[A-Z_]'; then
       FIXED=$(echo "$DESC" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
       INVALID_REASON="not kebab-case. Suggested: ${CURRENT_BRANCH%%/*}/$FIXED"
-    elif [[ ${#CURRENT_BRANCH} -gt $MAX_LENGTH ]]; then
-      INVALID_REASON="too long (${#CURRENT_BRANCH} > $MAX_LENGTH characters)"
-    elif [[ -n "$TICKET_PATTERN" ]] && ! echo "$DESC" | grep -qE "$TICKET_PATTERN"; then
-      INVALID_REASON="missing required ticket number (pattern: $TICKET_PATTERN)"
+    else
+      [[ -z "${MAX_LENGTH:-}" || ! "$MAX_LENGTH" =~ ^[0-9]+$ ]] && MAX_LENGTH=60
+      if [[ ${#CURRENT_BRANCH} -gt $MAX_LENGTH ]]; then
+        INVALID_REASON="too long (${#CURRENT_BRANCH} > $MAX_LENGTH characters)"
+      elif [[ -n "$TICKET_PATTERN" ]] && ! echo "$DESC" | grep -qE "$TICKET_PATTERN"; then
+        INVALID_REASON="missing required ticket number (pattern: $TICKET_PATTERN)"
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary

Replaces auto-generated PRs #105 and #106 (closed) with corrected fixes only.

**What's fixed:**
- `templates/pre-push`: warn when config file exists but `jq` is not installed (from #105)
- `templates/pre-push` + `.githooks/pre-push`: validate `MAX_LENGTH` is a non-empty integer before numeric comparison; fall back to `60` if missing or malformed (from #106)

**What's NOT applied (and why):**
- `[A-Z_]` → `[A-Z]` regex change — rejected: underscores are valid kebab-case violations and the "not kebab-case" message correctly covers both; removing `_` from the check would silently accept `feature/foo_bar`
- Removing `[[ -z "$w" ]] && continue` guards — rejected: PRs #105 proposed removing them without keeping `:-` fallback, causing empty array elements to print blank lines
- `"${WARNINGS[@]:-}"` → `"${WARNINGS[@]}"` — rejected: scripts use `set -euo pipefail`; bash 3.2 (macOS system shell) throws `unbound variable` on empty array without `:-`

## Version

`git-branch-naming` bumped `0.2.1` → `0.2.2` (PATCH)

## Test plan

- [ ] Push a valid branch — no warnings/errors, hook exits 0
- [ ] Push without `jq` installed with config file present — warning printed, defaults used
- [ ] Config with non-integer `maxLength` — fallback to 60, no crash
- [ ] Push branch with underscore — still caught by `[A-Z_]` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)