### PR TITLE
docs: bold+italic ✨ motto bar in all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tribe Coding — Claude Code Plugins
 
-> Good habits, better output.
+> ✨ ***Good habits, better output.***
 
 A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that automate the routines good developers follow anyway — consistent diagrams, clean branches, version discipline, session awareness.
 

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -1,6 +1,6 @@
 # Context
 
-> See exactly what's loaded into your Claude Code session — and how much context budget each source consumes.
+> ✨ ***See exactly what's loaded into your Claude Code session — and how much context budget each source consumes.***
 
 `/ctx-show` collects everything Claude Code loads at session start — CLAUDE.md files, auto-memory, and SessionStart hook output — and writes it to a single `.md` snapshot file. A summary table breaks down token usage per source so you know exactly what's filling your context window.
 

--- a/plugins/git-branch-naming/README.md
+++ b/plugins/git-branch-naming/README.md
@@ -1,6 +1,6 @@
 # git-branch-naming
 
-> Clean branch names, enforced automatically — before the mess even starts.
+> ✨ ***Clean branch names, enforced automatically — before the mess even starts.***
 
 A Claude Code plugin that enforces git branch naming conventions. Validates branch names before creation, warns when staged/pushed files don't match the branch type, and protects against direct pushes to main branches.
 

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -1,6 +1,6 @@
 # PlantUML
 
-> Add diagrams to your docs and conversations — Claude picks the type, draws, and keeps them in sync.
+> ✨ ***Add diagrams to your docs and conversations — Claude picks the type, draws, and keeps them in sync.***
 
 With this plugin, Claude proactively illustrates architecture, flows, and data structures using [PlantUML](https://plantuml.com): in markdown documentation and directly in the terminal during conversations.
 

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/README.md
+++ b/plugins/playbook/README.md
@@ -1,6 +1,6 @@
 # Playbook
 
-> Inject curated coding guidelines into every Claude Code session — per project, per team.
+> ✨ ***Inject curated coding guidelines into every Claude Code session — per project, per team.***
 
 Playbook lets you define **presets** — sets of coding rules, workflow conventions, and best practices — that Claude follows automatically. No more repeating "always use squash merge" or "update docs after every change" in every conversation.
 

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -158,12 +158,12 @@ README renders on a specific platform — design for where it will actually be r
 
 ## Motto / Tagline
 
-A memorable one-liner under the H1 (as a blockquote) helps readers instantly grasp the project's identity:
+A memorable one-liner under the H1 (as a blockquote) helps readers instantly grasp the project's identity. Format with ✨ emoji prefix and bold+italic (`***...***`) for visual emphasis:
 
 ```markdown
 # my-tool
 
-> Turn raw data into live dashboards in one command.
+> ✨ ***Turn raw data into live dashboards in one command.***
 ```
 
 When creating a README from scratch, propose a tagline to the user and let them decide. Keep it: short (≤10 words), concrete (not generic "powerful/flexible"), action-oriented.

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -1,6 +1,6 @@
 # Retroscope
 
-> Review what you accomplished today — structured retros from your Claude Code sessions.
+> ✨ ***Review what you accomplished today — structured retros from your Claude Code sessions.***
 
 A Claude Code plugin that generates retrospective summary reports from your Claude Code sessions. Review what you accomplished, track open questions, and get insights into your productivity and communication patterns.
 

--- a/plugins/semver/README.md
+++ b/plugins/semver/README.md
@@ -1,6 +1,6 @@
 # semver
 
-> Never ship without a version bump — Claude enforces SemVer before every commit, push, and PR.
+> ✨ ***Never ship without a version bump — Claude enforces SemVer before every commit, push, and PR.***
 
 Semantic versioning enforcement for Claude Code. Validates that a version bump is staged before `git commit`, `git push`, and PR creation. Injects SemVer rules into every session so Claude knows when and how to increment versions automatically.
 

--- a/plugins/statusline-compact/README.md
+++ b/plugins/statusline-compact/README.md
@@ -1,6 +1,6 @@
 # statusline-compact
 
-> All the essentials in one line — the most space-efficient Claude Code statusline.
+> ✨ ***All the essentials in one line — the most space-efficient Claude Code statusline.***
 
 Single-line statusline with brightness-coded API usage values.
 

--- a/plugins/statusline/README.md
+++ b/plugins/statusline/README.md
@@ -1,6 +1,6 @@
 # statusline
 
-> Know your API limits, context, and git state at a glance — without leaving Claude Code.
+> ✨ ***Know your API limits, context, and git state at a glance — without leaving Claude Code.***
 
 Two-line Claude Code statusline with real-time API usage, progress bars, and session info.
 


### PR DESCRIPTION
## Summary

- Apply `> ✨ ***...***` format to motto taglines in all 9 READMEs
- Update `readme` preset: add formatting rule + update example
- Bump playbook `0.6.0` → `0.6.1` (PATCH)

## Test plan

- [ ] Verify motto lines render as bold+italic on GitHub
- [ ] `grep -r '> ✨ \*\*\*' **/README.md` returns 9 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)