### PR TITLE
docs: add root docs update steps to new-plugin checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ A marketplace of reusable Claude Code plugins (`Tribe Coding`). Each plugin live
 - **playbook** — Injects curated coding guideline presets into sessions
 - **semver** — Enforces semantic versioning on commit/push/PR
 - **retroscope** — Generates retrospective reports summarizing sessions
+- **technology-explainer** — Adapts explanation depth based on user proficiency per technology
 - **context** — Inspects full session context in load order
 
 See [`docs/plugin-behavior.md`](docs/plugin-behavior.md) for how plugins use hooks, skills, and PostToolUse to work proactively.
@@ -84,6 +85,8 @@ For full authoring guidelines — SKILL.md hybrid design, preset RULES/REFERENCE
    - Store default config template in `templates/<name>.json`
    - Setup wizard writes to `{project}/.claude-plugin/<name>.json`
    - Scripts read from `.claude-plugin/<name>.json` first, fall back to `.claude/<name>.json`
+8. **Update root `README.md`** — add row to the Plugins table (alphabetical order)
+9. **Update the Plugins list above** — add bullet to the Plugins section in this file (alphabetical order)
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/
 | [**semver**](plugins/semver/README.md) | Validate that a version bump is staged before every commit, push, and PR — with configurable enforcement |
 | [**statusline**](plugins/statusline/README.md) | Two-line statusline showing API rate limits, context window usage, git branch, and model |
 | [**statusline-compact**](plugins/statusline-compact/README.md) | Single-line statusline with brightness-coded values — the minimal-footprint option |
+| [**technology-explainer**](plugins/technology-explainer/README.md) | Adapt explanation depth per technology — brief for experts, detailed for learners |
 
 ## 📦 Installation <a name="installation"></a>
 


### PR DESCRIPTION
## Summary

- Add steps 8-9 to "Adding a New Plugin" checklist in CLAUDE.md: update root `README.md` plugin table and `CLAUDE.md` plugin list
- Backfill missing `technology-explainer` entries in both root files

**Root cause:** the checklist ended at marketplace.json registration + acceptance tests, so when technology-explainer was added in #160 the root docs were skipped.

## Test plan

- [x] `CLAUDE.md` Plugins list: 9 entries
- [x] `README.md` Plugins table: 9 rows
- [x] Checklist now has 9 steps (was 7)
- [x] `marketplace.json` already has 9 entries (updated in #160)

🤖 Generated with [Claude Code](https://claude.ai/code)