### PR TITLE
feat: ai-fortune plugin — career direction analysis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,6 +44,11 @@
       "description": "Semantic versioning enforcement: validates version bumps before commit/push/PR, supports multiple version files"
     },
     {
+      "name": "ai-fortune",
+      "source": "./plugins/ai-fortune",
+      "description": "Career direction analysis: interview + AI usage pattern mining to identify roles AI won't replace"
+    },
+    {
       "name": "context",
       "source": "./plugins/context",
       "description": "Inspect full Claude Code session context: CLAUDE.md files, auto-memory, and SessionStart hook output"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ A marketplace of reusable Claude Code plugins (`Tribe Coding`). Each plugin live
 
 ## Plugins
 
+- **ai-fortune** — Career direction analysis: interview + AI usage pattern mining
 - **plantuml** — Keeps PlantUML diagram URLs in sync; provides ASCII rendering in terminal
 - **statusline** — Three-line statusline: rate limits, context/branch, extra usage
 - **statusline-compact** — Single-line statusline with brightness-coded API usage

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/
 
 | Plugin | What it does |
 |--------|-------------|
+| [**ai-fortune**](plugins/ai-fortune/README.md) | Analyze your AI usage patterns, run a career interview, and get a personalized career direction report |
 | [**context**](plugins/context/README.md) | Show everything loaded into your session — CLAUDE.md files, memory, hooks — with a per-source token breakdown |
 | [**git-branch-naming**](plugins/git-branch-naming/README.md) | Enforce branch naming conventions automatically; warns before push if the name or staged content doesn't match |
 | [**kb-grooming**](plugins/kb-grooming/README.md) | Audit documentation health — broken links, orphan files, README compliance — then create a GitHub epic with linked issues |

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -125,6 +125,38 @@ fi
 
 ---
 
+## Local Plugin Testing (before push)
+
+To test a plugin locally before pushing to remote and installing via marketplace:
+
+**1. Copy plugin into the marketplace clone:**
+```bash
+cp -r plugins/<name> ~/.claude/plugins/marketplaces/tribe-coding/plugins/<name>
+```
+
+**2. Register in the marketplace manifest (if not already):**
+```bash
+# Edit ~/.claude/plugins/marketplaces/tribe-coding/.claude-plugin/marketplace.json
+# Add the plugin entry to the "plugins" array
+```
+
+**3. Enable in settings:**
+```bash
+# Edit ~/.claude/settings.json — add to "enabledPlugins":
+"<name>@tribe-coding": true
+```
+
+**4. Restart Claude Code** — the plugin should appear in `/plugin` and its commands in the skill list.
+
+**After testing — clean up:**
+- Remove `~/.claude/plugins/marketplaces/tribe-coding/plugins/<name>` (will be re-created on next marketplace sync)
+- Remove `"<name>@tribe-coding": true` from `~/.claude/settings.json` (will be re-added on proper install)
+- The marketplace manifest cache will be overwritten on next sync, so no manual revert needed
+
+**Why this works:** Claude Code resolves plugin `"source"` paths relative to `~/.claude/plugins/marketplaces/<marketplace>/`. So `"source": "./plugins/ai-fortune"` resolves to `~/.claude/plugins/marketplaces/tribe-coding/plugins/ai-fortune`. Placing files there makes the plugin discoverable without pushing to remote.
+
+---
+
 ## Plugin Cache Sync
 
 Claude Code has a bug where the plugin cache is not invalidated on auto-update ([#14061](https://github.com/anthropics/claude-code/issues/14061), [#15621](https://github.com/anthropics/claude-code/issues/15621), [#15642](https://github.com/anthropics/claude-code/issues/15642)).

--- a/plugins/ai-fortune/.claude-plugin/plugin.json
+++ b/plugins/ai-fortune/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-fortune",
+  "version": "0.2.0",
+  "description": "Career direction analysis: interview + AI usage pattern mining to identify roles AI won't replace",
+  "author": {
+    "name": "Tribe Coding"
+  },
+  "license": "MIT",
+  "commands": [
+    "./commands/"
+  ],
+  "skills": []
+}

--- a/plugins/ai-fortune/README.md
+++ b/plugins/ai-fortune/README.md
@@ -1,0 +1,160 @@
+# AI Fortune
+
+> [!TIP]
+> ✨ ***Know your career blind spots before AI finds them for you.***
+
+A Claude Code plugin that analyzes your AI usage patterns, runs an adaptive career interview, performs real-time industry research, and generates a personalized career direction report — not generic advice, but data-backed recommendations anchored in how you actually work.
+
+> [!NOTE]
+> [📦 Installation](#installation) · [🚀 How it works](#how-it-works) · [📊 Data Sources](#data-sources) · [🎯 Report Sections](#report-sections) · [💾 Persistent State](#persistent-state) · [⚙️ Configuration](#configuration) · [🔧 Troubleshooting](#troubleshooting)
+
+## ✅ What it does <a name="what-it-does"></a>
+
+- **`/ai-fortune`** — Run a full career direction analysis: data collection → adaptive interview → web research → structured report
+
+One command that:
+1. Mines 7 data sources (insights report, session metadata, plugins, tech proficiency, stats)
+2. Runs an adaptive 15-question interview (skips what it already knows)
+3. Researches your industry's AI landscape via web search
+4. Generates a career risk assessment with 3-4 recommended directions
+
+## 📦 Installation <a name="installation"></a>
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install ai-fortune@tribe-coding
+```
+
+Select **ai-fortune** in `/plugin` → enable **auto-update**.
+
+## 🚀 How it works <a name="how-it-works"></a>
+
+```markdown
+You: /ai-fortune
+
+Claude: 📂 Loading persistent state...
+        ✅ Found previous answers from 2026-02-15 (14 days ago)
+
+        📊 Phase 1: Collecting data from 7 sources...
+        ✅ Memory chat file — extracted industry: Tech, role context
+        ✅ Insights report — 182 sessions, 5 project areas, plan-driven power user
+        ✅ Session metadata (7d) — 23 sessions, 4 projects
+        ✅ Technology explainer — 8 expert, 5 intermediate, 3 learning
+        ✅ Installed plugins — 10 plugins (sophisticated AI augmentation)
+        ✅ Stats cache — 299 total sessions over 39 days
+        Sources: 6/7 used
+
+        🎤 Phase 2: Adaptive interview...
+        Using your previous answer from Feb 15: "Software Engineer, Tech"
+        Using your previous answer from Feb 15: "40% code, 20% architecture..."
+
+Claude: ❓ What is the single most important thing you bring to your team?
+        ┌─────────────────────────────────────┐
+        │ 1. Systems thinking and tooling     │
+        │ 2. Cross-domain problem solving     │
+        │ 3. Other (free text)                │
+        └─────────────────────────────────────┘
+
+You: 1
+
+        ... (10-15 adaptive questions) ...
+
+        🔍 Phase 3: Web research & report generation...
+        Searching: "AI automation software engineering 2026 trends"
+        Searching: "Software Engineer AI replacement risk 2026"
+        Searching: "AI-resistant careers technology"
+
+        📋 Generating Career Direction Report...
+
+# Career Direction Report
+
+Generated: 2026-03-01 | Sources: 7/8 used
+
+## Your Profile
+**Role:** Software Engineer | **Industry:** Tech | **Experience:** 6-10 years
+**AI Adoption at org:** Widely adopted | **Personal AI dependency:** Essential
+
+## AI Leverage Profile
+**AI Leverage Score: 9/10** — Architect-level AI orchestration
+**Delegation Maturity: Level 5 — Architect**
+
+## Risk Assessment: Your Current Path
+**Overall AI displacement risk: MODERATE**
+
+| Dimension | Score | Evidence |
+|-----------|-------|----------|
+| Task Repeatability | ⭐⭐⭐ | 40% coding (partially automatable) |
+| Human Judgment | ⭐⭐⭐⭐ | Architecture decisions, stakeholder nav |
+| Physical Presence | ⭐ | Fully remote |
+| Regulatory/Trust | ⭐⭐ | No licensing requirements |
+| Creative Synthesis | ⭐⭐⭐⭐ | Plugin ecosystem design, cross-domain |
+
+## Recommended Directions
+### Direction 1: AI Platform Engineering Lead
+**Fit score: 9/10** ...
+
+        ... (full report with 3-4 directions, action plan, blind spots) ...
+
+        💾 State saved to ~/.claude/ai-fortune.json
+        📄 Report saved to /tmp/ai-fortune-reports/2026-03-01_14-30-45.md
+        Run /ai-fortune again anytime — it remembers your answers.
+```
+
+## 📊 Data Sources <a name="data-sources"></a>
+
+| # | Source | What it reveals | Required? |
+|---|--------|----------------|-----------|
+| 1 | Memory chat file | Industry, interests, domain context | Optional |
+| 2 | CC Insights report | Usage patterns, strengths, friction | Optional |
+| 3 | Session metadata (7d) | Recent work diversity, tool usage | Optional |
+| 4 | Technology explainer | Skill proficiency map | Optional |
+| 5 | Installed plugins | AI augmentation sophistication | Optional |
+| 6 | Stats cache | Longitudinal usage trends | Optional |
+| 7 | Web research | Industry AI landscape, salary data | Optional |
+| 8 | Interview | Self-assessment, aspirations | **Required** |
+
+The report can be generated with just the interview, but quality improves dramatically with more data sources. The plugin gracefully handles missing sources.
+
+## 🎯 Report Sections <a name="report-sections"></a>
+
+- **Your Profile** — role, industry, tech proficiency map from data
+- **AI Leverage Profile** — AI Leverage Score (0-10) and Delegation Maturity Model (Level 1-5), measuring how effectively you use AI as a force multiplier
+- **Risk Assessment** — 5-dimension risk matrix with evidence-backed scores
+- **Industry AI Landscape** — real-time web research on AI in your industry
+- **Recommended Directions** — 3-4 career paths with fit scores, skills bridge tables, salary ranges
+- **AI Orchestrator Advantage** — (for advanced users) why your AI orchestration skill is a competitive moat
+- **Action Plan** — concrete 30-day, 6-month, and 1-2 year milestones
+- **Blind Spots** — honest assessment of tech gaps, friction patterns, over-reliance risks
+
+## 💾 Persistent State <a name="persistent-state"></a>
+
+Interview answers are saved to `~/.claude/ai-fortune.json` with timestamps. On re-runs:
+
+- **Recent answers (< 6 months):** Skipped, shown as "Using your previous answer from {date}"
+- **Stale answers (>= 6 months):** Re-asked with previous value as default option
+- **File paths:** Saved so you don't re-enter them each time
+
+Reports are automatically saved to a user-chosen directory (default: `/tmp/ai-fortune-reports/`) with timestamped filenames (e.g., `2026-03-01_14-30-45.md`). The chosen directory is remembered for future runs. Browse past reports to track how recommendations evolve over time.
+
+## ⚙️ Configuration <a name="configuration"></a>
+
+No setup wizard needed — just run `/ai-fortune`. The plugin discovers data sources automatically and asks about any it can't find.
+
+State file: `~/.claude/ai-fortune.json`
+
+## 🔧 Troubleshooting <a name="troubleshooting"></a>
+
+**Scripts fail to run:**
+```bash
+python3 -m py_compile plugins/ai-fortune/scripts/parse-insights.py
+python3 -m py_compile plugins/ai-fortune/scripts/aggregate-sessions.py
+```
+
+**No insights report:**
+Generate one at [claude.ai/insights](https://claude.ai/insights) and download the HTML file to `~/.claude/usage-data/report.html`.
+
+**Missing session metadata:**
+Session metadata is collected automatically by Claude Code. If `~/.claude/usage-data/session-meta/` is empty, you may need to update Claude Code.
+
+**Want to reset saved answers:**
+Delete `~/.claude/ai-fortune.json` and re-run `/ai-fortune`.

--- a/plugins/ai-fortune/commands/ai-fortune/SKILL.md
+++ b/plugins/ai-fortune/commands/ai-fortune/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: ai-fortune
+description: >
+  Career direction analysis: interview + AI usage pattern mining to identify
+  roles AI won't replace. Collects data from 7 sources, runs adaptive interview,
+  performs web research, and generates a structured career risk report.
+  Keywords: ai fortune, career analysis, career risk, ai displacement, career direction,
+  job future, ai resistant, career pivot.
+---
+
+# /ai-fortune — Career Direction Analysis
+
+Run all phases in order. Each step specifies the exact tools to use.
+
+## Phase 0: Load Persistent State
+
+### Step 0: Load State
+
+1. Read `~/.claude/ai-fortune.json`
+   - If exists → load `dataSources` (saved file paths), `answers` (interview answers with timestamps), `reportsDir` (saved report directory)
+   - If not found → start with empty state: `dataSources = {}`, `answers = {}`, `reportsDir = null`
+2. Set `sources_used = 0` counter to track how many of the 8 data sources produce data
+
+---
+
+## Phase 1: Data Collection (Steps 1-6)
+
+Collect data from up to 7 sources. Each source is optional — if unavailable, note it and continue.
+
+### Step 1: Memory Chat File
+
+**Purpose:** Extract industry, tech stack, interests, domain context from the user's Claude web memory export.
+
+1. Check if `dataSources.memoryFilePath` exists in loaded state
+2. If saved path exists → `AskUserQuestion`: "Memory chat file path: use saved path `{path}`?"
+   - Options: "Use saved path", "Enter different path", "Skip this source"
+3. If no saved path → `AskUserQuestion`: "Where is your Claude memory chat export file? (Markdown file exported from claude.ai)"
+   - Options: "Skip this source"
+   - Free text for custom path
+4. If not skipped → `Read` the file
+5. Extract: industry, tech stack, interests, projects, domain expertise, personal context
+6. Save chosen path to `dataSources.memoryFilePath`
+7. Increment `sources_used`
+
+### Step 2: Insights Report
+
+**Purpose:** Extract AI usage patterns, strengths, friction, session types from the CC Insights HTML report.
+
+1. Check `dataSources.insightsReportPath` in state; default fallback: `~/.claude/usage-data/report.html`
+2. `AskUserQuestion` with saved/default path, same pattern as Step 1
+3. If not skipped → `Bash`: `python3 ${SKILL_DIR}/../../scripts/parse-insights.py "{path}"`
+4. Parse JSON output — key fields: `project_areas`, `top_tools`, `languages`, `session_types`, `usage_narrative`, `whats_working`, `whats_hindering`, `friction_categories`, `impressive_things`, `horizon_cards`, `satisfaction_distribution`, `multi_clauding`, `stats`
+5. Save path to `dataSources.insightsReportPath`
+6. Increment `sources_used`
+
+### Step 3: Session Metadata (7 days, all projects)
+
+**Purpose:** Get recent work patterns — project diversity, tool usage, complexity indicators.
+
+1. `Bash`: `python3 ${SKILL_DIR}/../../scripts/aggregate-sessions.py --days 7`
+2. Parse JSON output — key fields: `sessions_total`, `projects`, `tool_distribution`, `language_distribution`, `complexity_indicators` (task_agent_pct, mcp_pct, web_search_pct), `averages`, `session_types`, `first_prompts`
+3. If `sessions_total == 0` → note as unavailable, continue
+4. Increment `sources_used`
+
+### Step 4: Technology Explainer Config
+
+**Purpose:** Get objective technology proficiency map (expert/intermediate/learning).
+
+1. `Read` `~/.claude/technology-explainer.json`
+2. If exists → extract `technologies` grouped by `level` (expert, intermediate, learning), `default_level`, `custom_sources`
+3. If not found → note as unavailable
+4. Increment `sources_used` if found
+
+### Step 5: Installed Plugins
+
+**Purpose:** Assess AI augmentation sophistication.
+
+1. `Read` `~/.claude/settings.json` → extract `enabledPlugins` array
+2. For each plugin path → `Read` the `plugin.json` inside its `.claude-plugin/` directory
+3. Collect: plugin names, versions, descriptions, count of hooks/skills/commands
+4. Increment `sources_used`
+
+### Step 6: Stats Cache (optional)
+
+**Purpose:** Longitudinal usage data — total sessions, daily patterns, model usage.
+
+1. `Read` `~/.claude/stats-cache.json`
+2. If exists → extract: total sessions, messages/day, model distribution, date range
+3. If not found → note as unavailable, continue
+4. Increment `sources_used` if found
+
+---
+
+## Phase 2: Interview (Steps 7-8)
+
+### Step 7: Adaptive Interview
+
+1. `Read` `${SKILL_DIR}/references/interview-questions.md`
+2. For each question (Q1-Q15), apply re-ask logic:
+
+   **Re-ask decision tree:**
+   ```
+   Has previous answer in state?
+   ├── YES → How old is the answer?
+   │   ├── < 6 months → SKIP: Display "Using your previous answer from {date}: {value}"
+   │   └── >= 6 months → RE-ASK: Use AskUserQuestion with previous value as first option
+   │                      (add "(previous answer)" suffix to the label)
+   └── NO → Can data auto-answer this question?
+       ├── YES → Pre-fill from data, confirm with user: "Based on your data, {value} — correct?"
+       └── NO → ASK: Use AskUserQuestion with options from interview-questions.md
+   ```
+
+3. **Auto-skip rules** (use data to pre-answer):
+   - Q1 (role/industry): if memory file contains clear role/industry info
+   - Q5 (AI dependency): if session data shows >5 sessions/day → pre-fill "Essential"
+   - Q7 (years experience): if memory file mentions experience level
+   - Q10 (domain expertise): if technology-explainer has expert-level entries
+
+4. **Tier 3 collapse**: If user gives 2+ consecutive minimal answers (picks first option without customizing), skip remaining Tier 3 questions
+
+5. For `multiple_choice` questions → use `AskUserQuestion` with options from the question bank
+6. For `free_text` questions → use `AskUserQuestion` with 2-3 example options + free text
+
+### Step 8: Profile Synthesis
+
+1. Combine all collected data + interview answers into a unified profile
+2. Run contrastive analysis — compare self-reported vs data-observed:
+   - AI dependency (interview Q5) vs actual session frequency
+   - Daily task breakdown (Q2) vs project_areas from insights
+   - Claimed strengths (Q3, Q10) vs impressive_things from insights
+3. Note any discrepancies for the Blind Spots section
+4. Compute preliminary risk scores for each of the 5 dimensions
+
+---
+
+## Phase 3: Research & Report (Steps 9-11)
+
+### Step 9: Web Research
+
+Perform 3-5 targeted `WebSearch` queries based on the user's profile:
+
+1. `WebSearch`: "AI automation {user's industry} 2026 trends"
+2. `WebSearch`: "{user's role title} AI replacement risk 2026"
+3. `WebSearch`: "AI-resistant careers {user's domain}"
+4. `WebSearch`: "{user's top technology} AI automation capabilities 2026" (if relevant)
+5. `WebSearch`: "{recommended direction} salary range {user's geography}" (after directions are drafted)
+
+For each search → extract key findings, specific companies/products, salary data.
+Increment `sources_used`.
+
+### Step 10: Generate Report
+
+1. `Read` `${SKILL_DIR}/references/analysis-framework.md`
+2. `Read` `${SKILL_DIR}/references/report-template.md`
+3. Compute final scores:
+   - **Risk Matrix**: score each of 5 dimensions (1-5) with evidence
+   - **AI Leverage Score**: compute from plugin count, session complexity, multi-clauding %, task-agent %, delegation maturity
+   - **Delegation Maturity Level**: determine from session types, tool distribution, multi-clauding stats
+4. Generate 3-4 recommended career directions:
+   - Each direction must reference specific AI-resistant properties
+   - Each must include a skills bridge table with concrete resources
+   - Each must cite web research findings
+5. Generate the complete report following `report-template.md` structure
+6. **Display the report** in the terminal
+7. **Save the report to disk:**
+   - If `reportsDir` exists in loaded state → use it as default option
+   - `AskUserQuestion`: "Where to save the report?"
+     - Options: saved `reportsDir` or `/tmp/ai-fortune-reports/` (default, ephemeral), `~/.claude/ai-fortune/reports/` (persistent)
+     - If saved `reportsDir` matches one of the options, show it as first option with "(previous choice)" suffix
+   - `Bash`: `mkdir -p {chosen_dir}`
+   - Filename: `YYYY-MM-DD_HH-MM-SS.md` (current timestamp, e.g. `2026-03-01_14-30-45.md`)
+   - `Write` the complete report markdown to `{chosen_dir}/{filename}`
+   - Confirm: "Report saved to {chosen_dir}/{filename}"
+
+### Step 11: Save State
+
+1. Build state object:
+   ```json
+   {
+     "lastRun": "{ISO 8601 timestamp}",
+     "lastReportPath": "{full path to saved report from Step 10}",
+     "reportsDir": "{chosen directory from Step 10}",
+     "dataSources": {
+       "memoryFilePath": "{path from Step 1}",
+       "insightsReportPath": "{path from Step 2}"
+     },
+     "answers": {
+       "{question_key}": {
+         "value": "{answer text}",
+         "answeredAt": "{ISO 8601 timestamp}"
+       }
+     }
+   }
+   ```
+2. `Write` to `~/.claude/ai-fortune.json`
+3. Confirm: "State saved. Run `/ai-fortune` again anytime — it will remember your answers and skip recent ones."
+
+---
+
+## Error Handling
+
+- **Missing data source**: Note as "❌ {source}" in the Data Sources table, continue with remaining sources
+- **Script failure**: If parse-insights.py or aggregate-sessions.py fails, show stderr output, continue without that source
+- **Minimum viable report**: The report can be generated with just interview answers + web research (0 automated data sources). Quality improves with more sources.
+- **Web search failure**: If WebSearch is unavailable, note in the Industry AI Landscape section and provide analysis based on general knowledge
+
+---
+
+## Important Notes
+
+- **Auto-save**: The report is displayed in the terminal and saved to a user-chosen directory (default: `/tmp/ai-fortune-reports/`). The chosen directory is remembered for future runs.
+- **Privacy**: No data leaves the local machine except WebSearch queries (which use general terms, not personal data)
+- **Re-runnability**: Running `/ai-fortune` again will skip recent answers and use saved file paths
+- **Time estimate**: Full run with all sources takes ~5-10 minutes depending on interview length

--- a/plugins/ai-fortune/commands/ai-fortune/references/analysis-framework.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/analysis-framework.md
@@ -1,0 +1,117 @@
+# Analysis Framework
+
+## Risk Matrix (5 Dimensions)
+
+Rate each dimension 1-5 based on the user's profile data + interview answers.
+
+| Dimension | 1 (Low Risk) | 5 (High Risk) |
+|-----------|-------------|----------------|
+| **Task Repeatability** | Novel problems, unique context every time | Templated, pattern-based work |
+| **Human Judgment** | Ambiguous decisions, stakeholder politics | Clear right/wrong answers |
+| **Physical Presence** | Requires being physically there | Fully digital, remote-capable |
+| **Regulation/Trust** | Licensed, legal liability, fiduciary duty | No licenses, low-stakes output |
+| **Creative Synthesis** | Cross-domain innovation, taste-driven | Single-domain execution |
+
+### Scoring:
+- **LOW risk** (avg 1.0-2.0): Well-positioned, focus on amplifying with AI
+- **MODERATE risk** (avg 2.1-3.0): Some exposure, strategic upskilling needed
+- **HIGH risk** (avg 3.1-4.0): Significant exposure, consider pivot planning
+- **CRITICAL risk** (avg 4.1-5.0): Urgent action needed, many tasks automatable
+
+---
+
+## 7 AI-Resistant Career Properties
+
+Use these to evaluate recommended directions. A strong career direction should have 3+ of these properties.
+
+1. **Accountability bearing** — Someone must be legally/professionally responsible for outcomes. AI can advise but can't sign off. (Doctors, lawyers, auditors, licensed engineers)
+
+2. **Relationship-dependent** — Trust built over years that can't be transferred to an algorithm. (Sales to enterprise clients, therapists, executive coaches, account managers)
+
+3. **Intense context-switching** — Navigating multi-stakeholder environments where political/social dynamics matter as much as technical correctness. (Product managers, CTOs, diplomatic roles)
+
+4. **Physical embodiment** — Physical presence, manual dexterity, or sensory judgment required. (Surgeons, electricians, chefs, field engineers)
+
+5. **Regulatory barriers** — Licenses, certifications, security clearances that legally restrict who can do the work. (CPAs, medical professionals, classified-environment engineers)
+
+6. **Taste/judgment** — Success depends on subjective quality assessment that resists quantification. (Design directors, creative directors, editors, curators)
+
+7. **Novel problem space** — Working on frontier problems where training data doesn't yet exist. (Cutting-edge research, emerging market strategy, novel technology integration)
+
+---
+
+## AI Leverage Score (0-10)
+
+Measures how effectively the user **amplifies** their capabilities using AI, not how much they fear it.
+
+### Input signals:
+
+| Signal | Source | Weight |
+|--------|--------|--------|
+| Installed plugins count | settings.json | 1x |
+| Plugin sophistication (hooks, skills, presets) | plugin configs | 1x |
+| Session complexity (tool diversity per session) | session-meta | 2x |
+| Multi-clauding % | insights report | 1x |
+| Task agent usage % | session-meta | 2x |
+| Tool error recovery (errors vs successful outcomes) | session-meta + facets | 1x |
+| Delegation maturity level | computed below | 2x |
+
+### Scoring formula:
+```
+raw = sum(normalized_signal * weight) / total_weight
+score = round(raw * 10)
+```
+
+### Interpretation:
+- **1-3**: Beginner — using AI as enhanced search/autocomplete
+- **4-5**: Practitioner — AI handles defined tasks, user drives flow
+- **6-7**: Power User — multi-step delegation, custom workflows
+- **8-9**: Orchestrator — parallel sessions, meta-learning, plugin ecosystem
+- **10**: Architect — AI operates as autonomous extension of user's intent
+
+---
+
+## Delegation Maturity Model
+
+Based on insights report data patterns:
+
+| Level | Name | Session Indicators |
+|-------|------|-------------------|
+| 1 | **Q&A** | Quick Question sessions dominate, few tool calls, short sessions |
+| 2 | **Copilot** | Single Task sessions, code + debug, moderate tool usage |
+| 3 | **Executor** | Multi Task sessions, plan-driven, PR lifecycle management |
+| 4 | **Orchestrator** | Parallel sessions (multi-clauding), task agents, batch PR operations |
+| 5 | **Architect** | Custom presets/plugins, self-healing loops, meta-learning feedback |
+
+### Detection rules:
+- Level 1: >50% Quick Question sessions, avg <3 tool calls/session
+- Level 2: >40% Single Task, tool diversity <5 types
+- Level 3: >30% Multi Task OR Iterative Refinement, uses TaskCreate
+- Level 4: Multi-clauding >10%, uses_task_agent >20%, >3 projects/week
+- Level 5: Custom plugins installed, >5 tool types avg, meta-learning patterns in insights
+
+### Evidence gathering:
+- Session types from insights → base level
+- Tool distribution from session-meta → complexity indicator
+- Multi-clauding stats from insights → parallel capability
+- Plugin list from settings → customization depth
+- Friction patterns → learning/adaptation behavior
+
+---
+
+## Contrastive Analysis
+
+Compare self-reported data (interview) vs observed data (sessions/insights):
+
+| Aspect | Self-Reported Source | Observed Source | Look For |
+|--------|---------------------|----------------|----------|
+| AI dependency | Q5 interview | session frequency, tool calls | Under/over-estimation |
+| Role focus | Q2 daily tasks | project_areas, what_you_wanted | Discrepancy in time allocation |
+| Strengths | Q3, Q10 interview | whats_working, impressive_things | Blind spots or unrecognized strengths |
+| Weaknesses | Q6 predictions | friction_categories, tool_errors | Denial or over-worry |
+| Career direction | Q13 satisfaction | session diversity, new tool adoption | Stagnation vs active exploration |
+
+### How to present:
+- If data confirms self-report → reinforce with evidence
+- If data contradicts → present gently: "Your sessions suggest X, though you described Y — this gap is worth exploring"
+- If data reveals unmentioned strength → highlight as "hidden advantage"

--- a/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
@@ -1,0 +1,175 @@
+# Interview Question Bank
+
+Questions are organized by tier. Each question specifies:
+- `key`: persistent storage key in `~/.claude/ai-fortune.json`
+- `type`: `free_text` or `multiple_choice`
+- `options`: for MC questions (used with AskUserQuestion)
+- `skip_if_data`: data source fields that can answer this question automatically
+- `tier`: determines whether the question is always asked or adaptive
+
+---
+
+## Tier 1: Role & Industry (always ask)
+
+### Q1: Current Role & Industry
+- **key:** `current_role`
+- **type:** `free_text`
+- **prompt:** "What is your current job title and industry? (e.g., 'Software Engineer, FinTech')"
+- **skip_if_data:** memory file may contain role/industry context
+
+### Q2: Typical Workday Breakdown
+- **key:** `daily_tasks`
+- **type:** `free_text`
+- **prompt:** "How does your typical workday break down by activity? (e.g., '40% coding, 20% architecture, 20% meetings, 10% debugging, 10% docs')"
+- **skip_if_data:** none (subjective)
+
+### Q3: Core Value to Team
+- **key:** `core_value`
+- **type:** `free_text`
+- **prompt:** "What is the single most important thing you bring to your team that would be hardest to replace?"
+- **skip_if_data:** none (subjective)
+
+---
+
+## Tier 2: AI Context (always ask)
+
+### Q4: AI Adoption at Organization
+- **key:** `org_ai_adoption`
+- **type:** `multiple_choice`
+- **prompt:** "How widely is AI adopted in your organization?"
+- **options:**
+  - "Widely adopted — most teams use AI tools daily"
+  - "Early adoption — several teams experimenting"
+  - "Pilot stage — one or two teams testing"
+  - "Not adopted — no formal AI initiatives"
+  - "Actively resisted — organizational pushback"
+
+### Q5: Personal AI Dependency
+- **key:** `ai_dependency`
+- **type:** `multiple_choice`
+- **prompt:** "How dependent is your daily work on AI tools?"
+- **options:**
+  - "Essential — can't imagine working without AI"
+  - "Significant — AI handles 30%+ of my work"
+  - "Occasional — use AI for specific tasks"
+  - "Rarely — tried but not integrated"
+  - "Never — don't use AI tools"
+
+### Q6: AI Replacement Predictions
+- **key:** `ai_replacement_2yr`
+- **type:** `free_text`
+- **prompt:** "Which specific tasks in YOUR role do you think AI will handle within 2 years?"
+- **skip_if_data:** none (subjective prediction)
+
+---
+
+## Tier 3: Career Context (adaptive — skip if data available)
+
+### Q7: Years of Experience
+- **key:** `years_experience`
+- **type:** `multiple_choice`
+- **prompt:** "How many years of professional experience do you have?"
+- **options:**
+  - "0-2 years (early career)"
+  - "3-5 years (mid-level)"
+  - "6-10 years (senior)"
+  - "11-20 years (staff/principal)"
+  - "20+ years (veteran)"
+- **skip_if_data:** memory file may mention experience level
+
+### Q8: Management vs IC
+- **key:** `management_vs_ic`
+- **type:** `multiple_choice`
+- **prompt:** "What best describes your current role?"
+- **options:**
+  - "Team lead (IC + some management)"
+  - "Manager/Director (primarily people management)"
+  - "Individual Contributor (no direct reports)"
+  - "Mixed (varies by project)"
+
+### Q9: Client-facing vs Back-office
+- **key:** `client_facing`
+- **type:** `multiple_choice`
+- **prompt:** "How much of your work is client/customer-facing?"
+- **options:**
+  - "Primarily client-facing (sales, consulting, support)"
+  - "Mixed (some client interaction)"
+  - "Primarily back-office (internal tools, infrastructure)"
+  - "Fully internal (no external stakeholders)"
+
+---
+
+## Tier 4: Differentiators (always ask)
+
+### Q10: Domain Expertise
+- **key:** `domain_expertise`
+- **type:** `free_text`
+- **prompt:** "What specialized domain knowledge or expertise do you have that would be hard for AI to replicate? (e.g., regulatory knowledge, industry relationships, proprietary systems)"
+- **skip_if_data:** none
+
+### Q11: Creative vs Operational
+- **key:** `creative_vs_operational`
+- **type:** `multiple_choice`
+- **prompt:** "Where does most of your value come from?"
+- **options:**
+  - "Creative/strategic — designing solutions to novel problems"
+  - "Balanced — mix of creative and operational"
+  - "Operational — executing well-defined processes efficiently"
+  - "Interpersonal — relationships, negotiation, persuasion"
+
+### Q12: Physical Presence Requirements
+- **key:** `physical_presence`
+- **type:** `multiple_choice`
+- **prompt:** "Does your role require physical presence?"
+- **options:**
+  - "Fully remote — everything is digital"
+  - "Occasionally in-person (meetings, events)"
+  - "Regularly in-person (lab, manufacturing, site visits)"
+  - "Always in-person (hands-on work, equipment)"
+
+---
+
+## Tier 5: Aspirations (always ask)
+
+### Q13: Career Satisfaction & Direction
+- **key:** `career_satisfaction`
+- **type:** `multiple_choice`
+- **prompt:** "How do you feel about your current career trajectory?"
+- **options:**
+  - "Want to deepen — love what I do, want to go deeper"
+  - "Open to change — happy but curious about alternatives"
+  - "Considering pivot — actively exploring other paths"
+  - "Need change — current path feels unsustainable"
+
+### Q14: Risk Tolerance
+- **key:** `risk_tolerance`
+- **type:** `multiple_choice`
+- **prompt:** "What's your tolerance for career risk?"
+- **options:**
+  - "Conservative — prefer stability, incremental moves"
+  - "Moderate — willing to take calculated risks"
+  - "Aggressive — ready for bold moves if upside is clear"
+
+### Q15: Constraints on Pivot
+- **key:** `pivot_constraints`
+- **type:** `free_text`
+- **prompt:** "What constraints would limit a career pivot? (e.g., geographic, financial, family, language, visa, industry certifications)"
+- **skip_if_data:** none
+
+---
+
+## Adaptive Logic
+
+### Auto-skip rules:
+- If memory file reveals industry → mark Q1 as partially answered, confirm rather than ask fresh
+- If session data shows heavy task-agent usage → Q5 can be pre-filled as "Essential/Significant"
+- If technology-explainer config exists → skip tech-related parts of Q10
+
+### Re-ask rules (persistent state):
+- Answer < 6 months old → skip question, show "Using your previous answer from {date}: {value}"
+- Answer >= 6 months old → re-ask with previous value as default option (first option + "(previous answer)" suffix)
+- No previous answer → ask normally
+
+### Tier 3 collapse:
+- If user shows impatience (quick "skip" or "Other" answers) → collapse remaining Tier 3 questions
+- Detect via: 2+ consecutive minimal answers

--- a/plugins/ai-fortune/commands/ai-fortune/references/report-template.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/report-template.md
@@ -1,0 +1,180 @@
+# Report Template
+
+Generate the report following this exact structure. All sections are mandatory unless marked (conditional).
+Display the report in the terminal, then save it to the user-chosen directory (see SKILL.md Step 10 for details).
+
+---
+
+## Structure
+
+```
+# Career Direction Report
+
+Generated: {date} | Sources: {N}/8 used
+
+---
+
+## Your Profile
+
+**Role:** {title} | **Industry:** {industry} | **Experience:** {years}
+**AI Adoption at org:** {level} | **Personal AI dependency:** {level}
+
+**Technology Proficiency Map** (from technology-explainer):
+- Expert: {list}
+- Intermediate: {list}
+- Learning: {list}
+
+**Key strengths from data:**
+- {data-derived strength 1}
+- {data-derived strength 2}
+- {interview-derived strength 3}
+
+---
+
+## AI Leverage Profile
+
+**AI Leverage Score: {X}/10** — {interpretation}
+**Delegation Maturity: Level {N} — {name}** — {evidence}
+
+**Your AI work style:** {narrative from insights — e.g., "plan-driven power user,
+aggressive interruptor, meta-learning feedback loop builder"}
+
+**What you delegate to AI best:**
+- {top delegated task patterns from session data}
+
+**Where AI gets in your way:**
+- {friction patterns from insights}
+
+---
+
+## Risk Assessment: Your Current Path
+
+**Overall AI displacement risk: {LOW / MODERATE / HIGH / CRITICAL}**
+
+| Dimension | Score (1-5) | Evidence |
+|-----------|-------------|----------|
+| Task Repeatability | {stars} | {evidence from data + interview} |
+| Human Judgment | {stars} | {evidence} |
+| Physical Presence | {stars} | {evidence} |
+| Regulatory/Trust | {stars} | {evidence} |
+| Creative Synthesis | {stars} | {evidence} |
+
+**Timeline:** {when AI can handle core functions of this role}
+
+**What AI WILL handle in your role within 2 years:**
+- {task 1} — {why, with evidence}
+
+**What AI will NOT handle:**
+- {task 1} — {why, linked to AI-resistant properties}
+
+---
+
+## Industry AI Landscape (web research)
+
+{Current state of AI in user's specific industry from WebSearch —
+concrete products, startups, trends 2025-2026.
+Cite specific companies and tools, not vague generalities.}
+
+---
+
+## Recommended Directions (3-4 options)
+
+### Direction 1: {Title}
+
+**One-liner:** {value proposition}
+**Fit score:** {X}/10
+
+**Why this fits YOU specifically:**
+{2-3 sentences linking to user's profile data — not generic advice.
+Reference specific skills, experience, and AI leverage patterns.}
+
+**Why AI won't replace this (long-term):**
+{2-3 sentences referencing specific AI-resistant properties from the framework.
+Explain which of the 7 properties apply and why.}
+
+**Skills bridge:**
+| Already Have | Need to Acquire | How to Get |
+|-------------|-----------------|------------|
+| {skill from data} | {skill gap} | {specific resource/course/path} |
+
+**Transition timeline:** {realistic estimate with milestones}
+**Industry evidence:** {web search findings supporting this direction}
+**Salary range:** {from web search, with geographic context}
+
+### Direction 2-4: {same structure}
+
+---
+
+## Your Unique Edge: The AI Orchestrator Advantage
+(conditional: only for users with AI Leverage Score >= 7)
+
+{Section explaining that the ability to effectively orchestrate AI
+is itself a rare and valuable skill. Reference specific evidence:
+- Number and sophistication of installed plugins
+- Session complexity patterns
+- Delegation maturity level
+- Multi-clauding behavior
+- Meta-learning patterns
+
+Frame this as a competitive moat: while most people struggle to
+use AI at Level 1-2, this user operates at Level 4-5, which is
+itself a career differentiator.}
+
+---
+
+## Action Plan
+
+### Next 30 days
+- {concrete action 1 with specific resource/link}
+- {concrete action 2}
+- {concrete action 3}
+
+### Next 6 months
+- {milestone 1}
+- {milestone 2}
+
+### Next 1-2 years
+- {target state}
+- {measurable outcome}
+
+---
+
+## Blind Spots & Honest Assessment
+
+{Honest section about weaknesses found in the data:
+- Technology gaps (learning-level technologies from technology-explainer)
+- Friction patterns (what frustrates the user about AI — may indicate
+  areas where they need to adapt rather than resist)
+- Over-reliance risks (if AI Leverage Score is very high,
+  what happens if AI tools become unavailable or change?)
+- Skill gaps between current role and recommended directions
+- Contrastive analysis findings (self-reported vs observed discrepancies)}
+
+---
+
+## Data Sources Used
+
+| Source | Status | Key Insight |
+|--------|--------|-------------|
+| Memory Chat File | {check/cross} | {one-line summary} |
+| CC Insights Report | {check/cross} | {summary} |
+| Session Metadata ({N}d) | {check/cross} | {N sessions, M projects} |
+| Technology Explainer | {check/cross} | {expert/intermediate/learning counts} |
+| Stats Cache | {check/cross} | {summary} |
+| Installed Plugins | {check/cross} | {N plugins} |
+| Web Research | {check/cross} | {N searches} |
+| Interview | {check/cross} | {N questions answered} |
+```
+
+---
+
+## Formatting Rules
+
+- Use stars (e.g., `⭐⭐⭐`) for risk dimension scores
+- Use checkmarks (✅) and crosses (❌) for data source status
+- Keep each direction's analysis to ~150-200 words
+- Bold key findings and scores
+- Use tables for structured comparisons
+- Keep action items specific and actionable (not vague "learn more about X")
+- Salary ranges should include currency and geography
+- All evidence claims should reference which data source they come from

--- a/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
@@ -1,0 +1,297 @@
+# AI Fortune Acceptance Tests
+
+## Purpose
+
+The ai-fortune plugin generates personalized career direction reports based on AI usage data and an adaptive interview. Acceptance tests verify that scripts parse data correctly, the command orchestrates all phases, and the report generates even with missing data sources.
+
+Critical components to test:
+- `parse-insights.py` (HTML → JSON extraction)
+- `aggregate-sessions.py` (session metadata aggregation)
+- `/ai-fortune` command (full orchestration flow)
+- Persistent state (save/load `~/.claude/ai-fortune.json`)
+- Graceful degradation (missing sources)
+
+## Test Execution Order
+
+1. Static checks (automated)
+2. parse-insights.py tests (automated)
+3. aggregate-sessions.py tests (automated)
+4. Data access tests (automated)
+5. Full flow (manual)
+6. Graceful degradation (manual)
+
+## Automation Status
+
+- ✅ Fully automated: Tests 1, 2, 3, 4
+- ⚠️ Manual only: Tests 5, 6 (require interactive interview + report quality review)
+
+## Automated Test Results (Last Run)
+
+| Test | Status | Notes |
+|------|--------|-------|
+| 1.1 plugin.json valid | | |
+| 1.2 SKILL.md frontmatter | | |
+| 1.3 Scripts compile | | |
+| 2.1 parse-insights.py with real report | | |
+| 2.2 parse-insights.py missing file | | |
+| 3.1 aggregate-sessions.py --days 7 | | |
+| 3.2 aggregate-sessions.py --days 0 | | |
+| 4.1 settings.json readable | | |
+| 4.2 technology-explainer.json readable | | |
+| 4.3 session-meta directory exists | | |
+
+---
+
+## Test Categories
+
+### 1. Static Checks
+
+**Objective:** Verify file structure, JSON validity, script compilation, and SKILL.md frontmatter.
+
+**Automation:** ✅
+
+**Steps:**
+```bash
+PLUGIN="plugins/ai-fortune"
+
+# 1.1 plugin.json is valid JSON with required fields
+python3 -c "
+import json, sys
+with open('$PLUGIN/.claude-plugin/plugin.json') as f:
+    p = json.load(f)
+assert p['name'] == 'ai-fortune', f'wrong name: {p[\"name\"]}'
+assert p['version'] == '0.1.0', f'wrong version: {p[\"version\"]}'
+assert 'commands' in p, 'missing commands field'
+print('plugin.json: OK')
+"
+
+# 1.2 SKILL.md has valid YAML frontmatter
+python3 -c "
+import re
+with open('$PLUGIN/commands/ai-fortune/SKILL.md') as f:
+    content = f.read()
+assert content.startswith('---'), 'Missing YAML frontmatter delimiter'
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'Incomplete frontmatter'
+fm = parts[1]
+assert 'name:' in fm, 'Missing name in frontmatter'
+assert 'description:' in fm, 'Missing description in frontmatter'
+print('SKILL.md frontmatter: OK')
+"
+
+# 1.3 Python scripts compile without errors
+python3 -m py_compile $PLUGIN/scripts/parse-insights.py && echo "parse-insights.py: OK"
+python3 -m py_compile $PLUGIN/scripts/aggregate-sessions.py && echo "aggregate-sessions.py: OK"
+
+# 1.4 templates/ai-fortune.json is valid JSON
+python3 -c "import json; json.load(open('$PLUGIN/templates/ai-fortune.json'))" && echo "template: OK"
+
+# 1.5 Reference files exist
+for f in interview-questions.md analysis-framework.md report-template.md; do
+  test -f "$PLUGIN/commands/ai-fortune/references/$f" && echo "$f: OK" || echo "$f: MISSING"
+done
+```
+
+**Expected:**
+- ✅ All checks pass
+- ✅ plugin.json has name `ai-fortune`, version `0.1.0`
+- ✅ SKILL.md starts with `---` and has `name:` + `description:` in frontmatter
+- ✅ Both scripts compile without errors
+
+### 2. parse-insights.py
+
+**Objective:** Verify HTML parsing extracts expected data structure from real report.
+
+**Automation:** ✅
+
+**Steps:**
+```bash
+PLUGIN="plugins/ai-fortune"
+REPORT="$HOME/.claude/usage-data/report.html"
+
+# 2.1 Parse real report — check output is valid JSON with expected keys
+python3 $PLUGIN/scripts/parse-insights.py "$REPORT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+required = ['stats', 'project_areas', 'top_tools', 'languages', 'session_types', 'usage_narrative']
+missing = [k for k in required if k not in data]
+assert not missing, f'Missing keys: {missing}'
+assert len(data['project_areas']) > 0, 'No project areas extracted'
+assert len(data['top_tools']) > 0, 'No tools extracted'
+assert data['stats'].get('messages', 0) > 0, 'No message count in stats'
+print(f'parse-insights OK: {len(data[\"project_areas\"])} areas, {len(data[\"top_tools\"])} tools, {data[\"stats\"][\"messages\"]} messages')
+"
+
+# 2.2 Missing file — should exit 1 with error message
+python3 $PLUGIN/scripts/parse-insights.py /nonexistent/file.html 2>&1; echo "exit: $?"
+# Expected: stderr contains "Error: file not found", exit code 1
+```
+
+**Expected:**
+- ✅ 2.1: Valid JSON output with `stats`, `project_areas`, `top_tools`, `languages`, `session_types`, `usage_narrative`
+- ✅ 2.2: Exit code 1, stderr message about missing file
+
+### 3. aggregate-sessions.py
+
+**Objective:** Verify session metadata aggregation with different time windows.
+
+**Automation:** ✅
+
+**Steps:**
+```bash
+PLUGIN="plugins/ai-fortune"
+
+# 3.1 Aggregate last 7 days — check output structure
+python3 $PLUGIN/scripts/aggregate-sessions.py --days 7 | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+required = ['sessions_total', 'projects', 'tool_distribution', 'complexity_indicators', 'averages']
+missing = [k for k in required if k not in data]
+assert not missing, f'Missing keys: {missing}'
+assert data['period_days'] == 7
+assert isinstance(data['projects'], list)
+assert isinstance(data['complexity_indicators'], dict)
+print(f'aggregate OK: {data[\"sessions_total\"]} sessions, {len(data[\"projects\"])} projects')
+"
+
+# 3.2 Aggregate 0 days — should return 0 sessions with empty lists
+python3 $PLUGIN/scripts/aggregate-sessions.py --days 0 | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+assert data['sessions_total'] == 0, f'Expected 0 sessions, got {data[\"sessions_total\"]}'
+assert data['averages']['messages_per_session'] == 0
+print('aggregate --days 0: OK (0 sessions)')
+"
+```
+
+**Expected:**
+- ✅ 3.1: Valid JSON with `sessions_total > 0`, non-empty `projects` and `tool_distribution`
+- ✅ 3.2: `sessions_total == 0`, all averages are 0
+
+### 4. Data Access Tests
+
+**Objective:** Verify the command can access required data sources.
+
+**Automation:** ✅
+
+**Steps:**
+```bash
+# 4.1 settings.json exists and has enabledPlugins
+python3 -c "
+import json
+with open('$HOME/.claude/settings.json') as f:
+    s = json.load(f)
+plugins = s.get('enabledPlugins', s.get('projects', {}).get('*', {}).get('enabledPlugins', []))
+print(f'settings.json: {len(plugins)} plugins found')
+"
+
+# 4.2 technology-explainer.json (optional)
+python3 -c "
+import json, os
+path = os.path.expanduser('~/.claude/technology-explainer.json')
+if os.path.exists(path):
+    with open(path) as f:
+        t = json.load(f)
+    techs = t.get('technologies', {})
+    print(f'technology-explainer: {len(techs)} technologies configured')
+else:
+    print('technology-explainer: not found (optional)')
+"
+
+# 4.3 session-meta directory has files
+python3 -c "
+import os
+d = os.path.expanduser('~/.claude/usage-data/session-meta')
+if os.path.isdir(d):
+    files = [f for f in os.listdir(d) if f.endswith('.json')]
+    print(f'session-meta: {len(files)} files')
+else:
+    print('session-meta: directory not found')
+"
+```
+
+**Expected:**
+- ✅ 4.1: `settings.json` readable, reports plugin count
+- ✅ 4.2: Reports technology count or "not found (optional)"
+- ✅ 4.3: Reports session file count
+
+### 5. Full Flow (Manual)
+
+**Objective:** Verify end-to-end `/ai-fortune` command execution.
+
+**Automation:** ⚠️ Manual
+
+**Procedure:**
+1. Start fresh Claude Code session
+2. Run `/ai-fortune`
+3. Verify Phase 1 data collection:
+   - Asks for memory file path (or uses saved)
+   - Asks for insights report path (or uses saved)
+   - Runs both Python scripts successfully
+   - Reads technology-explainer, settings, stats-cache
+4. Verify Phase 2 interview:
+   - Shows previous answers for questions < 6 months old
+   - Re-asks questions >= 6 months old with previous answer as default
+   - Skips questions answerable from data
+   - Uses `AskUserQuestion` with proper options
+5. Verify Phase 3 report:
+   - Runs 3-5 WebSearch queries
+   - Generates report matching template structure
+   - Report includes all completed sections
+   - Report displays in terminal (not saved to disk)
+6. Verify state saved to `~/.claude/ai-fortune.json`
+
+**Outcomes:**
+
+| Step | Expected | Actual |
+|------|----------|--------|
+| Data collection | All available sources read | |
+| Interview | 10-15 questions, adaptive logic works | |
+| Web research | 3-5 searches executed | |
+| Report | Full structure, evidence-based | |
+| State save | File written with answers + paths | |
+
+### 6. Graceful Degradation (Manual)
+
+**Objective:** Verify the report generates even when most data sources are missing.
+
+**Automation:** ⚠️ Manual
+
+**Procedure:**
+1. Temporarily rename `~/.claude/usage-data/report.html`
+2. Temporarily rename `~/.claude/technology-explainer.json`
+3. Run `/ai-fortune`, skip memory file
+4. Verify:
+   - Script failures noted but don't crash the flow
+   - Interview runs normally
+   - Report generates with available data
+   - Data Sources table shows ❌ for missing sources
+5. Restore renamed files
+
+---
+
+## Regression Testing Guide
+
+### When to run:
+- After modifying `parse-insights.py` or `aggregate-sessions.py`
+- After changing SKILL.md orchestration flow
+- After changing interview-questions.md
+- After updating report-template.md or analysis-framework.md
+
+### Quick automated suite:
+```bash
+PLUGIN="plugins/ai-fortune"
+echo "=== Static Checks ==="
+python3 -c "import json; json.load(open('$PLUGIN/.claude-plugin/plugin.json'))" && echo "PASS: plugin.json"
+python3 -m py_compile $PLUGIN/scripts/parse-insights.py && echo "PASS: parse-insights.py compiles"
+python3 -m py_compile $PLUGIN/scripts/aggregate-sessions.py && echo "PASS: aggregate-sessions.py compiles"
+
+echo "=== Script Tests ==="
+python3 $PLUGIN/scripts/parse-insights.py ~/.claude/usage-data/report.html > /dev/null && echo "PASS: parse-insights"
+python3 $PLUGIN/scripts/aggregate-sessions.py --days 7 > /dev/null && echo "PASS: aggregate-sessions"
+python3 $PLUGIN/scripts/aggregate-sessions.py --days 0 | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['sessions_total']==0" && echo "PASS: aggregate-sessions --days 0"
+```
+
+### Expected success rate:
+- Automated tests: 100% (all should pass)
+- Manual tests: Dependent on available data sources; minimum viable with just interview

--- a/plugins/ai-fortune/scripts/aggregate-sessions.py
+++ b/plugins/ai-fortune/scripts/aggregate-sessions.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Aggregate Claude Code session metadata over a time window.
+
+Usage: python3 aggregate-sessions.py [--days N] [--dir PATH]
+Output: JSON to stdout
+
+Reads session-meta/*.json from ~/.claude/usage-data/ by default.
+Filters by start_time within the last N days (default: 7).
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def parse_iso(s):
+    """Parse ISO 8601 timestamp string to datetime (UTC)."""
+    # Handle Z suffix
+    s = s.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Aggregate Claude Code session metadata")
+    parser.add_argument("--days", type=int, default=7, help="Number of days to look back (default: 7)")
+    parser.add_argument("--dir", type=str, default=None, help="Path to session-meta directory")
+    args = parser.parse_args()
+
+    # Determine session-meta directory
+    if args.dir:
+        meta_dir = Path(args.dir)
+    else:
+        meta_dir = Path.home() / ".claude" / "usage-data" / "session-meta"
+
+    if not meta_dir.is_dir():
+        print(f"Error: directory not found: {meta_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=args.days)
+
+    # Aggregate counters
+    sessions = []
+    projects = Counter()
+    tool_dist = Counter()
+    lang_dist = Counter()
+    total_lines_added = 0
+    total_lines_removed = 0
+    total_files_modified = 0
+    total_messages_user = 0
+    total_messages_assistant = 0
+    total_duration = 0
+    total_input_tokens = 0
+    total_output_tokens = 0
+    total_commits = 0
+    total_pushes = 0
+    total_tool_errors = 0
+    tool_error_cats = Counter()
+    uses_task_agent = 0
+    uses_mcp = 0
+    uses_web_search = 0
+    uses_web_fetch = 0
+    total_interruptions = 0
+    hour_dist = Counter()
+    first_prompts = []
+    session_types = Counter()
+
+    # Read facets for session types
+    facets_dir = meta_dir.parent / "facets"
+    facets = {}
+    if facets_dir.is_dir():
+        for fp in facets_dir.glob("*.json"):
+            try:
+                with open(fp, "r", encoding="utf-8") as f:
+                    facet = json.load(f)
+                    sid = facet.get("session_id")
+                    if sid:
+                        facets[sid] = facet
+            except (json.JSONDecodeError, IOError):
+                continue
+
+    # Process session files
+    json_files = list(meta_dir.glob("*.json"))
+    for fp in json_files:
+        try:
+            with open(fp, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            continue
+
+        start = parse_iso(data.get("start_time", ""))
+        if not start or start < cutoff:
+            continue
+
+        sessions.append(data)
+
+        # Project
+        proj = data.get("project_path", "unknown")
+        # Shorten to last 2 path components
+        parts = proj.rstrip("/").split("/")
+        short_proj = "/".join(parts[-2:]) if len(parts) >= 2 else proj
+        projects[short_proj] += 1
+
+        # Tools
+        for tool, count in data.get("tool_counts", {}).items():
+            tool_dist[tool] += count
+
+        # Languages
+        for lang, count in data.get("languages", {}).items():
+            lang_dist[lang] += count
+
+        # Numeric aggregates
+        total_lines_added += data.get("lines_added", 0)
+        total_lines_removed += data.get("lines_removed", 0)
+        total_files_modified += data.get("files_modified", 0)
+        total_messages_user += data.get("user_message_count", 0)
+        total_messages_assistant += data.get("assistant_message_count", 0)
+        total_duration += data.get("duration_minutes", 0)
+        total_input_tokens += data.get("input_tokens", 0)
+        total_output_tokens += data.get("output_tokens", 0)
+        total_commits += data.get("git_commits", 0)
+        total_pushes += data.get("git_pushes", 0)
+        total_tool_errors += data.get("tool_errors", 0)
+        total_interruptions += data.get("user_interruptions", 0)
+
+        # Tool error categories
+        for cat, cnt in data.get("tool_error_categories", {}).items():
+            tool_error_cats[cat] += cnt
+
+        # Feature usage booleans
+        if data.get("uses_task_agent"):
+            uses_task_agent += 1
+        if data.get("uses_mcp"):
+            uses_mcp += 1
+        if data.get("uses_web_search"):
+            uses_web_search += 1
+        if data.get("uses_web_fetch"):
+            uses_web_fetch += 1
+
+        # Hour distribution
+        for h in data.get("message_hours", []):
+            hour_dist[h] += 1
+
+        # First prompts
+        fp_text = data.get("first_prompt", "")
+        if fp_text:
+            first_prompts.append(fp_text)
+
+        # Session type from facets
+        sid = data.get("session_id", "")
+        if sid in facets:
+            st = facets[sid].get("session_type", "unknown")
+            session_types[st] += 1
+
+    # Build result
+    n = len(sessions)
+    result = {
+        "period_days": args.days,
+        "sessions_total": n,
+        "projects": [{"path": p, "sessions": c} for p, c in projects.most_common()],
+        "tool_distribution": [{"tool": t, "count": c} for t, c in tool_dist.most_common()],
+        "language_distribution": [{"language": l, "count": c} for l, c in lang_dist.most_common()],
+        "session_types": dict(session_types) if session_types else {},
+        "totals": {
+            "user_messages": total_messages_user,
+            "assistant_messages": total_messages_assistant,
+            "duration_minutes": total_duration,
+            "lines_added": total_lines_added,
+            "lines_removed": total_lines_removed,
+            "files_modified": total_files_modified,
+            "git_commits": total_commits,
+            "git_pushes": total_pushes,
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+            "tool_errors": total_tool_errors,
+            "user_interruptions": total_interruptions,
+        },
+        "averages": {
+            "messages_per_session": round(total_messages_user / n, 1) if n else 0,
+            "duration_minutes": round(total_duration / n, 1) if n else 0,
+            "lines_added_per_session": round(total_lines_added / n, 1) if n else 0,
+            "files_per_session": round(total_files_modified / n, 1) if n else 0,
+        },
+        "complexity_indicators": {
+            "task_agent_pct": round(uses_task_agent / n * 100, 1) if n else 0,
+            "mcp_pct": round(uses_mcp / n * 100, 1) if n else 0,
+            "web_search_pct": round(uses_web_search / n * 100, 1) if n else 0,
+            "web_fetch_pct": round(uses_web_fetch / n * 100, 1) if n else 0,
+        },
+        "tool_error_categories": dict(tool_error_cats.most_common()),
+        "time_distribution": {str(h): c for h, c in sorted(hour_dist.items())},
+        "first_prompts": first_prompts[:50],  # cap to avoid huge output
+    }
+
+    json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/ai-fortune/scripts/parse-insights.py
+++ b/plugins/ai-fortune/scripts/parse-insights.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""Parse Claude Code Insights report.html into structured JSON.
+
+Usage: python3 parse-insights.py <path-to-report.html>
+Output: JSON to stdout
+
+Uses only stdlib (re, html.parser) — no external dependencies.
+"""
+
+import json
+import re
+import sys
+from html.parser import HTMLParser
+
+
+class InsightsParser(HTMLParser):
+    """Stateful HTML parser that extracts structured data from the insights report."""
+
+    def __init__(self):
+        super().__init__()
+        self._result = {
+            "stats": {},
+            "project_areas": [],
+            "top_tools": [],
+            "what_you_wanted": [],
+            "languages": [],
+            "session_types": [],
+            "usage_narrative": "",
+            "key_insight": "",
+            "multi_clauding": {},
+            "response_time_distribution": [],
+            "whats_working": "",
+            "whats_hindering": "",
+            "quick_wins": "",
+            "ambitious_workflows": "",
+            "impressive_things": [],
+            "what_helped_most": [],
+            "outcomes": [],
+            "friction_categories": [],
+            "friction_types": [],
+            "satisfaction_distribution": [],
+            "horizon_cards": [],
+            "tool_errors": [],
+        }
+
+        # Parser state
+        self._tag_stack = []
+        self._class_stack = []
+        self._capture = None  # what we're currently capturing
+        self._text_buf = ""
+        self._current_item = {}
+        self._in_chart_card = False
+        self._chart_title = ""
+        self._current_bar = {}
+        self._current_section = ""
+        self._in_friction_cat = False
+        self._friction_examples = []
+        self._current_project_area = {}
+        self._in_big_win = False
+        self._current_horizon = {}
+        self._horizon_field = None
+        self._glance_field = None
+        self._in_narrative = False
+        self._narrative_parts = []
+        self._in_key_insight = False
+        self._multi_clauding_capture = None
+
+    def handle_starttag(self, tag, attrs):
+        attrs_dict = dict(attrs)
+        cls = attrs_dict.get("class", "")
+        tag_id = attrs_dict.get("id", "")
+
+        self._tag_stack.append(tag)
+        self._class_stack.append(cls)
+
+        # Track current section by h2 id
+        if tag == "h2" and tag_id.startswith("section-"):
+            self._current_section = tag_id
+
+        # Stats row
+        if "stat-value" in cls:
+            self._capture = "stat-value"
+            self._text_buf = ""
+        elif "stat-label" in cls:
+            self._capture = "stat-label"
+            self._text_buf = ""
+
+        # Project areas
+        elif "area-name" in cls:
+            self._capture = "area-name"
+            self._text_buf = ""
+        elif "area-count" in cls:
+            self._capture = "area-count"
+            self._text_buf = ""
+        elif "area-desc" in cls:
+            self._capture = "area-desc"
+            self._text_buf = ""
+
+        # Bar charts
+        elif "chart-title" in cls:
+            self._capture = "chart-title"
+            self._text_buf = ""
+        elif "bar-label" in cls:
+            self._capture = "bar-label"
+            self._text_buf = ""
+        elif "bar-fill" in cls:
+            style = attrs_dict.get("style", "")
+            width_match = re.search(r"width:\s*([\d.]+)%", style)
+            if width_match:
+                self._current_bar["pct"] = round(float(width_match.group(1)), 1)
+        elif "bar-value" in cls:
+            self._capture = "bar-value"
+            self._text_buf = ""
+
+        # Glance sections
+        elif "glance-section" in cls:
+            self._glance_field = None
+            self._text_buf = ""
+
+        # Narrative
+        elif "narrative" in cls and tag == "div":
+            self._in_narrative = True
+            self._narrative_parts = []
+        elif "key-insight" in cls:
+            self._in_key_insight = True
+            self._text_buf = ""
+
+        # Multi-clauding
+        elif tag == "div" and "font-size: 24px" in attrs_dict.get("style", "") and "color: #7c3aed" in attrs_dict.get("style", ""):
+            self._multi_clauding_capture = "value"
+            self._text_buf = ""
+        elif tag == "div" and "font-size: 11px" in attrs_dict.get("style", "") and "text-transform: uppercase" in attrs_dict.get("style", ""):
+            if self._multi_clauding_capture == "value":
+                self._multi_clauding_capture = "label"
+                self._text_buf = ""
+
+        # Big wins
+        elif "big-win" in cls and "big-wins" not in cls:
+            self._in_big_win = True
+            self._current_item = {}
+        elif "big-win-title" in cls:
+            self._capture = "big-win-title"
+            self._text_buf = ""
+        elif "big-win-desc" in cls:
+            self._capture = "big-win-desc"
+            self._text_buf = ""
+
+        # Friction categories
+        elif "friction-category" in cls and "friction-categories" not in cls:
+            self._in_friction_cat = True
+            self._current_item = {}
+            self._friction_examples = []
+        elif "friction-title" in cls:
+            self._capture = "friction-title"
+            self._text_buf = ""
+        elif "friction-desc" in cls:
+            self._capture = "friction-desc"
+            self._text_buf = ""
+        elif tag == "li" and self._in_friction_cat:
+            self._capture = "friction-example"
+            self._text_buf = ""
+
+        # Horizon cards
+        elif "horizon-card" in cls:
+            self._current_horizon = {}
+        elif "horizon-title" in cls:
+            self._capture = "horizon-title"
+            self._text_buf = ""
+        elif "horizon-possible" in cls:
+            self._capture = "horizon-possible"
+            self._text_buf = ""
+        elif "horizon-tip" in cls:
+            self._capture = "horizon-tip"
+            self._text_buf = ""
+
+        # Tool errors chart
+        elif "chart-title" in cls and self._current_section == "section-usage":
+            self._capture = "chart-title"
+            self._text_buf = ""
+
+        # Narrative paragraphs
+        if tag == "p" and self._in_narrative and "key-insight" not in cls:
+            self._capture = "narrative-p"
+            self._text_buf = ""
+
+    def handle_endtag(self, tag):
+        if self._tag_stack and self._tag_stack[-1] == tag:
+            self._tag_stack.pop()
+        if self._class_stack:
+            self._class_stack.pop()
+
+        # Finalize captures on close
+        text = self._text_buf.strip()
+
+        if self._capture == "stat-value" and tag == "div":
+            self._current_item["value"] = text
+            self._capture = None
+        elif self._capture == "stat-label" and tag == "div":
+            label = text.lower().replace("/", "_per_")
+            val = self._current_item.get("value", "")
+            # Parse stat values
+            if "/" in val and "+" in val:
+                # Lines: +36,321/-3,666
+                parts = val.split("/")
+                self._result["stats"]["lines_added"] = int(parts[0].replace("+", "").replace(",", ""))
+                self._result["stats"]["lines_removed"] = int(parts[1].replace("-", "").replace(",", ""))
+            else:
+                try:
+                    self._result["stats"][label] = float(val.replace(",", ""))
+                except ValueError:
+                    self._result["stats"][label] = val
+            self._current_item = {}
+            self._capture = None
+
+        elif self._capture == "area-name" and tag == "span":
+            self._current_project_area["name"] = text
+            self._capture = None
+        elif self._capture == "area-count" and tag == "span":
+            self._current_project_area["sessions"] = text
+            self._capture = None
+        elif self._capture == "area-desc" and tag == "div":
+            self._current_project_area["description"] = text
+            self._result["project_areas"].append(self._current_project_area)
+            self._current_project_area = {}
+            self._capture = None
+
+        elif self._capture == "chart-title" and tag == "div":
+            self._chart_title = text
+            self._capture = None
+        elif self._capture == "bar-label" and tag == "div":
+            self._current_bar["label"] = text
+            self._capture = None
+        elif self._capture == "bar-value" and tag == "div":
+            try:
+                self._current_bar["count"] = int(text)
+            except ValueError:
+                self._current_bar["count"] = text
+            # Route bar to the right list based on chart title
+            bar = dict(self._current_bar)
+            self._current_bar = {}
+            self._capture = None
+            self._route_bar(bar)
+
+        elif self._capture == "big-win-title" and tag == "div":
+            self._current_item["title"] = text
+            self._capture = None
+        elif self._capture == "big-win-desc" and tag == "div":
+            self._current_item["description"] = text
+            self._result["impressive_things"].append(self._current_item)
+            self._current_item = {}
+            self._in_big_win = False
+            self._capture = None
+
+        elif self._capture == "friction-title" and tag == "div":
+            self._current_item["title"] = text
+            self._capture = None
+        elif self._capture == "friction-desc" and tag == "div":
+            self._current_item["description"] = text
+            self._capture = None
+        elif self._capture == "friction-example" and tag == "li":
+            self._friction_examples.append(text)
+            self._capture = None
+
+        elif self._capture == "horizon-title" and tag == "div":
+            self._current_horizon["title"] = text
+            self._capture = None
+        elif self._capture == "horizon-possible" and tag == "div":
+            self._current_horizon["description"] = text
+            self._capture = None
+        elif self._capture == "horizon-tip" and tag == "div":
+            self._current_horizon["tip"] = text
+            self._capture = None
+
+        elif self._capture == "narrative-p" and tag == "p":
+            self._narrative_parts.append(text)
+            self._capture = None
+
+        # Close friction category
+        if tag == "div" and self._in_friction_cat and self._current_item.get("title"):
+            # Check if we're closing the friction-category div
+            cls_stack_text = " ".join(self._class_stack[-3:]) if len(self._class_stack) >= 3 else ""
+            if "friction-category" not in cls_stack_text or tag == "div":
+                # Try to detect friction-category close: when we have title + desc + maybe examples
+                if self._current_item.get("description"):
+                    self._current_item["examples"] = list(self._friction_examples)
+                    self._result["friction_categories"].append(self._current_item)
+                    self._current_item = {}
+                    self._friction_examples = []
+                    self._in_friction_cat = False
+
+        # Close horizon card
+        if tag == "div" and self._current_horizon.get("title") and self._current_horizon.get("description"):
+            if "tip" in self._current_horizon:
+                self._result["horizon_cards"].append(self._current_horizon)
+                self._current_horizon = {}
+
+        # Close narrative
+        if tag == "div" and self._in_narrative:
+            if not any("narrative" in c for c in self._class_stack):
+                self._in_narrative = False
+                self._result["usage_narrative"] = "\n\n".join(self._narrative_parts)
+
+        # Close key insight
+        if tag == "div" and self._in_key_insight:
+            self._result["key_insight"] = text
+            self._in_key_insight = False
+
+        # Multi-clauding label
+        if self._multi_clauding_capture == "label" and tag == "div":
+            label = text.lower().replace(" ", "_")
+            val = self._current_item.get("mc_value", "")
+            try:
+                if "%" in val:
+                    self._result["multi_clauding"][label] = val
+                else:
+                    self._result["multi_clauding"][label] = int(val)
+            except (ValueError, TypeError):
+                self._result["multi_clauding"][label] = val
+            self._multi_clauding_capture = None
+            self._current_item = {}
+
+    def handle_data(self, data):
+        if self._capture:
+            self._text_buf += data
+
+        # Glance sections: detect field from <strong> text
+        if self._glance_field is None and self._tag_stack and self._tag_stack[-1] == "strong":
+            d = data.strip().rstrip(":")
+            field_map = {
+                "What's working": "whats_working",
+                "What\u2019s working": "whats_working",
+                "What's hindering you": "whats_hindering",
+                "What\u2019s hindering you": "whats_hindering",
+                "Quick wins to try": "quick_wins",
+                "Ambitious workflows": "ambitious_workflows",
+            }
+            if d in field_map:
+                self._glance_field = field_map[d]
+                self._text_buf = ""
+                self._capture = "glance"
+
+        if self._capture == "glance":
+            self._text_buf += data
+
+        # Multi-clauding value
+        if self._multi_clauding_capture == "value":
+            self._current_item["mc_value"] = data.strip()
+            self._multi_clauding_capture = "value_done"
+        elif self._multi_clauding_capture == "label":
+            self._text_buf += data
+
+    def handle_entityref(self, name):
+        char = {"amp": "&", "lt": "<", "gt": ">", "quot": '"', "apos": "'", "mdash": "\u2014", "ndash": "\u2013"}.get(name, f"&{name};")
+        if self._capture:
+            self._text_buf += char
+
+    def handle_charref(self, name):
+        try:
+            char = chr(int(name, 16) if name.startswith("x") else int(name))
+        except (ValueError, OverflowError):
+            char = f"&#{name};"
+        if self._capture:
+            self._text_buf += char
+
+    def _route_bar(self, bar):
+        """Route a completed bar-chart row to the correct result list."""
+        title = self._chart_title.lower()
+        if "what you wanted" in title:
+            self._result["what_you_wanted"].append(bar)
+        elif "top tools" in title:
+            self._result["top_tools"].append(bar)
+        elif "languages" in title and "language" in title.lower():
+            self._result["languages"].append(bar)
+        elif "session type" in title:
+            self._result["session_types"].append(bar)
+        elif "what helped" in title:
+            self._result["what_helped_most"].append(bar)
+        elif "outcome" in title:
+            self._result["outcomes"].append(bar)
+        elif "friction" in title:
+            self._result["friction_types"].append(bar)
+        elif "satisfaction" in title:
+            self._result["satisfaction_distribution"].append(bar)
+        elif "tool error" in title:
+            self._result["tool_errors"].append(bar)
+        elif "response time" in title:
+            self._result["response_time_distribution"].append(bar)
+
+    def get_result(self):
+        return self._result
+
+
+def extract_glance_sections(html_text):
+    """Extract at-a-glance sections using regex as fallback."""
+    result = {}
+    pattern = r'<div class="glance-section"><strong>(.*?)</strong>\s*(.*?)\s*<a\s'
+    for match in re.finditer(pattern, html_text, re.DOTALL):
+        label = match.group(1).rstrip(":")
+        text = re.sub(r"<[^>]+>", "", match.group(2)).strip()
+        text = _decode_entities(text)
+        field_map = {
+            "What's working": "whats_working",
+            "What\u2019s working": "whats_working",
+            "What's hindering you": "whats_hindering",
+            "What\u2019s hindering you": "whats_hindering",
+            "Quick wins to try": "quick_wins",
+            "Ambitious workflows": "ambitious_workflows",
+        }
+        key = field_map.get(label)
+        if key:
+            result[key] = text
+    return result
+
+
+def extract_big_wins(html_text):
+    """Extract impressive things / big wins via regex."""
+    results = []
+    pattern = r'<div class="big-win-title">(.*?)</div>\s*<div class="big-win-desc">(.*?)</div>'
+    for m in re.finditer(pattern, html_text, re.DOTALL):
+        title = _decode_entities(re.sub(r"<[^>]+>", "", m.group(1)).strip())
+        desc = _decode_entities(re.sub(r"<[^>]+>", "", m.group(2)).strip())
+        results.append({"title": title, "description": desc})
+    return results
+
+
+def extract_multi_clauding(html_text):
+    """Extract multi-clauding stats via regex."""
+    result = {}
+    # Pattern: value divs with #7c3aed color followed by label divs
+    pattern = (
+        r'<div style="[^"]*font-size: 24px[^"]*color: #7c3aed[^"]*">(.*?)</div>'
+        r'\s*<div style="[^"]*font-size: 11px[^"]*text-transform: uppercase[^"]*">(.*?)</div>'
+    )
+    for m in re.finditer(pattern, html_text, re.DOTALL):
+        val = m.group(1).strip()
+        label = m.group(2).strip().lower().replace(" ", "_")
+        if "%" in val:
+            result[label] = val
+        else:
+            try:
+                result[label] = int(val.replace(",", ""))
+            except ValueError:
+                result[label] = val
+    return result
+
+
+def _decode_entities(text):
+    """Decode common HTML entities."""
+    text = text.replace("&amp;", "&")
+    text = text.replace("&quot;", '"')
+    text = text.replace("&#x27;", "'")
+    text = text.replace("&lt;", "<")
+    text = text.replace("&gt;", ">")
+    text = text.replace("&mdash;", "\u2014")
+    text = text.replace("&ndash;", "\u2013")
+    return text
+
+
+def extract_subtitle(html_text):
+    """Extract subtitle stats: messages, sessions, days, date range."""
+    m = re.search(r'class="subtitle">(.*?)</p>', html_text, re.DOTALL)
+    if not m:
+        return {}
+    text = m.group(1).strip()
+    result = {}
+    msgs = re.search(r"([\d,]+)\s+messages", text)
+    if msgs:
+        result["messages"] = int(msgs.group(1).replace(",", ""))
+    sess = re.search(r"across\s+([\d,]+)\s+sessions", text)
+    if sess:
+        result["sessions_analyzed"] = int(sess.group(1).replace(",", ""))
+    total = re.search(r"\(([\d,]+)\s+total\)", text)
+    if total:
+        result["sessions_total"] = int(total.group(1).replace(",", ""))
+    dates = re.search(r"\|\s*(\d{4}-\d{2}-\d{2})\s+to\s+(\d{4}-\d{2}-\d{2})", text)
+    if dates:
+        result["date_from"] = dates.group(1)
+        result["date_to"] = dates.group(2)
+    return result
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: parse-insights.py <path-to-report.html>", file=sys.stderr)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            html_text = f.read()
+    except FileNotFoundError:
+        print(f"Error: file not found: {filepath}", file=sys.stderr)
+        sys.exit(1)
+    except IOError as e:
+        print(f"Error reading file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse with HTML parser
+    parser = InsightsParser()
+    parser.feed(html_text)
+    result = parser.get_result()
+
+    # Merge subtitle stats
+    subtitle = extract_subtitle(html_text)
+    result["stats"].update(subtitle)
+
+    # Merge glance sections (regex fallback for robustness)
+    glance = extract_glance_sections(html_text)
+    for key, val in glance.items():
+        if not result.get(key):
+            result[key] = val
+
+    # Merge big wins (regex fallback)
+    if not result.get("impressive_things"):
+        result["impressive_things"] = extract_big_wins(html_text)
+
+    # Merge multi-clauding (regex fallback)
+    if not result.get("multi_clauding"):
+        result["multi_clauding"] = extract_multi_clauding(html_text)
+
+    # Clean up empty lists/strings
+    result = {k: v for k, v in result.items() if v or v == 0}
+
+    json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    print()  # trailing newline
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/ai-fortune/templates/ai-fortune.json
+++ b/plugins/ai-fortune/templates/ai-fortune.json
@@ -1,0 +1,10 @@
+{
+  "lastRun": null,
+  "lastReportPath": null,
+  "reportsDir": null,
+  "dataSources": {
+    "memoryFilePath": null,
+    "insightsReportPath": "~/.claude/usage-data/report.html"
+  },
+  "answers": {}
+}


### PR DESCRIPTION
## Summary

- New plugin `/ai-fortune` — personalized career direction analysis based on real AI usage data
- Mines 7 data sources: insights report, session metadata, installed plugins, tech proficiency, stats cache, memory file, web research
- 15-question adaptive interview with persistent state (`~/.claude/ai-fortune.json`) — skips recent answers, re-asks stale ones
- Generates structured career risk report: 5-dimension risk matrix, AI Leverage Score, Delegation Maturity Model, 3-4 recommended directions with skills bridge tables
- 2 Python scripts (stdlib only): `parse-insights.py` (HTML→JSON), `aggregate-sessions.py` (session aggregation)
- Docs: local plugin testing guide added to `docs/conventions.md`

## Files

```
plugins/ai-fortune/
├── .claude-plugin/plugin.json          # manifest v0.2.0
├── commands/ai-fortune/
│   ├── SKILL.md                        # orchestration flow (11 steps, 3 phases)
│   └── references/
│       ├── interview-questions.md      # 15 questions in 5 tiers
│       ├── analysis-framework.md       # risk matrix, AI-resistant properties, scoring
│       └── report-template.md          # full report structure
├── scripts/
│   ├── parse-insights.py              # insights HTML → JSON
│   └── aggregate-sessions.py          # session-meta aggregation
├── templates/ai-fortune.json          # default state template
├── docs/ACCEPTANCE_TESTS.md           # 6 test categories
└── README.md
```

Also: marketplace.json, root README, CLAUDE.md, docs/conventions.md

## Test plan

- [x] `python3 -m py_compile` both scripts
- [x] `parse-insights.py` with real `report.html` — extracts 5 project areas, 6 tools, narrative, friction, wins
- [x] `aggregate-sessions.py --days 7` — 78 sessions found
- [x] `aggregate-sessions.py --days 0` — 0 sessions (edge case)
- [x] plugin.json valid, SKILL.md frontmatter valid
- [x] `/ai-fortune` command visible and runnable after local install
- [ ] Full end-to-end flow (manual — interview + report generation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)