### PR TITLE
docs: use placeholder for model name in Co-Authored-By example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Version bump for PR #XX: <description>
 Changes in 1.3.0:
 - <list changes>
 
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+Co-Authored-By: Claude <model> <noreply@anthropic.com>"
 ```
 
 **Version bump rules:**


### PR DESCRIPTION
## Summary

- Replace hardcoded "Claude Sonnet 4.5" with `Claude <model>` placeholder in CONTRIBUTING.md commit example, so it doesn't go stale with every model release

Fixes #166

## Test plan

- [ ] Verify CONTRIBUTING.md shows `Claude <model>` in the example

🤖 Generated with [Claude Code](https://claude.com/claude-code)