### PR TITLE
docs: README compliance audit — fences, navbars, anchors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,10 @@ For full authoring guidelines — SKILL.md hybrid design, preset RULES/REFERENCE
 9. **Update the Plugins list above** — add bullet to the Plugins section in this file (alphabetical order)
 10. **README navbar** — nav line goes after the header block (motto + intro paragraph), lists ALL sections except the first one (usually Demo); see `readme` playbook preset for full rules
 
+## README Demo Sections
+
+Claude Code console interaction examples (blocks showing `You: … Claude: …` dialogues, tool call output, or slash command output) in plugin README files MUST use `` ```markdown `` fenced code blocks — not bare `` ``` ``. This enables syntax highlighting on GitHub (tables, emoji, bold) and ensures consistent appearance across all plugins. Do NOT apply `` ```markdown `` to non-interaction blocks (plain text lists, file trees, format templates) — those stay as bare `` ``` ``.
+
 ## Dependencies
 
 - plantuml: Python 3.x, git

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/
 > [!NOTE]
 > [📦 Installation](#installation)
 
-## 🧩 Plugins
+## 🧩 Plugins <a name="plugins"></a>
 
 | Plugin | What it does |
 |--------|-------------|

--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Inspect full Claude Code session context: CLAUDE.md files, auto-memory, and SessionStart hook output",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -8,9 +8,9 @@
 > [!NOTE]
 > [⚙️ How it works](#how-it-works) · [📋 Sources](#sources) · [📊 Summary Table Columns](#summary-table-columns) · [⚡ Commands](#commands) · [📦 Installation](#installation)
 
-## 🎬 Demo
+## 🎬 Demo <a name="demo"></a>
 
-```
+```markdown
 > /ctx-show
 
 ● Bash(bash ".../scripts/ctx-show.sh")

--- a/plugins/git-branch-naming/.claude-plugin/plugin.json
+++ b/plugins/git-branch-naming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-branch-naming",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Git branch naming convention enforcement: validates names, warns on content mismatch before push",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/git-branch-naming/README.md
+++ b/plugins/git-branch-naming/README.md
@@ -6,9 +6,9 @@
 A Claude Code plugin that enforces git branch naming conventions. Validates branch names before creation, warns when staged/pushed files don't match the branch type, and protects against direct pushes to main branches.
 
 > [!NOTE]
-> [🎬 Usage Examples](#usage-examples) · [📦 Installation](#installation) · [⚙️ Configuration](#configuration)
+> [💡 Why](#why-this-plugin-exists) · [🎬 Usage Examples](#usage-examples) · [📐 Format](#branch-name-format) · [📦 Installation](#installation) · [⚙️ Configuration](#configuration) · [👥 Team Setup](#team-setup-workflow) · [🔍 Mismatch](#content-mismatch) · [🪝 Pre-push](#pre-push-hook) · [🏗️ Architecture](#architecture) · [💰 Token Cost](#token-cost) · [🧪 Testing](#testing) · [📚 References](#references)
 
-## What It Does
+## ✅ What It Does <a name="what-it-does"></a>
 
 - **Validates branch names** at creation (`git checkout -b`, `git branch`, `git switch -c`)
 - **Warns on content mismatch** before `git commit` (staged files) and `git push` (full branch diff)
@@ -16,11 +16,11 @@ A Claude Code plugin that enforces git branch naming conventions. Validates bran
 - **Injects naming rules** into every Claude Code session (zero extra user prompts)
 - **Configurable per project** via `.claude-plugin/git-branch-naming.json` — committed to git and shared team-wide
 
-## Why This Plugin Exists
+## 💡 Why This Plugin Exists <a name="why-this-plugin-exists"></a>
 
 Without this plugin, Claude happily runs whatever git command you ask — including problematic ones:
 
-```
+```markdown
 You: create a branch for the login feature
 Claude: git checkout -b LoginFeature   ✅ done
 ```
@@ -45,7 +45,7 @@ This plugin catches the problem at the source — before the branch is created.
 
 ### Scenario 1: Claude creates a branch with a bad name
 
-```
+```markdown
 You: create a branch for the new payment feature
 
 Claude: ⚠️  Branch name 'payment-feature' is missing a valid prefix.
@@ -63,19 +63,19 @@ Proceed anyway, or rename to 'feature/payment-feature'?
 
 The plugin teaches Claude *how* naming works, so it picks the right prefix based on what you're actually doing — not just what you literally say:
 
-```
+```markdown
 You: we need to fix the null pointer crash in the cart service, it's urgent
 
 Claude: git checkout -b hotfix/fix-null-pointer-cart-service   ✅
 ```
 
-```
+```markdown
 You: I want to reorganize the auth module, no behavior changes
 
 Claude: git checkout -b refactor/reorganize-auth-module   ✅
 ```
 
-```
+```markdown
 You: add unit tests for the payment processor
 
 Claude: git checkout -b test/add-payment-processor-unit-tests   ✅
@@ -85,7 +85,7 @@ Without this plugin, Claude would likely create `fix-crash`, `refactor` or `new-
 
 ### Scenario 3: Ticket number required by team config
 
-```
+```markdown
 You: start working on PROJ-789, the cart checkout bug
 
 Claude: git checkout -b bugfix/PROJ-789-fix-cart-checkout   ✅
@@ -95,7 +95,7 @@ Without the plugin, Claude might have created `bugfix/fix-cart-checkout` — val
 
 ### Scenario 4: Content mismatch before commit
 
-```
+```markdown
 You: git commit -m "docs: update API reference"
 
 Claude: ⚠️  Branch 'feature/add-payment' usually contains code changes, but 90%
@@ -110,7 +110,7 @@ Catches the common mistake of committing to the wrong branch.
 
 ### Scenario 5: Direct push to main blocked
 
-```
+```markdown
 You: git push origin main
 
 Claude: ⚠️  You are about to push directly to protected branch 'main'.
@@ -122,7 +122,7 @@ This is usually done via a pull request instead of a direct push. Are you sure?
 
 Your team uses JIRA and wants strict enforcement. One dev runs `/git-branch-naming:setup`, commits `.claude-plugin/git-branch-naming.json`, and from that point every teammate's Claude Code session enforces the same rules — no onboarding docs required.
 
-## Branch Name Format
+## 📐 Branch Name Format <a name="branch-name-format"></a>
 
 ```
 <prefix>/<kebab-case-description>
@@ -159,6 +159,8 @@ In a Claude Code session:
 ```
 
 This creates `.claude-plugin/git-branch-naming.json` with your project's conventions. Commit it to git to share with your team.
+
+**Requirements:** bash 3.2+, git, jq (scripts fall back to defaults if jq is unavailable)
 
 ## ⚙️ Configuration <a name="configuration"></a>
 
@@ -221,7 +223,7 @@ Configuration lives in `.claude-plugin/git-branch-naming.json` (committed to git
 
 This requires ticket numbers: `feature/PROJ-123-add-login`
 
-## Team Setup Workflow
+## 👥 Team Setup Workflow <a name="team-setup-workflow"></a>
 
 1. **One developer** runs the setup wizard:
    ```
@@ -237,111 +239,23 @@ This requires ticket numbers: `feature/PROJ-123-add-login`
 
 3. **All team members** clone the repo — conventions are automatically enforced in their Claude Code sessions.
 
-## Content Mismatch Detection
+## 🔍 Content Mismatch Detection <a name="content-mismatch"></a>
 
-The plugin checks that files you're committing/pushing match what the branch name implies.
+Warns when staged/pushed files don't match the branch prefix (e.g., only docs on a `feature/` branch). See [`docs/content-mismatch.md`](docs/content-mismatch.md) for thresholds, prefix-to-content mapping, and example warnings.
 
-### Two checkpoints
+## 🪝 Pre-push Git Hook <a name="pre-push-hook"></a>
 
-| Checkpoint | What's checked | Threshold | Default |
-|------------|---------------|-----------|---------|
-| `git commit` | Staged files vs branch prefix | >80% type mismatch | `ask` |
-| `git push` | Full branch diff + commit messages | >50% mismatch | `ask` |
+For enforcement outside Claude Code (CI, terminal git). See [`docs/pre-push-hook.md`](docs/pre-push-hook.md) for installation instructions.
 
-### Example warnings
+## 🏗️ Architecture <a name="architecture"></a>
 
-> **`docs/` branch with code files:**
-> "Branch 'docs/update-api' is a docs branch, but 90% of files are code files (9/10 files). Consider using a 'feature/' or 'refactor/' prefix instead."
+Hook scripts run as external processes — zero context cost. See [`docs/architecture.md`](docs/architecture.md) for the full file tree.
 
-> **`feature/` branch with only docs:**
-> "Branch 'feature/add-login' usually contains code changes, but 85% of files are documentation. Is this intentional?"
+## 💰 Token Cost Analysis <a name="token-cost"></a>
 
-### Prefix-to-content mapping
+~220 tokens fixed per session; all validation runs externally at zero context cost. See [`docs/token-cost.md`](docs/token-cost.md) for the full breakdown.
 
-| Prefix | Expected | Warning condition |
-|--------|----------|-------------------|
-| `feature/`, `bugfix/`, `hotfix/` | Code + tests | Only docs, no code (>80%) |
-| `docs/` | Markdown, rst, txt | Code files (>80%) |
-| `test/` | Test files | No test files at all |
-| `chore/` | Config, CI, deps | Application source code (>80%) |
-| `refactor/` | Code | (checks only for `--branch` mode) |
-| `release/` | Any | No check |
-
-## Pre-push Git Hook
-
-For enforcement outside of Claude Code (CI, terminal git), install the pre-push hook:
-
-```bash
-mkdir -p .githooks
-cp /path/to/plugin/templates/pre-push .githooks/pre-push
-chmod +x .githooks/pre-push
-git config core.hooksPath .githooks
-```
-
-Or let the setup wizard install it: `/git-branch-naming:setup` → answer "Yes" to hook installation.
-
-The hook reads `.claude-plugin/git-branch-naming.json` (falls back to `.claude/git-branch-naming.json` for backwards compatibility).
-
-## Architecture
-
-```
-scripts/
-├── inject-rules.sh           # SessionStart: outputs ~130 tokens of rules
-├── validate-branch.sh        # PreToolUse: intercepts git commands, validates names
-└── check-content-mismatch.sh # Helper: staged/branch file analysis
-
-hooks/hooks.json              # PreToolUse(Bash) + SessionStart wiring
-commands/git-branch-naming-setup/SKILL.md  # /git-branch-naming:setup wizard
-skills/branch-naming-guide/SKILL.md        # On-demand naming reference
-templates/
-├── git-branch-naming.json    # Default config template
-└── pre-push                  # Standalone git pre-push hook
-```
-
-## Token Cost Analysis
-
-### Fixed cost per session (~220 tokens)
-
-Every Claude Code session pays this cost regardless of whether you use git at all:
-
-| Component | Tokens | Source |
-|-----------|--------|--------|
-| SessionStart rules (`inject-rules.sh`) | ~130 | Injected into system prompt |
-| Skill description (`branch-naming-guide`) | ~60 | Skill list loaded at startup |
-| Command description (`git-branch-naming-setup`) | ~30 | Command list loaded at startup |
-| **Total fixed** | **~220** | — |
-
-At Sonnet 4.6 pricing ($3.00 / 1M input tokens), 220 tokens cost **$0.00066 per session** — less than a tenth of a cent.
-
-### Variable cost (only when triggered)
-
-| Event | Tokens | Frequency |
-|-------|--------|-----------|
-| `branch-naming-guide` skill body | ~400 | When Claude consults naming guide |
-| `git-branch-naming-setup` command body | ~500 | When `/git-branch-naming:setup` is run |
-| Warning message in conversation | ~50–100 | When validation fires |
-
-### Zero-cost operations
-
-The PreToolUse hook (`validate-branch.sh`, `check-content-mismatch.sh`) runs as an **external process** — it never adds tokens to the context window. This means:
-- Every `git checkout`, `git commit`, `git push` validation costs **0 tokens**
-- Validation runs even on the largest codebase with no context overhead
-- Mismatch analysis (file classification, diff inspection) is entirely outside Claude
-
-### Comparison with naive approaches
-
-| Approach | Cost per session | Notes |
-|----------|-----------------|-------|
-| This plugin | ~220 tokens | Fixed; validation is external |
-| Inline rules in CLAUDE.md | ~220 tokens | Same, but no enforcement mechanism |
-| Asking Claude to validate each time | ~300–500 tokens | Per-validation cost, no automation |
-| No plugin (ad-hoc reminders) | 0 tokens | But conventions drift and Claude forgets |
-
-### Design principle
-
-The plugin is designed so that **enforcement has zero context cost**. All three validation scripts (`validate-branch.sh`, `check-content-mismatch.sh`, `inject-rules.sh`) run outside the LLM — they read stdin JSON and write `permissionDecision` JSON without consuming any context window tokens. The ~220 token fixed cost covers only the rules Claude needs to *understand* conventions, not to *enforce* them.
-
-## Testing
+## 🧪 Testing <a name="testing"></a>
 
 See [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) for comprehensive test documentation including:
 - Automated unit tests for all scripts
@@ -350,13 +264,7 @@ See [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) for comprehensive tes
 - Cross-platform compatibility tests
 - Team config sharing workflow
 
-## Requirements
-
-- **bash** 3.2+ (macOS compatible)
-- **git** (any modern version)
-- **jq** (for config loading — scripts fall back to defaults if jq is unavailable)
-
-## References
+## 📚 References <a name="references"></a>
 
 Standards and best practices this plugin is based on:
 

--- a/plugins/git-branch-naming/docs/architecture.md
+++ b/plugins/git-branch-naming/docs/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+```
+scripts/
+├── inject-rules.sh           # SessionStart: outputs ~130 tokens of rules
+├── validate-branch.sh        # PreToolUse: intercepts git commands, validates names
+└── check-content-mismatch.sh # Helper: staged/branch file analysis
+
+hooks/hooks.json              # PreToolUse(Bash) + SessionStart wiring
+commands/git-branch-naming-setup/SKILL.md  # /git-branch-naming:setup wizard
+skills/branch-naming-guide/SKILL.md        # On-demand naming reference
+templates/
+├── git-branch-naming.json    # Default config template
+└── pre-push                  # Standalone git pre-push hook
+```

--- a/plugins/git-branch-naming/docs/content-mismatch.md
+++ b/plugins/git-branch-naming/docs/content-mismatch.md
@@ -1,0 +1,29 @@
+# Content Mismatch Detection
+
+The plugin checks that files you're committing/pushing match what the branch name implies.
+
+## Two checkpoints
+
+| Checkpoint | What's checked | Threshold | Default |
+|------------|---------------|-----------|---------|
+| `git commit` | Staged files vs branch prefix | >80% type mismatch | `ask` |
+| `git push` | Full branch diff + commit messages | >50% mismatch | `ask` |
+
+## Example warnings
+
+> **`docs/` branch with code files:**
+> "Branch 'docs/update-api' is a docs branch, but 90% of files are code files (9/10 files). Consider using a 'feature/' or 'refactor/' prefix instead."
+
+> **`feature/` branch with only docs:**
+> "Branch 'feature/add-login' usually contains code changes, but 85% of files are documentation. Is this intentional?"
+
+## Prefix-to-content mapping
+
+| Prefix | Expected | Warning condition |
+|--------|----------|-------------------|
+| `feature/`, `bugfix/`, `hotfix/` | Code + tests | Only docs, no code (>80%) |
+| `docs/` | Markdown, rst, txt | Code files (>80%) |
+| `test/` | Test files | No test files at all |
+| `chore/` | Config, CI, deps | Application source code (>80%) |
+| `refactor/` | Code | (checks only for `--branch` mode) |
+| `release/` | Any | No check |

--- a/plugins/git-branch-naming/docs/pre-push-hook.md
+++ b/plugins/git-branch-naming/docs/pre-push-hook.md
@@ -1,0 +1,14 @@
+# Pre-push Git Hook
+
+For enforcement outside of Claude Code (CI, terminal git), install the pre-push hook:
+
+```bash
+mkdir -p .githooks
+cp /path/to/plugin/templates/pre-push .githooks/pre-push
+chmod +x .githooks/pre-push
+git config core.hooksPath .githooks
+```
+
+Or let the setup wizard install it: `/git-branch-naming:setup` → answer "Yes" to hook installation.
+
+The hook reads `.claude-plugin/git-branch-naming.json` (falls back to `.claude/git-branch-naming.json` for backwards compatibility).

--- a/plugins/git-branch-naming/docs/token-cost.md
+++ b/plugins/git-branch-naming/docs/token-cost.md
@@ -1,0 +1,42 @@
+# Token Cost Analysis
+
+## Fixed cost per session (~220 tokens)
+
+Every Claude Code session pays this cost regardless of whether you use git at all:
+
+| Component | Tokens | Source |
+|-----------|--------|--------|
+| SessionStart rules (`inject-rules.sh`) | ~130 | Injected into system prompt |
+| Skill description (`branch-naming-guide`) | ~60 | Skill list loaded at startup |
+| Command description (`git-branch-naming-setup`) | ~30 | Command list loaded at startup |
+| **Total fixed** | **~220** | — |
+
+At Sonnet 4.6 pricing ($3.00 / 1M input tokens), 220 tokens cost **$0.00066 per session** — less than a tenth of a cent.
+
+## Variable cost (only when triggered)
+
+| Event | Tokens | Frequency |
+|-------|--------|-----------|
+| `branch-naming-guide` skill body | ~400 | When Claude consults naming guide |
+| `git-branch-naming-setup` command body | ~500 | When `/git-branch-naming:setup` is run |
+| Warning message in conversation | ~50–100 | When validation fires |
+
+## Zero-cost operations
+
+The PreToolUse hook (`validate-branch.sh`, `check-content-mismatch.sh`) runs as an **external process** — it never adds tokens to the context window. This means:
+- Every `git checkout`, `git commit`, `git push` validation costs **0 tokens**
+- Validation runs even on the largest codebase with no context overhead
+- Mismatch analysis (file classification, diff inspection) is entirely outside Claude
+
+## Comparison with naive approaches
+
+| Approach | Cost per session | Notes |
+|----------|-----------------|-------|
+| This plugin | ~220 tokens | Fixed; validation is external |
+| Inline rules in CLAUDE.md | ~220 tokens | Same, but no enforcement mechanism |
+| Asking Claude to validate each time | ~300–500 tokens | Per-validation cost, no automation |
+| No plugin (ad-hoc reminders) | 0 tokens | But conventions drift and Claude forgets |
+
+## Design principle
+
+The plugin is designed so that **enforcement has zero context cost**. All three validation scripts (`validate-branch.sh`, `check-content-mismatch.sh`, `inject-rules.sh`) run outside the LLM — they read stdin JSON and write `permissionDecision` JSON without consuming any context window tokens. The ~220 token fixed cost covers only the rules Claude needs to *understand* conventions, not to *enforce* them.

--- a/plugins/kb-grooming/.claude-plugin/plugin.json
+++ b/plugins/kb-grooming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-grooming",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Documentation health analysis: structural checks, semantic compliance, and GitHub issue creation",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/kb-grooming/README.md
+++ b/plugins/kb-grooming/README.md
@@ -6,11 +6,11 @@
 Documentation health analysis for Claude Code projects. Scans all markdown files for structural problems and semantic compliance, then creates a GitHub epic with linked issues for each finding group.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [⚡ Commands](#commands) · [📦 Installation](#installation) · [⚙️ Setup](#setup) · [📝 Config](#config)
+> [⚙️ How it works](#how-it-works) · [⚡ Commands](#commands) · [📦 Installation](#installation) · [⚙️ Setup](#setup) · [📝 Config](#config) · [🔗 Dependencies](#dependencies)
 
 ## 🎬 Demo <a name="demo"></a>
 
-```
+```markdown
 > /kb-groom
 
 Loading config… built-in defaults.
@@ -32,12 +32,12 @@ Create GitHub issues?
 > yep
 
 Created issues:
-  * #210 — [EPIC] KB grooming report 2026-02-28
-  * #211 — Fix 5 broken documentation links
-  * #212 — Review 2 orphan documents
-  * #213 — Update stale API reference in setup.md
-  * #214 — Resolve TODO in CONTRIBUTING.md
-  * #215 — Add missing Installation section to README
+- #210 — [EPIC] KB grooming report 2026-02-28
+- #211 — Fix 5 broken documentation links
+- #212 — Review 2 orphan documents
+- #213 — Update stale API reference in setup.md
+- #214 — Resolve TODO in CONTRIBUTING.md
+- #215 — Add missing Installation section to README
 ```
 
 If you decline issue creation, the full report is saved to `docs/audit/kb-grooming-report-2026-02-28.md`.
@@ -125,7 +125,7 @@ The wizard walks through:
 }
 ```
 
-## Dependencies
+## 🔗 Dependencies <a name="dependencies"></a>
 
 - bash, python3 (structural scan)
 - `gh` CLI (optional, for GitHub issue creation)

--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -8,13 +8,13 @@ With this plugin, Claude proactively illustrates architecture, flows, and data s
 > [!NOTE]
 > [⚙️ How it works](#how-it-works) · [📦 Installation](#installation)
 
-## 🎬 Demo
+## 🎬 Demo <a name="demo"></a>
 
 A developer asks Claude to document the login flow. Claude adds a diagram to the docs — then, during the conversation, renders the same diagram as ASCII art in the terminal.
 
 ### Step 1 — Claude writes `docs/auth.md` and adds a diagram proactively
 
-```
+```markdown
 > Document the login flow for the auth service.
 
 ✦ Using skill: plantuml-diagram-guide
@@ -55,7 +55,7 @@ I'll create docs/auth.md. The flow involves four actors — I'll use a sequence 
 
 ### Step 2 — Later in the conversation, Claude renders it as ASCII in the terminal
 
-```
+```markdown
 > Walk me through the login flow step by step.
 
 ✦ Using skill: plantuml-diagram-guide

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.6.5",
+  "version": "0.6.7",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/README.md
+++ b/plugins/playbook/README.md
@@ -6,9 +6,9 @@
 Playbook lets you define **presets** — sets of coding rules, workflow conventions, and best practices — that Claude follows automatically. No more repeating "always use squash merge" or "update docs after every change" in every conversation.
 
 > [!NOTE]
-> [How it works](#how-it-works) · [Available Presets](#available-presets) · [Installation](#installation) · [Configuration](#configuration)
+> [📦 Installation](#installation) · [📋 Presets](#available-presets) · [⚡ Commands](#commands) · [🔧 Configuration](#configuration) · [✏️ Custom Presets](#custom-presets)
 
-## How it works <a name="how-it-works"></a>
+## ⚙️ How it works <a name="how-it-works"></a>
 
 Each preset is a markdown file with two zones:
 
@@ -17,7 +17,7 @@ Each preset is a markdown file with two zones:
 
 Claude sees the active rules in every session and follows them without being asked.
 
-## Installation <a name="installation"></a>
+## 📦 Installation <a name="installation"></a>
 
 ```bash
 /plugin marketplace add Tribe-Coding/claude-plugins
@@ -31,7 +31,7 @@ Then in the next session, run `/playbook-setup` to choose which presets to enabl
 
 > **Auto-update** keeps presets in sync with the latest fixes automatically on each Claude Code restart.
 
-## Available Presets <a name="available-presets"></a>
+## 📋 Available Presets <a name="available-presets"></a>
 
 | Preset | What it enforces |
 |--------|-----------------|
@@ -47,14 +47,14 @@ Then in the next session, run `/playbook-setup` to choose which presets to enabl
 
 Use `/playbook-browse` to read the full reference for any preset.
 
-## Commands
+## ⚡ Commands <a name="commands"></a>
 
 | Command | What it does |
 |---------|-------------|
 | `/playbook-setup` | Interactive wizard — enable/disable presets, global or per-project |
 | `/playbook-browse` | Read the full REFERENCE zone of any preset |
 
-## Configuration <a name="configuration"></a>
+## 🔧 Configuration <a name="configuration"></a>
 
 **Global** (`~/.claude/playbook.json`) — applies to all projects:
 
@@ -70,6 +70,6 @@ Use `/playbook-browse` to read the full reference for any preset.
 
 Project config takes priority. Use `"exclude"` to suppress global presets in a specific project.
 
-## Custom Presets
+## ✏️ Custom Presets <a name="custom-presets"></a>
 
 You can write your own presets for team-specific conventions. See [AUTHORING.md](../../docs/AUTHORING.md) for the format, rule patterns, token budget, and anti-patterns.

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -10,7 +10,7 @@ tags: [docs, readme]
 MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "what is this?" and "why would I use it?".
 
 - When creating/editing README.md → first 5 lines: project name, one-line description, problem it solves, target audience
-- After header block (motto + intro paragraph) → add a nav line as `> [!NOTE]` GitHub Alert with ALL sections **except the first one** (usually Demo — it's already visible above the fold; never include the first section in nav) and **except GitHub community files** (GitHub surfaces these automatically — see Navigation Line reference section). Use ` · ` as separator. No "Scroll to:" prefix. Add explicit `<a name="...">` anchor to each emoji heading: `## ⚙️ How it works <a name="how-it-works"></a>`. Then nav links use the explicit anchor: `[⚙️ How it works](#how-it-works)`
+- After header block (motto + intro paragraph) → add a nav line as `> [!NOTE]` GitHub Alert. **NEVER include the first H2 section** — it is always visible above the fold. This is a hard rule: do not add it "for completeness", do not add it when there are few sections, do not add it for any reason. Also **exclude GitHub community files** (GitHub surfaces these automatically — see Navigation Line reference section). Include all other H2 sections. Use ` · ` as separator. No "Scroll to:" prefix. Add explicit `<a name="...">` anchor to each emoji heading: `## ⚙️ How it works <a name="how-it-works"></a>`. Then nav links use the explicit anchor: `[⚙️ How it works](#how-it-works)`
 - Use emoji in headings (🚀 📦 ⚡ ⚙️) unless user explicitly forbids it
 - For tools/CLIs/plugins → lead with a concrete demo (real input → real output), NOT a feature list
 - Installation: official method only — no workarounds; merge Quick Start + Installation into one section
@@ -29,7 +29,7 @@ MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "w
 <!-- REFERENCE -->
 ## Navigation Line
 
-Add a nav line after the header block (tagline + intro paragraph) using a `[!NOTE]` GitHub Alert. Include ALL sections except the first one (usually Demo — it's already visible above the fold) and except Contributing (GitHub renders a Contributing link automatically in its sidebar). Use ` · ` as separator:
+Add a nav line after the header block (tagline + intro paragraph) using a `[!NOTE]` GitHub Alert. **NEVER include the first H2 section** — no exceptions, regardless of how few sections the README has. Also exclude GitHub community files (see table below). Include all other H2 sections. Use ` · ` as separator:
 
 ```markdown
 > [!NOTE]

--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -6,9 +6,9 @@
 A Claude Code plugin that generates retrospective summary reports from your Claude Code sessions. Review what you accomplished, track open questions, and get insights into your productivity and communication patterns.
 
 > [!NOTE]
-> [⚡ Quick Start](#quick-start) · [⚙️ How it works](#how-it-works) · [⚙️ Configuration](#configuration)
+> [⚡ Quick Start](#quick-start) · [📄 Report Format](#report-format) · [📂 Storage](#storage-structure) · [⚙️ Configuration](#configuration) · [⚙️ How it works](#how-it-works) · [💲 Cost](#cost-estimates) · [🗺️ Roadmap](#future-roadmap) · [🔧 Troubleshooting](#troubleshooting)
 
-## What it does
+## ✅ What it does <a name="what-it-does"></a>
 
 - **`/retro session`** — Summarize the current session from conversation context (display only)
 - **`/retro today`** — Aggregate report for all today's sessions, saved to your storage repo
@@ -26,7 +26,7 @@ Reports include: task outcomes, decisions made, open questions, GitHub/PR refere
 
 > **Tip:** You can also run `/retroscope:setup` directly at any time to configure or update settings.
 
-## Report Format
+## 📄 Report Format <a name="report-format"></a>
 
 ```markdown
 # 📋 Retroscope: my-project — 2026-02-23
@@ -67,7 +67,7 @@ Highly productive session focused on new plugin development...
 - Add streak tracking
 ```
 
-## Storage Structure
+## 📂 Storage Structure <a name="storage-structure"></a>
 
 Reports are saved as git-tracked markdown files:
 
@@ -107,7 +107,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin
 5. **Storage** — Saves to the configured storage repo and creates a git commit
 6. **Caching** — If a report already exists and is newer than all session files, displays cached version instantly
 
-## Cost Estimates
+## 💲 Cost Estimates <a name="cost-estimates"></a>
 
 | Config | Sessions | Est. Cost |
 |--------|----------|----------|
@@ -116,7 +116,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin
 | Sonnet + extract mode ON | 2 avg sessions | ~$0.05–0.15 |
 | Sonnet + extract mode OFF | 2 avg sessions | ~$0.20–0.60 |
 
-## Future Roadmap (v0.2.0+)
+## 🗺️ Future Roadmap (v0.2.0+) <a name="future-roadmap"></a>
 
 - `/retro this-week` — aggregate daily reports Mon–today
 - `/retro last-week` — Mon–Sun of previous week
@@ -131,7 +131,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin
 - Session tagging — auto-tag by activity type (debugging, feature dev, docs, review)
 - Burnout detection — flag long low-productivity sessions
 
-## Troubleshooting
+## 🔧 Troubleshooting <a name="troubleshooting"></a>
 
 **No sessions found for today:**
 - Check that `CLAUDE_PROJECT_DIR` matches your project path

--- a/plugins/semver/.claude-plugin/plugin.json
+++ b/plugins/semver/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semver",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Semantic versioning enforcement: validates version bumps before commit/push/PR, supports multiple version files",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/semver/README.md
+++ b/plugins/semver/README.md
@@ -6,11 +6,11 @@
 Semantic versioning enforcement for Claude Code. Validates that a version bump is staged before `git commit`, `git push`, and PR creation. Injects SemVer rules into every session so Claude knows when and how to increment versions automatically.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [⚙️ Configuration](#configuration)
+> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [⚙️ Configuration](#configuration) · [🛠️ Skills](#skills) · [📚 Reference](#reference)
 
-## 🎬 Demo
+## 🎬 Demo <a name="demo"></a>
 
-```
+```markdown
 You: commit the auth service refactor
 
 Claude: ⚠️  No version bump detected.
@@ -84,10 +84,10 @@ Config lives at `.claude-plugin/semver.json` (project, committed to git) and `~/
 | `warn` | Log a warning, continue anyway |
 | `block` | Refuse to commit/push until version is bumped |
 
-## Skills (on-demand)
+## 🛠️ Skills (on-demand) <a name="skills"></a>
 
 `semver-guide` — loaded automatically when Claude needs to decide MAJOR/MINOR/PATCH. Covers SemVer 2.0.0 decision tree, conflict resolution when rebasing, and common mistakes.
 
-## Reference
+## 📚 Reference <a name="reference"></a>
 
 - [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) — test suite

--- a/plugins/statusline-compact/.claude-plugin/plugin.json
+++ b/plugins/statusline-compact/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline-compact",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Compact single-line Claude Code statusline with brightness-coded API usage values. Shows 5h/7d rate limits, extra usage, context window, git branch, and model - all on one line.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/statusline-compact/README.md
+++ b/plugins/statusline-compact/README.md
@@ -6,11 +6,11 @@
 Single-line statusline with brightness-coded API usage values.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation)
+> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [⚖️ Compared to statusline](#compared-to-statusline) · [📚 Reference](#reference)
 
-## 🎬 Demo
+## 🎬 Demo <a name="demo"></a>
 
-```
+```markdown
 5h 92% 50m !!   7d 22% ~5d   extra $4.79   Sonnet 4.6   context 30%   my-project/   main*
 ```
 
@@ -47,7 +47,7 @@ Select **statusline-compact** in `/plugin` → enable **auto-update**. Restart y
 
 **Requirements:** `jq`, `curl`, `python3`; macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
 
-## Compared to statusline
+## ⚖️ Compared to statusline <a name="compared-to-statusline"></a>
 
 | | statusline | statusline-compact |
 |-|------------|-------------------|
@@ -56,6 +56,6 @@ Select **statusline-compact** in `/plugin` → enable **auto-update**. Restart y
 | Space usage | More | Less |
 | Choose when | You want visual progress bars | You want minimal terminal footprint |
 
-## Reference
+## 📚 Reference <a name="reference"></a>
 
 - [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) — test suite

--- a/plugins/statusline/.claude-plugin/plugin.json
+++ b/plugins/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Three-line Claude Code statusline with enhanced resolution: 5h (30 blocks/10m), 7d (28 blocks/6h), extra usage (N blocks/1d). Features improved alignment, dimmed separators, and wide character support.",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/statusline/README.md
+++ b/plugins/statusline/README.md
@@ -6,11 +6,11 @@
 Three-line Claude Code statusline with real-time API usage, progress bars, and session info.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation)
+> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [📚 Reference](#reference)
 
-## 🎬 Demo
+## 🎬 Demo <a name="demo"></a>
 
-```
+```markdown
 5h/10m････■■■■■■■■■■■■■̿■■■■■■■■■■■■■■■■■■･･3h42m      🤖･Sonnet･4.6       ✏️･clever-zooming-firefly
 7d/6h･････････■■■■■■■■■■■■■■■■■■■■■■■■■̿■■■･･~5d        📚･32%              📁･my-project
 1M/1d･⏸️･■■■■■■■■■■■■■■■■■■■■■■■■■■■■̿･･¤4.79       💵･$4.79            🌿･main･⚠️
@@ -58,7 +58,7 @@ Select **statusline** in `/plugin` → enable **auto-update**. Restart your sess
 
 **Requirements:** `jq`, `curl`, `python3`; macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
 
-## Reference
+## 📚 Reference <a name="reference"></a>
 
 - [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) — test suite
 - [`docs/STDIN_JSON.md`](docs/STDIN_JSON.md) — all JSON fields piped by Claude Code to `statusline.sh`

--- a/plugins/technology-explainer/.claude-plugin/plugin.json
+++ b/plugins/technology-explainer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "technology-explainer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Adapts explanation depth based on user proficiency per technology: expert, intermediate, or learning",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/technology-explainer/README.md
+++ b/plugins/technology-explainer/README.md
@@ -8,9 +8,9 @@ Configure your proficiency level per technology and Claude automatically adjusts
 > [!NOTE]
 > [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🎮 Commands](#commands) · [📝 Config](#config)
 
-## 🎬 Demo
+## 🎬 Demo <a name="demo"></a>
 
-```
+```markdown
 > /technology-explainer-update git expert
 
 Updated **git** → **expert**.
@@ -22,7 +22,7 @@ Updated **terraform** → **learning**.
 
 After restarting:
 
-```
+```markdown
 > How does git stash work?
 
 ✦ Using skill: proficiency-guide-expert


### PR DESCRIPTION
## Summary

- Use ` ```markdown ` for console interaction demos across all 10 plugin READMEs (not bare ` ``` `)
- Add emoji + `<a name>` anchors to all H2 headings missing them
- Complete navbars: include all sections except the first one and GitHub community files
- Extract 4 detail sections from git-branch-naming README (367→274 lines) into `docs/`
- Clarify CLAUDE.md "README Demo Sections" rule — specify what qualifies as console interaction
- Strengthen `readme` preset navbar rule — explicit "NEVER include first H2" with no-exception wording
- PATCH bump all 10 plugins

## Test plan

- [ ] `wc -l plugins/git-branch-naming/README.md` ≤ 300
- [ ] All demo blocks use ` ```markdown ` — no bare ` ``` ` in demo sections
- [ ] All H2 headings have emoji + `<a name>` anchors
- [ ] Navbars list all H2 sections except the first one and community files
- [ ] Extracted docs links resolve: `docs/token-cost.md`, `docs/content-mismatch.md`, `docs/architecture.md`, `docs/pre-push-hook.md`
- [ ] Version bumps in all 10 `plugin.json` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)