### PR TITLE
Fix for Empty except

### DIFF
--- a/plugins/retroscope/scripts/find-sessions.py
+++ b/plugins/retroscope/scripts/find-sessions.py
@@ -615,8 +615,9 @@ def get_stats(jsonl_file: str):
                     (inp + cw + cr) * entry["input"] / 1_000_000
                     + out * entry["output"]           / 1_000_000
                 )
-    except OSError:
-        pass
+    except OSError as e:
+        # If the file cannot be reopened/read, skip refined cost computation but still emit stats.
+        print(f"Warning: failed to recompute cost stats from {jsonl_file}: {e}", file=sys.stderr)
 
     stats["estimated_cost_usd"] = round(actual_cost, 4)
     stats["naive_cost_usd"] = round(naive_cost, 4)


### PR DESCRIPTION
In general, to fix an `except` that only does `pass`, either (a) add a clear explanatory comment justifying why it is safe to ignore the exception, or (b) handle the exception meaningfully—e.g., by logging, emitting a warning, or adjusting the computation state. Here, we should keep the overall flow (still print stats even if cost recomputation fails) but avoid silent suppression.

The best fix with minimal behavior change is to catch the `OSError` as a variable, emit a warning or diagnostic message to `sys.stderr`, and then proceed. This keeps the script robust (it doesn’t crash if the file is unreadable) but gives users/operators a clear indication that cost computation was skipped. We’ll modify the `except OSError:` block in `get_stats` to:

- Bind the exception as `e`.
- Print a short, explicit warning to `sys.stderr` that includes the file path and the error message.
- Optionally leave a brief comment explaining that the failure is non-fatal and stats will be printed with zero/partial cost.

No new imports are needed because `sys` is already imported at the top of the file. All changes will be confined to the `except OSError:` block around lines 618–619 in `plugins/retroscope/scripts/find-sessions.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._