### PR TITLE
docs: standardize setup sections across plugin READMEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ For full authoring guidelines — SKILL.md hybrid design, preset RULES/REFERENCE
    - Store default config template in `templates/<name>.json`
    - Setup wizard writes to `{project}/.claude-plugin/<name>.json`
    - Scripts read from `.claude-plugin/<name>.json` first, fall back to `.claude/<name>.json`
+   - README must document the setup command and config location (see `readme` playbook preset → Setup Section for Plugins)
 8. **If plugin installs git hooks** (pre-commit, pre-push, etc.) → use marker-based injection and provide an uninstall command (see [`docs/conventions.md`](docs/conventions.md) — Git Hook Installation)
 9. **Update root `README.md`** — add row to the Plugins table (alphabetical order)
 10. **Update the Plugins list above** — add bullet to the Plugins section in this file (alphabetical order)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -17,7 +17,7 @@ Plugins that need project-level configuration store config files in `.claude-plu
 
 **Backwards compatibility:** Scripts also check `{project}/.claude/<name>.json` as fallback for configs created before this convention.
 
-**Setup wizards** (`/playbook-setup`, `/semver-setup`, `/git-branch-naming-setup`, `/retroscope-setup`) write to `.claude-plugin/<name>.json` by default.
+**Setup wizards** (e.g., `/playbook-setup`, `/semver-setup`, `/git-branch-naming-setup`, `/kb-grooming-setup`, `/retroscope-setup`, `/technology-explainer-setup`) write to `.claude-plugin/<name>.json` by default. The statusline plugins (`/statusline-setup`, `/statusline-compact:statusline-setup`) configure `~/.claude/settings.json` instead.
 
 ---
 

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -24,6 +24,7 @@ MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "w
 - **ALWAYS invoke the `playbook-browse readme` skill BEFORE writing, modifying, reviewing, or improving any README** (including when the user refers to it as "readme", "рідмі", "the landing page", or similar). This is MANDATORY — do not skip even when executing a plan or implementing a task that produces a README.
 - When shortening a README (removing sections, detail, or full component descriptions) → BEFORE deleting, verify each removed block has a destination (per-component README, `docs/`, `CONTRIBUTING.md`). If no destination exists — create it first, then remove from README. After completing the rewrite, produce a "what went where" summary for the user.
 - Do NOT add a standalone License section — a one-line "MIT — see LICENSE" adds no value; readers who care check the `LICENSE` file directly
+- If a plugin has a setup wizard command → the README MUST document the setup command and config file location(s). Either: (a) a dedicated `## 🔧 Setup` section after Installation with the command, what it configures, and config paths, or (b) the setup command in `## Installation` followed by a `## Configuration` section with full schema. Zero-setup plugins omit setup documentation entirely
 <!-- /RULES -->
 
 <!-- REFERENCE -->
@@ -157,6 +158,40 @@ Adapt to the project — not all sections are needed for every project:
 7. **Contributing** — link to `CONTRIBUTING.md` or brief guidelines
 
 Omit sections that don't apply. A 60-line focused README beats a 300-line comprehensive one.
+
+## Setup Section for Plugins
+
+When a plugin has a setup wizard command (`/<name>-setup`), the README must make it discoverable. Two acceptable patterns:
+
+**Pattern A — Dedicated section** (preferred when setup needs explanation):
+
+```markdown
+## 🔧 Setup <a name="setup"></a>
+
+⁣```bash
+/<plugin-name>-setup
+⁣```
+
+The wizard configures:
+- **Item 1** — what it does
+- **Item 2** — what it does
+
+Config: `~/.claude/<name>.json` (global) and `.claude-plugin/<name>.json` (project).
+```
+
+**Pattern B — Inline in Installation** (when setup is a one-liner):
+Show the setup command in Installation, then have a `## Configuration` section with config schema and examples.
+
+**Required information** (in either pattern):
+1. Setup command in a copy-pasteable code block
+2. What the wizard configures (1–3 bullet points)
+3. Config file location(s) with scope (global vs project)
+
+**Placement:** Setup section goes immediately after Installation, before Usage/Commands. Add `[🔧 Setup](#setup)` to the nav line.
+
+**Zero-setup plugins** (no setup command) do not need setup documentation.
+
+**Reference implementation:** `plugins/kb-grooming/README.md` (Pattern A).
 
 ## Platform-Aware Rendering
 

--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -6,7 +6,7 @@
 A Claude Code plugin that generates retrospective summary reports from your Claude Code sessions. Review what you accomplished, track open questions, and get insights into your productivity and communication patterns.
 
 > [!NOTE]
-> [⚡ Quick Start](#quick-start) · [📄 Report Format](#report-format) · [📂 Storage](#storage-structure) · [⚙️ Configuration](#configuration) · [⚙️ How it works](#how-it-works) · [💲 Cost](#cost-estimates) · [🗺️ Roadmap](#future-roadmap) · [🔧 Troubleshooting](#troubleshooting)
+> [📦 Installation](#installation) · [🔧 Setup](#setup) · [📄 Report Format](#report-format) · [📂 Storage](#storage-structure) · [⚙️ Configuration](#configuration) · [⚙️ How it works](#how-it-works) · [💲 Cost](#cost-estimates) · [🗺️ Roadmap](#future-roadmap) · [🔧 Troubleshooting](#troubleshooting)
 
 ## ✅ What it does <a name="what-it-does"></a>
 
@@ -16,15 +16,29 @@ A Claude Code plugin that generates retrospective summary reports from your Clau
 
 Reports include: task outcomes, decisions made, open questions, GitHub/PR references, productivity metrics, and suggestions for improving your Claude Code workflow.
 
-## ⚡ Quick Start <a name="quick-start"></a>
+## 📦 Installation <a name="installation"></a>
 
-1. Install the plugin: `/plugin install retroscope@tribe-coding`
-2. Start a Claude Code session
-3. Run `/retro` — if no config is found, it will offer to run setup automatically
-4. Work normally in Claude Code
-5. Run `/retro today` at end of day
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install retroscope@tribe-coding
+```
 
-> **Tip:** You can also run `/retroscope:setup` directly at any time to configure or update settings.
+Select **retroscope** in `/plugin` → enable **auto-update**.
+
+## 🔧 Setup <a name="setup"></a>
+
+```bash
+/retroscope:setup
+```
+
+The wizard configures:
+- **Storage directory** — where reports are saved (creates + git-inits if needed)
+- **Report model** — `haiku` (fast, ~$0.01/report), `sonnet` (detailed), or `inherit`
+- **Options** — language, timezone, extract mode, session source, auto-push
+
+Config: `~/.claude/retroscope.json` (global) and `.claude-plugin/retroscope.json` (project overrides).
+
+> **Tip:** If you run `/retro` without config, it will offer to run setup automatically.
 
 ## 📄 Report Format <a name="report-format"></a>
 

--- a/plugins/statusline-compact/.claude-plugin/plugin.json
+++ b/plugins/statusline-compact/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline-compact",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Compact single-line Claude Code statusline with brightness-coded API usage values. Shows 5h/7d rate limits, extra usage, context window, git branch, and model - all on one line.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/statusline-compact/README.md
+++ b/plugins/statusline-compact/README.md
@@ -6,7 +6,7 @@
 Single-line statusline with brightness-coded API usage values.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [⚖️ Compared to statusline](#compared-to-statusline) · [📚 Reference](#reference)
+> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🔧 Setup](#setup) · [⚖️ Compared to statusline](#compared-to-statusline) · [📚 Reference](#reference)
 
 ## 🎬 Demo <a name="demo"></a>
 
@@ -37,15 +37,22 @@ Values dim at low usage and brighten as they climb: yellow above 90%, red at 100
 /plugin install statusline-compact@tribe-coding
 ```
 
-Then run the setup command to configure `~/.claude/settings.json`:
+Select **statusline-compact** in `/plugin` → enable **auto-update**.
+
+**Requirements:** `jq`, `curl`, `python3`; macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
+
+## 🔧 Setup <a name="setup"></a>
 
 ```bash
 /statusline-compact:statusline-setup
 ```
 
-Select **statusline-compact** in `/plugin` → enable **auto-update**. Restart your session — done.
+The wizard:
+- **Copies** the compact statusline script to `~/.claude/`
+- **Configures** the `statusLine` field in `~/.claude/settings.json`
+- **Verifies** `jq` and `curl` are available
 
-**Requirements:** `jq`, `curl`, `python3`; macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
+Restart your session after setup.
 
 ## ⚖️ Compared to statusline <a name="compared-to-statusline"></a>
 

--- a/plugins/statusline/.claude-plugin/plugin.json
+++ b/plugins/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Three-line Claude Code statusline with enhanced resolution: 5h (30 blocks/10m), 7d (28 blocks/6h), extra usage (N blocks/1d). Features improved alignment, dimmed separators, and wide character support.",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/statusline/README.md
+++ b/plugins/statusline/README.md
@@ -6,7 +6,7 @@
 Three-line Claude Code statusline with real-time API usage, progress bars, and session info.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [📚 Reference](#reference)
+> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🔧 Setup](#setup) · [📚 Reference](#reference)
 
 ## 🎬 Demo <a name="demo"></a>
 
@@ -48,15 +48,22 @@ Cache refresh: 60s (all bars).
 /plugin install statusline@tribe-coding
 ```
 
-Then run the setup command to configure `~/.claude/settings.json`:
+Select **statusline** in `/plugin` → enable **auto-update**.
+
+**Requirements:** `jq`, `curl`, `python3`; macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
+
+## 🔧 Setup <a name="setup"></a>
 
 ```bash
 /statusline:statusline-setup
 ```
 
-Select **statusline** in `/plugin` → enable **auto-update**. Restart your session — done.
+The wizard:
+- **Copies** `statusline.sh` to `~/.claude/`
+- **Configures** the `statusLine` field in `~/.claude/settings.json`
+- **Verifies** `jq` and `curl` are available
 
-**Requirements:** `jq`, `curl`, `python3`; macOS Keychain or `~/.claude/.credentials.json` (for Anthropic OAuth token)
+Restart your session after setup.
 
 ## 📚 Reference <a name="reference"></a>
 


### PR DESCRIPTION
## Summary

- **New rule** in `readme` playbook preset: plugins with setup wizards MUST document the setup command, what it configures, and config paths (two acceptable patterns: dedicated section or inline + Configuration)
- **Fixed 3 READMEs** missing proper setup docs: retroscope, statusline, statusline-compact
- **Updated** stale setup wizard list in `docs/conventions.md` (4 → 8 wizards)
- **Added** setup-docs sub-bullet to CLAUDE.md new-plugin checklist (step 7)
- **Version bumps**: playbook 0.6.8, retroscope 0.2.7, statusline 1.4.4, statusline-compact 0.2.5

## Test plan

- [ ] Verify retroscope README has Installation + Setup sections with correct anchors
- [ ] Verify statusline/statusline-compact READMEs have dedicated Setup sections
- [ ] Verify `readme` preset RULES zone has the new setup rule
- [ ] Verify `readme` preset REFERENCE zone has "Setup Section for Plugins" block
- [ ] Verify `docs/conventions.md` lists all 8 setup wizards
- [ ] Verify nav lines render correctly on GitHub (anchors match headings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)