### PR TITLE
chore: add kb-grooming project config

### DIFF
--- a/.claude-plugin/kb-grooming.json
+++ b/.claude-plugin/kb-grooming.json
@@ -1,0 +1,26 @@
+{
+  "model": "inherit",
+  "scope": {
+    "include": ["*.md"],
+    "exclude": []
+  },
+  "checks": {
+    "brokenLinks": true,
+    "orphanDocs": true,
+    "duplicateContent": true,
+    "claudemdOverflow": true,
+    "mandatoryDocs": true,
+    "readmeCompliance": true,
+    "terminologyConsistency": true,
+    "adrCompleteness": true,
+    "contentActuality": true
+  },
+  "output": {
+    "githubIssues": true,
+    "reportFile": false
+  },
+  "github": {
+    "labels": "auto",
+    "assignee": "artem-from-ua"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/kb-grooming.json` project configuration
- Was untracked, causing git dirty indicator (⚠️) in statusline

🤖 Generated with [Claude Code](https://claude.com/claude-code)