### PR TITLE
docs: add navigation bars and fix anchor links across all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/
 | [**statusline**](plugins/statusline/README.md) | Two-line statusline showing API rate limits, context window usage, git branch, and model |
 | [**statusline-compact**](plugins/statusline-compact/README.md) | Single-line statusline with brightness-coded values — the minimal-footprint option |
 
-## 📦 Installation
+## 📦 Installation <a name="installation"></a>
 
 ### 1. Add the marketplace
 
@@ -39,6 +39,6 @@ Repeat for each plugin you want.
 
 Open `/plugin`, select each installed plugin, and enable **auto-update**.
 
-## 🤝 Contributing
+## 🤝 Contributing <a name="contributing"></a>
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow, plugin structure, and code standards.

--- a/plugins/git-branch-naming/README.md
+++ b/plugins/git-branch-naming/README.md
@@ -1,6 +1,10 @@
 # git-branch-naming
 
+> Clean branch names, enforced automatically — before the mess even starts.
+
 A Claude Code plugin that enforces git branch naming conventions. Validates branch names before creation, warns when staged/pushed files don't match the branch type, and protects against direct pushes to main branches.
+
+> **Scroll to: [🎬 Usage Examples](#usage-examples) · [📦 Installation](#installation) · [⚙️ Configuration](#configuration)**
 
 ## What It Does
 
@@ -35,7 +39,7 @@ Nobody knows what's in these branches, `git branch -a` is unreadable, and automa
 
 This plugin catches the problem at the source — before the branch is created.
 
-## Usage Examples
+## 🎬 Usage Examples <a name="usage-examples"></a>
 
 ### Scenario 1: Claude creates a branch with a bad name
 
@@ -132,7 +136,7 @@ Examples:
 - ❌ `Feature/UserAuth` — wrong case
 - ❌ `feature/user_auth` — underscore not allowed
 
-## Installation
+## 📦 Installation <a name="installation"></a>
 
 ### 1. Add to `enabledPlugins`
 
@@ -154,7 +158,7 @@ In a Claude Code session:
 
 This creates `.claude-plugin/git-branch-naming.json` with your project's conventions. Commit it to git to share with your team.
 
-## Configuration
+## ⚙️ Configuration <a name="configuration"></a>
 
 Configuration lives in `.claude-plugin/git-branch-naming.json` (committed to git, team-wide).
 

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -4,7 +4,7 @@
 
 With this plugin, Claude proactively illustrates architecture, flows, and data structures using [PlantUML](https://plantuml.com): in markdown documentation and directly in the terminal during conversations.
 
-> **Scroll to: [⚙️ How it works](#%EF%B8%8F-how-it-works) · [📦 Installation](#-installation)**
+> **Scroll to: [⚙️ How it works](#how-it-works) · [📦 Installation](#installation)**
 
 ## 🎬 Demo
 
@@ -91,7 +91,7 @@ Here's the full flow:
 ![Login Request Flow (PNG image)](https://www.plantuml.com/...)
 ```
 
-## ⚙️ How it works
+## ⚙️ How it works <a name="how-it-works"></a>
 
 Every diagram has two parts: a `plantuml` source block and an image URL below it. Claude writes both — you only edit the source. When you save, the URL updates automatically.
 
@@ -102,7 +102,7 @@ Every diagram has two parts: a `plantuml` source block and an image URL below it
 | PreToolUse | Auto-allows all PlantUML operations — no permission prompts |
 | Before creating any diagram | `plantuml-diagram-guide` skill invoked automatically — picks the right type from 17 options |
 
-## 📦 Installation
+## 📦 Installation <a name="installation"></a>
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins

--- a/plugins/playbook/README.md
+++ b/plugins/playbook/README.md
@@ -4,7 +4,9 @@
 
 Playbook lets you define **presets** — sets of coding rules, workflow conventions, and best practices — that Claude follows automatically. No more repeating "always use squash merge" or "update docs after every change" in every conversation.
 
-## How it works
+> **Scroll to: [How it works](#how-it-works) · [Available Presets](#available-presets) · [Installation](#installation) · [Configuration](#configuration)**
+
+## How it works <a name="how-it-works"></a>
 
 Each preset is a markdown file with two zones:
 
@@ -13,7 +15,7 @@ Each preset is a markdown file with two zones:
 
 Claude sees the active rules in every session and follows them without being asked.
 
-## Installation
+## Installation <a name="installation"></a>
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins
@@ -27,7 +29,7 @@ Then in the next session, run `/playbook-setup` to choose which presets to enabl
 
 > **Auto-update** keeps presets in sync with the latest fixes automatically on each Claude Code restart.
 
-## Available Presets
+## Available Presets <a name="available-presets"></a>
 
 | Preset | What it enforces |
 |--------|-----------------|
@@ -50,7 +52,7 @@ Use `/playbook-browse` to read the full reference for any preset.
 | `/playbook-setup` | Interactive wizard — enable/disable presets, global or per-project |
 | `/playbook-browse` | Read the full REFERENCE zone of any preset |
 
-## Configuration
+## Configuration <a name="configuration"></a>
 
 **Global** (`~/.claude/playbook.json`) — applies to all projects:
 
@@ -69,7 +71,3 @@ Project config takes priority. Use `"exclude"` to suppress global presets in a s
 ## Custom Presets
 
 You can write your own presets for team-specific conventions. See [AUTHORING.md](../../docs/AUTHORING.md) for the format, rule patterns, token budget, and anti-patterns.
-
-## License
-
-MIT

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -1,6 +1,10 @@
 # Retroscope
 
+> Review what you accomplished today — structured retros from your Claude Code sessions.
+
 A Claude Code plugin that generates retrospective summary reports from your Claude Code sessions. Review what you accomplished, track open questions, and get insights into your productivity and communication patterns.
+
+> **Scroll to: [⚡ Quick Start](#quick-start) · [⚙️ How it works](#how-it-works) · [⚙️ Configuration](#configuration)**
 
 ## What it does
 
@@ -10,7 +14,7 @@ A Claude Code plugin that generates retrospective summary reports from your Clau
 
 Reports include: task outcomes, decisions made, open questions, GitHub/PR references, productivity metrics, and suggestions for improving your Claude Code workflow.
 
-## Quick Start
+## ⚡ Quick Start <a name="quick-start"></a>
 
 1. Install the plugin: `/plugin install retroscope@tribe-coding`
 2. Start a Claude Code session
@@ -76,7 +80,7 @@ Reports are saved as git-tracked markdown files:
                         └── summary.md
 ```
 
-## Configuration
+## ⚙️ Configuration <a name="configuration"></a>
 
 Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin/retroscope.json` (project-level overrides).
 
@@ -92,7 +96,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin
 | `suggestRetroOnExit` | `true` | Show `/retro` reminder on session exit |
 | `autoPush` | `false` | Auto-push after each report commit |
 
-## How it works
+## ⚙️ How it works <a name="how-it-works"></a>
 
 1. **Session discovery** — `find-sessions.py` locates JSONL session files in `~/.claude/projects/` for the target date
 2. **Content extraction** — Filters user prompts and assistant responses (skips tool inputs/outputs when extract mode is on)

--- a/plugins/semver/README.md
+++ b/plugins/semver/README.md
@@ -4,6 +4,8 @@
 
 Semantic versioning enforcement for Claude Code. Validates that a version bump is staged before `git commit`, `git push`, and PR creation. Injects SemVer rules into every session so Claude knows when and how to increment versions automatically.
 
+> **Scroll to: [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [⚙️ Configuration](#configuration)**
+
 ## 🎬 Demo
 
 ```
@@ -20,7 +22,7 @@ Suggested: 2.4.0
 Bump version now, or commit anyway?
 ```
 
-## ⚙️ How it works
+## ⚙️ How it works <a name="how-it-works"></a>
 
 | Trigger | What happens |
 |---------|-------------|
@@ -36,7 +38,7 @@ Bump version now, or commit anyway?
 
 **Excluded from bump checks by default:** `*.md`, `docs/**`, `LICENSE`, `.gitignore`, `.claude-plugin/**`
 
-## 📦 Installation
+## 📦 Installation <a name="installation"></a>
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins
@@ -51,7 +53,7 @@ Then run the setup wizard to configure your version files and trigger strategy:
 
 Select **semver** in `/plugin` → enable **auto-update**. Restart your session — done.
 
-## ⚙️ Configuration
+## ⚙️ Configuration <a name="configuration"></a>
 
 Config lives at `.claude-plugin/semver.json` (project, committed to git) and `~/.claude/semver.json` (global fallback). Project config takes priority.
 

--- a/plugins/statusline-compact/README.md
+++ b/plugins/statusline-compact/README.md
@@ -4,6 +4,8 @@
 
 Single-line statusline with brightness-coded API usage values.
 
+> **Scroll to: [⚙️ How it works](#how-it-works) · [📦 Installation](#installation)**
+
 ## 🎬 Demo
 
 ```
@@ -13,7 +15,7 @@ Single-line statusline with brightness-coded API usage values.
 Values dim at low usage and brighten as they climb: yellow above 90%, red at 100%.
 `!!` = warning, `XX` = exhausted.
 
-## ⚙️ How it works
+## ⚙️ How it works <a name="how-it-works"></a>
 
 | Trigger | What happens |
 |---------|-------------|
@@ -26,7 +28,7 @@ Values dim at low usage and brighten as they climb: yellow above 90%, red at 100
 
 **Tracked values:** 5h rate limit · 7d rate limit · extra usage ($ amount) · context % · directory · git branch · model name
 
-## 📦 Installation
+## 📦 Installation <a name="installation"></a>
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins

--- a/plugins/statusline/README.md
+++ b/plugins/statusline/README.md
@@ -4,6 +4,8 @@
 
 Two-line Claude Code statusline with real-time API usage, progress bars, and session info.
 
+> **Scroll to: [⚙️ How it works](#how-it-works) · [📦 Installation](#installation)**
+
 ## 🎬 Demo
 
 ```
@@ -14,7 +16,7 @@ Two-line Claude Code statusline with real-time API usage, progress bars, and ses
 **Line 1:** 5-hour limit · 7-day limit · extra usage (monthly billing with $ spent)
 **Line 2:** directory · git branch (yellow when dirty) · model · context window %
 
-## ⚙️ How it works
+## ⚙️ How it works <a name="how-it-works"></a>
 
 | Trigger | What happens |
 |---------|-------------|
@@ -35,7 +37,7 @@ Warning icons: ⚠️ above 90%, ❌ at 100%.
 
 Cache refresh: 60s (all bars).
 
-## 📦 Installation
+## 📦 Installation <a name="installation"></a>
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins


### PR DESCRIPTION
## Summary

- Add "Scroll to:" navigation bars to 6 plugin READMEs that were missing them (semver, statusline, statusline-compact, playbook, git-branch-naming, retroscope)
- Add explicit `<a name>` anchors to all emoji headings — GitHub's auto-generated anchors for emoji headings are unreliable and break silently
- Fix broken nav links in root README (`#installation`, `#contributing`) and plantuml README (`#how-it-works`)
- Add taglines to git-branch-naming and retroscope READMEs
- Add emoji to key headings in git-branch-naming and retroscope for consistency
- Remove anti-pattern `## License` section from playbook README (per `readme` preset guidelines)

## Test plan

- [ ] Verify all "Scroll to:" nav links work on GitHub for each README
- [ ] Confirm `<a name>` anchors match the `#fragment` in each nav bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)