### PR TITLE
docs: add clickable skill links in technology-explainer README

### DIFF
--- a/plugins/technology-explainer/.claude-plugin/plugin.json
+++ b/plugins/technology-explainer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "technology-explainer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Adapts explanation depth based on user proficiency per technology: expert, intermediate, or learning",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/technology-explainer/README.md
+++ b/plugins/technology-explainer/README.md
@@ -59,9 +59,9 @@ Three proficiency levels control Claude's explanation depth:
 
 | Level | Behavior | Example |
 |-------|----------|---------|
-| **Expert** | Brief, no-theory answers | Just the command or fact |
-| **Intermediate** | Nuances and gotchas, skip basics | Why this approach, common pitfalls |
-| **Learning** | Detailed theory, examples, step-by-step | Full explanations with context |
+| [**Expert**](skills/proficiency-guide-expert/SKILL.md) | Brief, no-theory answers | Just the command or fact |
+| [**Intermediate**](skills/proficiency-guide-intermediate/SKILL.md) | Nuances and gotchas, skip basics | Why this approach, common pitfalls |
+| [**Learning**](skills/proficiency-guide-learning/SKILL.md) | Detailed theory, examples, step-by-step | Full explanations with context |
 
 | Trigger | What happens |
 |---------|-------------|


### PR DESCRIPTION
## Summary

- Make Expert/Intermediate/Learning level names in the "How it works" table link to their respective SKILL.md files on GitHub

## Test plan

- [x] Links point to correct relative paths (`skills/proficiency-guide-{expert,intermediate,learning}/SKILL.md`)
- [ ] Verify links render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)