### PR TITLE
docs: fix inconsistencies and missing metadata across plugins

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,12 @@
 <!-- Check all that apply -->
 - [ ] plantuml
 - [ ] statusline
-- [ ] Other: ___________
+- [ ] statusline-compact
+- [ ] git-branch-naming
+- [ ] playbook
+- [ ] semver
+- [ ] retroscope
+- [ ] context
 - [ ] None (only root-level files changed)
 
 ## Version Bump Required

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,24 +67,75 @@ Key components:
 - `commands/plantuml-validate/` — user-invocable `/plantuml-validate` command
 
 ### statusline
-Two-line Claude Code statusline: progress bars (line 1) + session info (line 2). Tracks 5h/7d rate limits, extra usage (monthly billing), context window, git branch, and model. Features warning icons (❌ at 100%, ⚠️ at >90%) and pacing visualization.
+Three-line Claude Code statusline: rate limits (line 1) + context/branch (line 2) + extra usage (line 3). Tracks 5h/7d rate limits, extra usage (monthly billing), context window, git branch, and model.
 
 **Layout:**
-- **Line 1:** ⏳ 5h limit | 📅 7d limit | 💸 extra usage (status icon, progress bar, money spent)
-- **Line 2:** 📁 directory | 🌿 branch | 🤖 model | 📚 context%
+- **Line 1:** 5h limit progress bar (30 blocks/10m) + model + directory
+- **Line 2:** 7d limit progress bar (28 blocks/6h) + context% + branch
+- **Line 3:** extra usage (monthly billing, N blocks/1d) + money spent
 
 **Progress bar resolution:**
-- **5h**: 20 blocks → 15 minutes per block (5h / 20 = 900s)
-- **7d**: 21 blocks → 8 hours per block (7d / 21 = 28800s)
-- **Extra**: N blocks (days in month) → 1 day per block (month / N = 86400s)
+- **5h**: 30 blocks → 10 minutes per block (5h / 30 = 600s)
+- **7d**: 28 blocks → 6 hours per block (7d / 28 = 21600s)
+- **Extra**: N blocks (days in month) → 1 day per block
 - **Cache**: 60s refresh rate (minimum resolution for all bars)
 
 **Key components:**
-- `scripts/statusline.sh` — main script, reads JSON from stdin (piped by Claude Code), outputs two ANSI-colored lines. Fetches Anthropic OAuth usage API (cached 60s in `/tmp/claude-statusline-usage-cache`), reads OAuth token from macOS Keychain or Linux credentials file
+- `scripts/statusline.sh` — main script, reads JSON from stdin (piped by Claude Code), outputs three ANSI-colored lines. Fetches Anthropic OAuth usage API (cached 60s in `/tmp/claude-statusline-usage-cache`), reads OAuth token from macOS Keychain or Linux credentials file
 - `scripts/setup-statusline.sh` — SessionStart hook, copies `statusline.sh` to `~/.claude/statusline.sh`. Logs all operations to `/tmp/claude-plugin-sync.log`
 - `commands/statusline-setup/` — user-invocable `/statusline-setup` command, configures `~/.claude/settings.json`
 - `docs/ACCEPTANCE_TESTS.md` — comprehensive test documentation (8 categories, 17+ tests)
 - `docs/STDIN_JSON.md` — reference for all JSON fields piped by Claude Code to `statusline.sh`
+
+### statusline-compact
+Compact single-line Claude Code statusline with brightness-coded API usage values.
+
+Key components:
+- `scripts/statusline.sh` — main script, outputs one ANSI-colored line with brightness coding (dim at low usage → brighter → yellow >90% → red at 100%)
+- `scripts/setup-statusline.sh` — SessionStart hook, copies `statusline.sh` to `~/.claude/statusline.sh`
+- `commands/statusline-setup/` — user-invocable `/statusline-setup` command, configures `~/.claude/settings.json`
+
+### git-branch-naming
+Enforces branch naming conventions (prefix/kebab-case) and warns when branch type mismatches file changes.
+
+Key components:
+- `scripts/validate-branch.sh` — PreToolUse hook, validates branch name before every Bash command
+- `scripts/inject-rules.sh` — SessionStart hook, outputs branch naming rules
+- `commands/git-branch-naming-setup/` — setup wizard writes `.claude-plugin/git-branch-naming.json`
+- `skills/branch-naming-guide/` — auto-invocable skill with full naming guidelines
+
+### playbook
+Injects curated coding guideline presets into sessions. Presets have two zones: RULES (injected every session) and REFERENCE (loaded on demand).
+
+Key components:
+- `scripts/inject-rules.sh` — SessionStart hook, reads `playbook.json` config and outputs enabled preset RULES zones
+- `commands/playbook-setup/` — setup wizard writes `playbook.json` config
+- `skills/playbook-browse/` — on-demand skill loads REFERENCE zone for a given preset
+- `presets/` — 5 built-in presets: `documentation-principles`, `github-workflow`, `macos-python`, `macos-zsh-quirks`, `readme`
+
+### semver
+Enforces semantic versioning on commit/push/PR. Validates that version files were bumped when source files changed.
+
+Key components:
+- `scripts/validate-bump.sh` — PreToolUse hook, checks version bump before Bash git operations
+- `scripts/inject-rules.sh` — SessionStart hook, outputs semver rules
+- `commands/semver-setup/` — setup wizard writes `.claude-plugin/semver.json`
+- `skills/semver-guide/` — auto-invocable skill with MAJOR/MINOR/PATCH decision tree
+
+### retroscope
+Generates retrospective reports summarizing Claude Code sessions: tasks completed, decisions made, open questions.
+
+Key components:
+- `scripts/inject-rules.sh` — SessionStart hook, outputs retroscope behavior rules
+- `scripts/session-end.sh` — SessionEnd hook, records session metadata for daily reports
+- `commands/retro/` — user-invocable `/retro` command with three modes: `session`, `today`, `yesterday`
+- `commands/retroscope-setup/` — setup wizard writes storage directory and config
+
+### context
+Inspects the full Claude Code session context in load order: CLAUDE.md files, auto-memory, and SessionStart hook output.
+
+Key components:
+- `commands/ctx-show/` — user-invocable `/ctx-show` command. Outputs all context sources with source separators; prints summary table (scope, type, lines, tokens, context%) to stderr
 
 ## Plugin Structure Convention
 
@@ -438,7 +489,7 @@ Examples:
    Changes in X.Y.Z:
    - <list key changes>
 
-   Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
    ```
 6. **Then create PR** (NEVER before version bump)
 7. **After merge**: User runs `claude-marketplace-sync --force` to update cache

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -100,7 +100,7 @@ Why it works: maps symptom → fix in one line. Claude pattern-matches the error
 
 ---
 
-### Pattern 5: Mandatory Skill Invocation
+### Pattern 4: Mandatory Skill Invocation
 
 **Best for:** presets with a REFERENCE zone too large for RULES — forces Claude to load full guidelines before acting.
 
@@ -136,7 +136,7 @@ Why the second bad example fails: `"creating or improving"` describes a **direct
 
 ---
 
-### Pattern 4: Checklist
+### Pattern 5: Checklist
 
 **Use sparingly.** Checklists are the weakest pattern because each item requires a judgment call ("Did the architecture change?") that Claude must evaluate without clear criteria.
 

--- a/docs/ideation/statusline-customizable/tasks-manifest.md
+++ b/docs/ideation/statusline-customizable/tasks-manifest.md
@@ -1,5 +1,7 @@
 # Tasks manifest
 
+> **Status: SUPERSEDED** — This initiative was replaced by the `statusline-compact` plugin (a separate, independent plugin with single-line layout). Both phases remain pending and are no longer planned. Kept for historical context.
+
 **Project:** statusline-customizable
 **Created:** 2026-02-16
 **Branch:** feature/statusline-customizable

--- a/plugins/statusline-compact/.claude-plugin/plugin.json
+++ b/plugins/statusline-compact/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
   "name": "statusline-compact",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Compact single-line Claude Code statusline with brightness-coded API usage values. Shows 5h/7d rate limits, extra usage, context window, git branch, and model - all on one line.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",
-  "commands": ["./commands/"]
+  "commands": ["./commands/"],
+  "skills": []
 }

--- a/plugins/statusline/.claude-plugin/plugin.json
+++ b/plugins/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Three-line Claude Code statusline with enhanced resolution: 5h (30 blocks/10m), 7d (28 blocks/6h), extra usage (N blocks/1d). Features improved alignment, dimmed separators, and wide character support.",
   "author": {
     "name": "Tribe Coding"
@@ -8,5 +8,6 @@
   "license": "MIT",
   "commands": [
     "./commands/"
-  ]
+  ],
+  "skills": []
 }


### PR DESCRIPTION
## Description

Fixes documentation inconsistencies and gaps identified during a full documentation audit. Closes #148.

## Changes

- **PR template**: add all 8 plugins as checkboxes (was: only plantuml, statusline)
- **CLAUDE.md**: fix statusline description — Two-line → Three-line with correct layout (30/28 blocks) matching `statusline.sh` source
- **CLAUDE.md**: add plugin descriptions for 6 previously undocumented plugins: statusline-compact, git-branch-naming, playbook, semver, retroscope, context
- **CLAUDE.md**: update `Co-Authored-By` example — Sonnet 4.5 → Sonnet 4.6
- **docs/AUTHORING.md**: fix pattern numbering (was: 1,2,3,5,4 → now: 1,2,3,4,5)
- **statusline, statusline-compact `plugin.json`**: add explicit `"skills": []` field per plugin convention
- **docs/ideation/statusline-customizable/tasks-manifest.md**: add superseded note (replaced by `statusline-compact` plugin)

## Plugin(s) Affected

- [x] statusline
- [x] statusline-compact
- [ ] plantuml
- [ ] git-branch-naming
- [ ] playbook
- [ ] semver
- [ ] retroscope
- [ ] context
- [ ] None (only root-level files changed)

## Version Bump Required

- [x] ✅ Version bumped in `plugins/<name>/.claude-plugin/plugin.json`

**Version change:**
- `statusline`: `1.3.6` → `1.3.7`
- `statusline-compact`: `0.2.1` → `0.2.2`

**Type of version bump:**
- [x] PATCH (bug fixes, documentation)

**Reasoning:** Added explicit `"skills": []` field — documentation/metadata fix, no behavior change.

## Testing

- [x] Verified `statusline.sh` header confirms THREE-LINE layout (lines 2-8)
- [x] Verified pattern numbering in AUTHORING.md now sequential (1→2→3→4→5)
- [x] All 8 plugins listed in PR template checkboxes
- [x] All plugin.json files have explicit skills field

## Checklist

- [x] All SKILL.md files have valid YAML frontmatter
- [x] Hooks use `${CLAUDE_PLUGIN_ROOT}` (not `$(dirname "$0")`)
- [x] Cross-platform compatibility (macOS + Linux)
- [x] Updated ACCEPTANCE_TESTS.md (if behavior changed) — N/A, no behavior change
- [x] **Version bumped before merge** (REQUIRED)
- [x] Ready to merge

## Related Issues

Closes #148
Related to #149 (CLAUDE.md extraction — blocked by this PR)