### PR TITLE
docs: fix missing [!TIP] wrapper in plugin README motto bars

### DIFF
--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -1,5 +1,6 @@
 # Context
 
+> [!TIP]
 > ✨ ***See exactly what's loaded into your Claude Code session — and how much context budget each source consumes.***
 
 `/ctx-show` collects everything Claude Code loads at session start — CLAUDE.md files, auto-memory, and SessionStart hook output — and writes it to a single `.md` snapshot file. A summary table breaks down token usage per source so you know exactly what's filling your context window.

--- a/plugins/git-branch-naming/README.md
+++ b/plugins/git-branch-naming/README.md
@@ -1,5 +1,6 @@
 # git-branch-naming
 
+> [!TIP]
 > ✨ ***Clean branch names, enforced automatically — before the mess even starts.***
 
 A Claude Code plugin that enforces git branch naming conventions. Validates branch names before creation, warns when staged/pushed files don't match the branch type, and protects against direct pushes to main branches.

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -1,5 +1,6 @@
 # PlantUML
 
+> [!TIP]
 > ✨ ***Add diagrams to your docs and conversations — Claude picks the type, draws, and keeps them in sync.***
 
 With this plugin, Claude proactively illustrates architecture, flows, and data structures using [PlantUML](https://plantuml.com): in markdown documentation and directly in the terminal during conversations.

--- a/plugins/playbook/README.md
+++ b/plugins/playbook/README.md
@@ -1,5 +1,6 @@
 # Playbook
 
+> [!TIP]
 > ✨ ***Inject curated coding guidelines into every Claude Code session — per project, per team.***
 
 Playbook lets you define **presets** — sets of coding rules, workflow conventions, and best practices — that Claude follows automatically. No more repeating "always use squash merge" or "update docs after every change" in every conversation.

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -1,5 +1,6 @@
 # Retroscope
 
+> [!TIP]
 > ✨ ***Review what you accomplished today — structured retros from your Claude Code sessions.***
 
 A Claude Code plugin that generates retrospective summary reports from your Claude Code sessions. Review what you accomplished, track open questions, and get insights into your productivity and communication patterns.

--- a/plugins/semver/README.md
+++ b/plugins/semver/README.md
@@ -1,5 +1,6 @@
 # semver
 
+> [!TIP]
 > ✨ ***Never ship without a version bump — Claude enforces SemVer before every commit, push, and PR.***
 
 Semantic versioning enforcement for Claude Code. Validates that a version bump is staged before `git commit`, `git push`, and PR creation. Injects SemVer rules into every session so Claude knows when and how to increment versions automatically.

--- a/plugins/statusline-compact/README.md
+++ b/plugins/statusline-compact/README.md
@@ -1,5 +1,6 @@
 # statusline-compact
 
+> [!TIP]
 > ✨ ***All the essentials in one line — the most space-efficient Claude Code statusline.***
 
 Single-line statusline with brightness-coded API usage values.

--- a/plugins/statusline/README.md
+++ b/plugins/statusline/README.md
@@ -1,5 +1,6 @@
 # statusline
 
+> [!TIP]
 > ✨ ***Know your API limits, context, and git state at a glance — without leaving Claude Code.***
 
 Two-line Claude Code statusline with real-time API usage, progress bars, and session info.


### PR DESCRIPTION
## Summary

- Previous PR only updated the root README with `[!TIP]` callout
- Apply the same `> [!TIP]` wrapper to all 8 plugin READMEs

## Test plan

- [ ] All 9 READMEs render motto as styled TIP callout on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)