### PR TITLE
feat(ai-fortune): post-launch improvements v0.3.0

### DIFF
--- a/plugins/ai-fortune/.claude-plugin/plugin.json
+++ b/plugins/ai-fortune/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-fortune",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Career direction analysis: interview + AI usage pattern mining to identify roles AI won't replace",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/ai-fortune/README.md
+++ b/plugins/ai-fortune/README.md
@@ -14,9 +14,12 @@ A Claude Code plugin that analyzes your AI usage patterns, runs an adaptive care
 
 One command that:
 1. Mines 7 data sources (insights report, session metadata, plugins, tech proficiency, stats)
-2. Runs an adaptive 15-question interview (skips what it already knows)
-3. Researches your industry's AI landscape via web search
-4. Generates a career risk assessment with 3-4 recommended directions
+2. Runs an adaptive 18-question interview with sub-questions (skips what it already knows)
+3. Researches your industry's AI landscape via 5-8 targeted web searches
+4. Generates a 5-level amplitude spectrum of career directions — from optimize-in-place to radical change
+5. Detects burnout risk from session patterns and flags sustainability warnings
+6. Prevents echo chamber bias with diversity validation across domains and industries
+7. Anchors salary comparisons against your current compensation bracket
 
 ## 📦 Installation <a name="installation"></a>
 
@@ -49,20 +52,21 @@ Claude: 📂 Loading persistent state...
         Using your previous answer from Feb 15: "40% code, 20% architecture..."
 
 Claude: ❓ What is the single most important thing you bring to your team?
-        ┌─────────────────────────────────────┐
-        │ 1. Systems thinking and tooling     │
-        │ 2. Cross-domain problem solving     │
-        │ 3. Other (free text)                │
-        └─────────────────────────────────────┘
+        (Be honest — there's no wrong answer. Examples:
+         "I'm the only one who understands the legacy billing system"
+         "No one else wants to maintain the CI/CD pipeline"
+         "I translate between backend and product teams")
 
-You: 1
+You: I bridge the gap between infrastructure and product — no one else speaks both languages.
 
-        ... (10-15 adaptive questions) ...
+        ... (12-18 adaptive questions, max 2 per prompt) ...
 
         🔍 Phase 3: Web research & report generation...
         Searching: "AI automation software engineering 2026 trends"
         Searching: "Software Engineer AI replacement risk 2026"
         Searching: "AI-resistant careers technology"
+        Searching: "Software Engineer salary Kyiv 2026"
+        Searching: "DevRel job market Europe remote 2026"
 
         📋 Generating Career Direction Report...
 
@@ -89,11 +93,23 @@ Generated: 2026-03-01 | Sources: 7/8 used
 | Regulatory/Trust | ⭐⭐ | No licensing requirements |
 | Creative Synthesis | ⭐⭐⭐⭐ | Plugin ecosystem design, cross-domain |
 
-## Recommended Directions
-### Direction 1: AI Platform Engineering Lead
-**Fit score: 9/10** ...
+## Recommended Directions (5-Level Amplitude Spectrum)
 
-        ... (full report with 3-4 directions, action plan, blind spots) ...
+### L1 — Optimize Current: Senior AI Platform Engineer
+### L2 — Lateral Move: Developer Relations Lead
+### L3 — New Company: Staff Engineer at AI-Adopting Enterprise
+### L4 — Career Pivot: Technical Product Manager
+### L5 — Radical Change: Independent AI Tooling Consultant
+
+| Level | Direction | Risk | Salary Delta | Timeline |
+|-------|-----------|------|-------------|----------|
+| L1 | Sr AI Platform Engineer | Low | +15% | 3-6mo |
+| L2 | DevRel Lead | Low | +5% | 6-12mo |
+| L3 | Staff Eng (Enterprise) | Med | +25% | 3-6mo |
+| L4 | Technical PM | Med | +10% | 12-18mo |
+| L5 | Independent Consultant | High | +40%/-20% | 18-24mo |
+
+        ... (full report with action plan, blind spots, burnout check) ...
 
         💾 State saved to ~/.claude/ai-fortune.json
         📄 Report saved to /tmp/ai-fortune-reports/2026-03-01_14-30-45.md
@@ -117,14 +133,14 @@ The report can be generated with just the interview, but quality improves dramat
 
 ## 🎯 Report Sections <a name="report-sections"></a>
 
-- **Your Profile** — role, industry, tech proficiency map from data
+- **Your Profile** — role, industry, location, languages, compensation, tech proficiency map
 - **AI Leverage Profile** — AI Leverage Score (0-10) and Delegation Maturity Model (Level 1-5), measuring how effectively you use AI as a force multiplier
 - **Risk Assessment** — 5-dimension risk matrix with evidence-backed scores
 - **Industry AI Landscape** — real-time web research on AI in your industry
-- **Recommended Directions** — 3-4 career paths with fit scores, skills bridge tables, salary ranges
+- **Recommended Directions** — 5-level amplitude spectrum (Optimize Current → Lateral Move → New Company → Career Pivot → Radical Change) with target business types (named companies), salary ranges with delta vs current, and a comparison table
 - **AI Orchestrator Advantage** — (for advanced users) why your AI orchestration skill is a competitive moat
 - **Action Plan** — concrete 30-day, 6-month, and 1-2 year milestones
-- **Blind Spots** — honest assessment of tech gaps, friction patterns, over-reliance risks
+- **Blind Spots** — honest assessment of tech gaps, friction patterns, over-reliance risks, burnout risk detection (session-pattern-based), and financial risk assessment (salary anchoring vs current bracket)
 
 ## 💾 Persistent State <a name="persistent-state"></a>
 

--- a/plugins/ai-fortune/commands/ai-fortune/SKILL.md
+++ b/plugins/ai-fortune/commands/ai-fortune/SKILL.md
@@ -96,7 +96,7 @@ Collect data from up to 7 sources. Each source is optional — if unavailable, n
 ### Step 7: Adaptive Interview
 
 1. `Read` `${SKILL_DIR}/references/interview-questions.md`
-2. For each question (Q1-Q15), apply re-ask logic:
+2. For each question (Q1a, Q1b, Q2, Q3, Q4, Q5a, Q5b, Q6-Q12, Q14-Q18), apply re-ask logic:
 
    **Re-ask decision tree:**
    ```
@@ -105,31 +105,46 @@ Collect data from up to 7 sources. Each source is optional — if unavailable, n
    │   ├── < 6 months → SKIP: Display "Using your previous answer from {date}: {value}"
    │   └── >= 6 months → RE-ASK: Use AskUserQuestion with previous value as first option
    │                      (add "(previous answer)" suffix to the label)
-   └── NO → Can data auto-answer this question?
-       ├── YES → Pre-fill from data, confirm with user: "Based on your data, {value} — correct?"
-       └── NO → ASK: Use AskUserQuestion with options from interview-questions.md
+   └── NO → Does a legacy key have a migratable answer? (see interview-questions.md § Legacy answer migration)
+       ├── YES → PRE-FILL: Use migrated value as first option "(from previous session)", always confirm
+       └── NO → Can data auto-answer this question?
+           ├── YES → Pre-fill from data, confirm with user: "Based on your data, {value} — correct?"
+           └── NO → ASK: Use AskUserQuestion with options from interview-questions.md
    ```
 
-3. **Auto-skip rules** (use data to pre-answer):
-   - Q1 (role/industry): if memory file contains clear role/industry info
-   - Q5 (AI dependency): if session data shows >5 sessions/day → pre-fill "Essential"
+3. **Pacing rule**: Ask at most 2 questions per AskUserQuestion call. Tier 4 (Q10-Q12) MUST be asked one at a time — these require thoughtful answers.
+
+4. **Q3 presentation**: When asking Q3 (core value), present the `examples_for_priming` from the question bank as context before the question. Expect free text answer — the examples normalize honest self-assessment, not constrain answers.
+
+5. **Auto-skip rules** (use data to pre-answer):
+   - Q1a (role/industry): if memory file contains clear role/industry info
+   - Q5a (AI dependency, work): if session data shows >5 sessions/day → pre-fill "Essential"
+   - Q5b (AI dependency, personal): if session data shows per-project diversity with personal projects → use as signal
    - Q7 (years experience): if memory file mentions experience level
    - Q10 (domain expertise): if technology-explainer has expert-level entries
+   - Q17 (languages): if memory file mentions languages → pre-fill, confirm
+   - Q18 (local market): if Q15 covers geography or memory has location → pre-fill, confirm
+   - Q18 should be asked before Q16 when both are unanswered (so currency placeholder adapts)
 
-4. **Tier 3 collapse**: If user gives 2+ consecutive minimal answers (picks first option without customizing), skip remaining Tier 3 questions
+6. **Tier 3 collapse**: If user gives 2+ consecutive minimal answers (picks first option without customizing), skip remaining Tier 3 questions
 
-5. For `multiple_choice` questions → use `AskUserQuestion` with options from the question bank
-6. For `free_text` questions → use `AskUserQuestion` with 2-3 example options + free text
+7. For `multiple_choice` questions → use `AskUserQuestion` with options from the question bank
+8. For `free_text` questions → use `AskUserQuestion` with 2-3 example options + free text
 
 ### Step 8: Profile Synthesis
 
 1. Combine all collected data + interview answers into a unified profile
 2. Run contrastive analysis — compare self-reported vs data-observed:
-   - AI dependency (interview Q5) vs actual session frequency
+   - AI dependency at work (Q5a) vs actual session frequency
+   - AI dependency personal (Q5b) vs project diversity in session data
+   - Work vs personal AI gap (Q5a vs Q5b) — split personality detection
    - Daily task breakdown (Q2) vs project_areas from insights
    - Claimed strengths (Q3, Q10) vs impressive_things from insights
+   - Compensation (Q16) vs market rates for role (will compare in Step 9)
+   - Session timestamps vs Q2 — detect night/weekend work patterns
 3. Note any discrepancies for the Blind Spots section
 4. Compute preliminary risk scores for each of the 5 dimensions
+5. **Burnout risk screening**: Count burnout indicators from analysis-framework.md (night work >30%, no rest days 7/7, dual workload, session marathon >3h, escalating volume >50% WoW). Record flag count for report generation.
 
 ---
 
@@ -137,13 +152,16 @@ Collect data from up to 7 sources. Each source is optional — if unavailable, n
 
 ### Step 9: Web Research
 
-Perform 3-5 targeted `WebSearch` queries based on the user's profile:
+Perform 5-8 targeted `WebSearch` queries based on the user's profile:
 
 1. `WebSearch`: "AI automation {user's industry} 2026 trends"
 2. `WebSearch`: "{user's role title} AI replacement risk 2026"
 3. `WebSearch`: "AI-resistant careers {user's domain}"
 4. `WebSearch`: "{user's top technology} AI automation capabilities 2026" (if relevant)
-5. `WebSearch`: "{recommended direction} salary range {user's geography}" (after directions are drafted)
+5. `WebSearch`: "{user's role} salary range {Q18 city/market} 2026" (use Q18 answer for geography-specific searches)
+6. `WebSearch`: "{recommended L3 direction} job market {Q18 city}" (target business discovery)
+7. `WebSearch`: "{recommended L5 direction} freelance market demand 2026" (radical change validation)
+8. `WebSearch`: "{recommended direction} salary range {user's geography}" (after directions are drafted, for remaining levels)
 
 For each search → extract key findings, specific companies/products, salary data.
 Increment `sources_used`.
@@ -156,21 +174,42 @@ Increment `sources_used`.
    - **Risk Matrix**: score each of 5 dimensions (1-5) with evidence
    - **AI Leverage Score**: compute from plugin count, session complexity, multi-clauding %, task-agent %, delegation maturity
    - **Delegation Maturity Level**: determine from session types, tool distribution, multi-clauding stats
-4. Generate 3-4 recommended career directions:
+4. Generate 5 recommended career directions (one per amplitude level):
+   - L1 (Optimize Current): always detailed — baseline reference
+   - L2 (Lateral Move): always included — low-friction alternative
+   - L3 (New Company): detailed if Q1b ≠ "Love it" OR risk ≥ MODERATE
+   - L4 (Career Pivot): detailed if Q1b ∈ {"Want to pivot", "Need change"} OR Q14 ≠ "Conservative"
+   - L5 (Radical Change): always included — stretch option
    - Each direction must reference specific AI-resistant properties
-   - Each must include a skills bridge table with concrete resources
-   - Each must cite web research findings
-5. Generate the complete report following `report-template.md` structure
-6. **Display the report** in the terminal
-7. **Save the report to disk:**
-   - If `reportsDir` exists in loaded state → use it as default option
-   - `AskUserQuestion`: "Where to save the report?"
-     - Options: saved `reportsDir` or `/tmp/ai-fortune-reports/` (default, ephemeral), `~/.claude/ai-fortune/reports/` (persistent)
-     - If saved `reportsDir` matches one of the options, show it as first option with "(previous choice)" suffix
-   - `Bash`: `mkdir -p {chosen_dir}`
-   - Filename: `YYYY-MM-DD_HH-MM-SS.md` (current timestamp, e.g. `2026-03-01_14-30-45.md`)
-   - `Write` the complete report markdown to `{chosen_dir}/{filename}`
-   - Confirm: "Report saved to {chosen_dir}/{filename}"
+   - Each must include target business types (real companies, mixed local + remote, diverse industries)
+   - L3-L5 must include a skills bridge table with concrete resources
+   - Each must cite web research findings and salary ranges
+5. **Anti-echo-chamber validation**: Run the 5-point checklist from analysis-framework.md. If any check fails → revise directions before finalizing:
+   - Not all 5 in same industry
+   - Not all 5 require same primary skill
+   - At least one direction NOT about building/selling AI
+   - At least one leverages an unconsidered skill
+   - L5 is genuinely radical
+6. **Salary anchoring** (if Q16 answered):
+   - For each direction, compute delta vs current bracket from Q16
+   - Populate "vs current" and "Minimum viable?" fields
+   - Generate the Comparison Table with salary deltas
+   - Add Financial Risk Assessment to Blind Spots section
+7. **Burnout integration** (if 3+ burnout flags from Step 8):
+   - Add Sustainability Warning subsection to Blind Spots
+   - Extend all direction timelines by 3-6 months (or 6-12 months if 5/5 flags)
+   - Recommend L1 as primary path if 5/5 flags
+8. Generate the complete report following `report-template.md` structure
+9. **Display the report** in the terminal
+10. **Save the report to disk:**
+    - If `reportsDir` exists in loaded state → use it as default option
+    - `AskUserQuestion`: "Where to save the report?"
+      - Options: saved `reportsDir` or `/tmp/ai-fortune-reports/` (default, ephemeral), `~/.claude/ai-fortune/reports/` (persistent)
+      - If saved `reportsDir` matches one of the options, show it as first option with "(previous choice)" suffix
+    - `Bash`: `mkdir -p {chosen_dir}`
+    - Filename: `YYYY-MM-DD_HH-MM-SS.md` (current timestamp, e.g. `2026-03-01_14-30-45.md`)
+    - `Write` the complete report markdown to `{chosen_dir}/{filename}`
+    - Confirm: "Report saved to {chosen_dir}/{filename}"
 
 ### Step 11: Save State
 
@@ -192,6 +231,8 @@ Increment `sources_used`.
      }
    }
    ```
+   New answer keys: `career_direction_sentiment` (Q1b), `ai_dependency_work` (Q5a), `ai_dependency_personal` (Q5b), `current_compensation` (Q16), `working_languages` (Q17), `local_market` (Q18).
+   Old keys `ai_dependency` and `career_satisfaction` are preserved in state but no longer actively read. They serve as migration sources: on first run after upgrade, their values seed defaults for the new split questions (Q5a/Q1b). See interview-questions.md § Legacy answer migration for the mapping table. Old keys age out naturally after 6 months.
 2. `Write` to `~/.claude/ai-fortune.json`
 3. Confirm: "State saved. Run `/ai-fortune` again anytime — it will remember your answers and skip recent ones."
 

--- a/plugins/ai-fortune/commands/ai-fortune/references/analysis-framework.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/analysis-framework.md
@@ -99,19 +99,109 @@ Based on insights report data patterns:
 
 ---
 
+## Amplitude Classification
+
+Classify each recommended direction into one of 5 amplitude levels. The report MUST include exactly one direction per level.
+
+| Level | Name | Description | When to Generate |
+|-------|------|-------------|-----------------|
+| L1 | **Optimize Current** | Stay in current role, deepen specialization, leverage AI harder | Always — baseline reference point |
+| L2 | **Lateral Move** | Same industry, adjacent role (e.g., dev → DevRel, PM → TPM) | Always — low-friction alternative |
+| L3 | **New Company** | Same role/skills, different company type or industry | If Q1b ≠ "Love it" OR risk score ≥ MODERATE |
+| L4 | **Career Pivot** | New role requiring significant reskilling (e.g., dev → product, ops → consulting) | If Q1b ∈ {"Want to pivot", "Need change"} OR Q14 ≠ "Conservative" |
+| L5 | **Radical Change** | Entrepreneurship, freelance, completely new field, geographic move | Always — stretch option, even for conservative users |
+
+### Generation rules:
+- Q1b "Love it" → L1 gets the most detail, L4/L5 are brief "for future reference"
+- Q1b "Need change" → L3-L5 get the most detail, L1 is brief "if you must stay"
+- Q14 "Conservative" → L4/L5 include extra risk mitigation steps
+- Q14 "Aggressive" → L4/L5 include faster timelines
+
+### Content requirements per level:
+- **All levels**: direction title, one-liner, "What to do" (concrete actions), target business types, "Why AI won't replace this" (AI-resistant properties), salary range + delta vs current, timeline
+- **L3-L5 only**: skills bridge table (Already Have → Need to Acquire → How to Get)
+
+---
+
+## Business Type Classification
+
+When recommending target businesses, classify them into these types and ensure diversity across directions:
+
+| Type | Description | Examples |
+|------|-------------|---------|
+| **AI-native** | Built around AI from day one | AI labs, AI-first SaaS, AI infrastructure |
+| **AI-adopting** | Traditional companies investing heavily in AI | Banks with ML teams, retailers with recommendation engines |
+| **AI-consulting** | Helping others adopt AI | Consultancies, system integrators, AI training firms |
+| **Non-AI** | Industries where AI is peripheral or absent | Construction, artisan crafts, regulated professions |
+
+### Rules:
+- Name real companies (not hypothetical), mixing well-known and emerging
+- Mix local companies (from Q18 market) with remote-friendly options
+- Diversify industries across the 5 directions
+- Specify company size: startup (<50), scale-up (50-500), enterprise (500+)
+- For each target business, note: company name, type, size, why it fits
+
+---
+
 ## Contrastive Analysis
 
 Compare self-reported data (interview) vs observed data (sessions/insights):
 
 | Aspect | Self-Reported Source | Observed Source | Look For |
 |--------|---------------------|----------------|----------|
-| AI dependency | Q5 interview | session frequency, tool calls | Under/over-estimation |
+| AI dependency (work) | Q5a interview | session frequency, tool calls | Under/over-estimation |
+| AI dependency (personal) | Q5b interview | project diversity, side-project sessions | Work vs personal gap |
+| Work vs personal AI gap | Q5a vs Q5b | session patterns by project | Split personality — power user at home, basic at work (or vice versa) |
 | Role focus | Q2 daily tasks | project_areas, what_you_wanted | Discrepancy in time allocation |
 | Strengths | Q3, Q10 interview | whats_working, impressive_things | Blind spots or unrecognized strengths |
 | Weaknesses | Q6 predictions | friction_categories, tool_errors | Denial or over-worry |
-| Career direction | Q13 satisfaction | session diversity, new tool adoption | Stagnation vs active exploration |
+| Career direction | Q1b sentiment | session diversity, new tool adoption | Stagnation vs active exploration |
+| Compensation vs market | Q16 bracket | web search salary data for Q18 market | Under/over-compensated for role |
+| Work/life balance | Q2 daily tasks | time_distribution, session timestamps | Night/weekend work patterns |
+| Transition capacity | Q14 risk tolerance | burnout indicators, session intensity | Stated risk tolerance vs actual bandwidth |
 
 ### How to present:
 - If data confirms self-report → reinforce with evidence
 - If data contradicts → present gently: "Your sessions suggest X, though you described Y — this gap is worth exploring"
 - If data reveals unmentioned strength → highlight as "hidden advantage"
+
+---
+
+## Burnout Risk Indicators
+
+Screen for burnout risk using session metadata and interview answers. These indicators are warning signs, not diagnoses.
+
+| # | Indicator | Threshold | Data Source |
+|---|-----------|-----------|-------------|
+| 1 | **Night work** | >30% of sessions start between 22:00-06:00 | session-meta timestamps |
+| 2 | **No rest days** | 7/7 days with sessions in the past 2 weeks | session-meta dates |
+| 3 | **Dual workload** | Q5a and Q5b both "Essential" or "Significant" | interview answers |
+| 4 | **Session marathon** | Average session duration >3 hours | session-meta duration |
+| 5 | **Escalating volume** | >50% week-over-week increase in session count | session-meta weekly counts |
+
+### Scoring:
+- **0-2 flags**: Normal — no burnout mention in report
+- **3-4 flags**: **Sustainability Warning** — dedicated subsection in Blind Spots; extend all direction timelines by 3-6 months to account for recovery
+- **5 flags**: **URGENT** — prominent warning at top of Blind Spots; strongly recommend L1 (Optimize Current) as primary path; extend all timelines by 6-12 months
+
+---
+
+## Direction Diversity Requirements
+
+The 5 recommended directions MUST meet these diversity minimums to prevent echo chamber bias:
+
+| Dimension | Minimum | How to Count |
+|-----------|---------|-------------|
+| Skill domains | 3 distinct | e.g., engineering, management, design, sales, research |
+| Industries | 2 distinct | e.g., tech, finance, healthcare, education, manufacturing |
+| Work formats | 2 distinct | e.g., full-time employment, freelance/consulting, entrepreneurship, part-time |
+| Non-AI directions | 1 minimum | At least one direction where AI expertise is NOT the primary value proposition |
+
+### Anti-echo-chamber checklist (all must pass):
+1. ☐ Not all 5 directions are in the same industry
+2. ☐ Not all 5 directions require the same primary skill
+3. ☐ At least one direction does NOT involve building/selling AI tools
+4. ☐ At least one direction leverages a skill the user may not have considered (from Q3 examples_for_priming or contrastive analysis hidden advantages)
+5. ☐ L5 (Radical Change) is genuinely radical — not just "the same job at a startup"
+
+If any check fails → revise directions before finalizing the report.

--- a/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
@@ -11,11 +11,21 @@ Questions are organized by tier. Each question specifies:
 
 ## Tier 1: Role & Industry (always ask)
 
-### Q1: Current Role & Industry
+### Q1a: Current Role & Industry (factual)
 - **key:** `current_role`
 - **type:** `free_text`
 - **prompt:** "What is your current job title and industry? (e.g., 'Software Engineer, FinTech')"
 - **skip_if_data:** memory file may contain role/industry context
+
+### Q1b: Career Direction Sentiment
+- **key:** `career_direction_sentiment`
+- **type:** `multiple_choice`
+- **prompt:** "How do you feel about this career direction?"
+- **options:**
+  - "Love it — wouldn't change a thing"
+  - "Open to change — happy but curious about alternatives"
+  - "Want to pivot — actively exploring other paths"
+  - "Need change — current path feels unsustainable"
 
 ### Q2: Typical Workday Breakdown
 - **key:** `daily_tasks`
@@ -26,8 +36,12 @@ Questions are organized by tier. Each question specifies:
 ### Q3: Core Value to Team
 - **key:** `core_value`
 - **type:** `free_text`
-- **prompt:** "What is the single most important thing you bring to your team that would be hardest to replace?"
+- **prompt:** "What is the single most important thing you bring to your team that would be hardest to replace? Be honest — there's no wrong answer. If your position is retained by circumstance rather than unique skill, say that."
 - **skip_if_data:** none (subjective)
+- **examples_for_priming:**
+  - "I'm the only one who understands the legacy billing system" (legacy knowledge)
+  - "No one else wants to maintain the CI/CD pipeline, so I do it" (only willing worker)
+  - "I translate between the backend team and the product team" (cross-team coordination)
 
 ---
 
@@ -44,16 +58,27 @@ Questions are organized by tier. Each question specifies:
   - "Not adopted — no formal AI initiatives"
   - "Actively resisted — organizational pushback"
 
-### Q5: Personal AI Dependency
-- **key:** `ai_dependency`
+### Q5a: AI Dependency — Work
+- **key:** `ai_dependency_work`
 - **type:** `multiple_choice`
-- **prompt:** "How dependent is your daily work on AI tools?"
+- **prompt:** "How dependent is your WORK (day job) on AI tools?"
 - **options:**
   - "Essential — can't imagine working without AI"
   - "Significant — AI handles 30%+ of my work"
   - "Occasional — use AI for specific tasks"
   - "Rarely — tried but not integrated"
   - "Never — don't use AI tools"
+
+### Q5b: AI Dependency — Personal/Side Projects
+- **key:** `ai_dependency_personal`
+- **type:** `multiple_choice`
+- **prompt:** "How dependent are your PERSONAL/side projects on AI tools?"
+- **options:**
+  - "Essential — AI is central to my side work"
+  - "Significant — AI handles 30%+ of side project work"
+  - "Occasional — use AI for specific personal tasks"
+  - "Rarely — tried but not integrated"
+  - "N/A — no side projects"
 
 ### Q6: AI Replacement Predictions
 - **key:** `ai_replacement_2yr`
@@ -129,17 +154,7 @@ Questions are organized by tier. Each question specifies:
 
 ---
 
-## Tier 5: Aspirations (always ask)
-
-### Q13: Career Satisfaction & Direction
-- **key:** `career_satisfaction`
-- **type:** `multiple_choice`
-- **prompt:** "How do you feel about your current career trajectory?"
-- **options:**
-  - "Want to deepen — love what I do, want to go deeper"
-  - "Open to change — happy but curious about alternatives"
-  - "Considering pivot — actively exploring other paths"
-  - "Need change — current path feels unsustainable"
+## Tier 5: Aspirations & Context (always ask)
 
 ### Q14: Risk Tolerance
 - **key:** `risk_tolerance`
@@ -156,19 +171,63 @@ Questions are organized by tier. Each question specifies:
 - **prompt:** "What constraints would limit a career pivot? (e.g., geographic, financial, family, language, visa, industry certifications)"
 - **skip_if_data:** none
 
+### Q16: Current Compensation
+- **key:** `current_compensation`
+- **type:** `multiple_choice`
+- **prompt:** "What is your current annual compensation range? (in {currency})"
+- **options:**
+  - "Under {currency}30k"
+  - "{currency}30k–60k"
+  - "{currency}60k–100k"
+  - "{currency}100k–150k"
+  - "{currency}150k–250k"
+  - "Over {currency}250k"
+- **skip_if_data:** never auto-skip (sensitive, always confirm)
+- **note:** `{currency}` placeholder is resolved from Q18 answer or defaults to `$`
+
+### Q17: Working Languages
+- **key:** `working_languages`
+- **type:** `free_text`
+- **prompt:** "What languages do you work in professionally? (e.g., 'English (native), Ukrainian (native), German (B2)')"
+- **skip_if_data:** memory file may mention languages
+
+### Q18: Local Market
+- **key:** `local_market`
+- **type:** `free_text`
+- **prompt:** "Where are you based and what job market do you primarily target? (e.g., 'Kyiv, Ukraine — open to EU remote')"
+- **skip_if_data:** Q15 may cover geography; memory file may mention location
+
 ---
 
 ## Adaptive Logic
 
 ### Auto-skip rules:
-- If memory file reveals industry → mark Q1 as partially answered, confirm rather than ask fresh
-- If session data shows heavy task-agent usage → Q5 can be pre-filled as "Essential/Significant"
+- If memory file reveals industry → mark Q1a as partially answered, confirm rather than ask fresh
+- If session data shows heavy task-agent usage → Q5a can be pre-filled as "Essential/Significant"
+- If session data shows per-project AI usage patterns → Q5b can use project diversity as signal
 - If technology-explainer config exists → skip tech-related parts of Q10
+- If memory file mentions languages → Q17 can be pre-filled, confirm
+- If Q15 already covers geography or memory has location → Q18 can be pre-filled, confirm
+- Q18 should be asked before Q16 when both are unanswered (so currency can adapt)
 
 ### Re-ask rules (persistent state):
 - Answer < 6 months old → skip question, show "Using your previous answer from {date}: {value}"
 - Answer >= 6 months old → re-ask with previous value as default option (first option + "(previous answer)" suffix)
 - No previous answer → ask normally
+
+### Legacy answer migration:
+When a question is split, removed, or substantially reworded across versions, old answers in state can seed defaults for new questions:
+
+| Old Key | Old Question | New Key(s) | Migration |
+|---------|-------------|------------|-----------|
+| `ai_dependency` | Q5 "How dependent is your daily work on AI tools?" | `ai_dependency_work` (Q5a) | Use old value as default for Q5a; ask Q5b fresh |
+| `career_satisfaction` | Q13 "How do you feel about your current career trajectory?" | `career_direction_sentiment` (Q1b) | Use old value as default for Q1b (options map 1:1) |
+
+Rules:
+- If old key has a value and new key does not → pre-fill new question with old value as first option "(from previous session)" and ask for confirmation
+- If both old and new keys have values → ignore old key, use new key
+- Never auto-skip based on a migrated value — always confirm with the user
+- Old keys are never deleted from state; they age out naturally after 6 months
 
 ### Tier 3 collapse:
 - If user shows impatience (quick "skip" or "Other" answers) → collapse remaining Tier 3 questions

--- a/plugins/ai-fortune/commands/ai-fortune/references/report-template.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/report-template.md
@@ -17,7 +17,9 @@ Generated: {date} | Sources: {N}/8 used
 ## Your Profile
 
 **Role:** {title} | **Industry:** {industry} | **Experience:** {years}
-**AI Adoption at org:** {level} | **Personal AI dependency:** {level}
+**Location:** {from Q18} | **Languages:** {from Q17}
+**AI Adoption at org:** {level} | **AI (work):** {Q5a} | **AI (personal):** {Q5b}
+**Current compensation:** {from Q16}
 
 **Technology Proficiency Map** (from technology-explainer):
 - Expert: {list}
@@ -77,31 +79,140 @@ Cite specific companies and tools, not vague generalities.}
 
 ---
 
-## Recommended Directions (3-4 options)
+## Recommended Directions (5-Level Amplitude Spectrum)
 
-### Direction 1: {Title}
+### L1 — Optimize Current: {Title}
 
 **One-liner:** {value proposition}
-**Fit score:** {X}/10
 
-**Why this fits YOU specifically:**
-{2-3 sentences linking to user's profile data — not generic advice.
-Reference specific skills, experience, and AI leverage patterns.}
+**What to do:**
+- {concrete action 1}
+- {concrete action 2}
+- {concrete action 3}
 
-**Why AI won't replace this (long-term):**
-{2-3 sentences referencing specific AI-resistant properties from the framework.
-Explain which of the 7 properties apply and why.}
+**Target business types:**
+- {company name} ({AI-native/AI-adopting/AI-consulting/Non-AI}, {size}) — {why it fits}
+- {company name} ({type}, {size}) — {why it fits}
+- *{Q18 city}-specific:* {local company} ({type}, {size})
+
+**Why AI won't replace this:**
+{2-3 sentences referencing specific AI-resistant properties from the framework.}
+
+**Salary range:** {range from web search} | **vs current:** {delta: +X%, same, -X%} | **Minimum viable?** {yes/no}
+**Timeline:** {realistic estimate}
+
+---
+
+### L2 — Lateral Move: {Title}
+
+**One-liner:** {value proposition}
+
+**What to do:**
+- {concrete action 1}
+- {concrete action 2}
+
+**Target business types:**
+- {company name} ({type}, {size}) — {why it fits}
+- {company name} ({type}, {size}) — {why it fits}
+- *{Q18 city}-specific:* {local company} ({type}, {size})
+
+**Why AI won't replace this:**
+{2-3 sentences referencing AI-resistant properties.}
+
+**Salary range:** {range} | **vs current:** {delta} | **Minimum viable?** {yes/no}
+**Timeline:** {estimate}
+
+---
+
+### L3 — New Company: {Title}
+
+**One-liner:** {value proposition}
+
+**What to do:**
+- {concrete action 1}
+- {concrete action 2}
+
+**Target business types:**
+- {company name} ({type}, {size}) — {why it fits}
+- {company name} ({type}, {size}) — {why it fits}
+- *{Q18 city}-specific:* {local company} ({type}, {size})
+
+**Why AI won't replace this:**
+{2-3 sentences referencing AI-resistant properties.}
 
 **Skills bridge:**
 | Already Have | Need to Acquire | How to Get |
 |-------------|-----------------|------------|
 | {skill from data} | {skill gap} | {specific resource/course/path} |
 
-**Transition timeline:** {realistic estimate with milestones}
-**Industry evidence:** {web search findings supporting this direction}
-**Salary range:** {from web search, with geographic context}
+**Salary range:** {range} | **vs current:** {delta} | **Minimum viable?** {yes/no}
+**Timeline:** {estimate with milestones}
 
-### Direction 2-4: {same structure}
+---
+
+### L4 — Career Pivot: {Title}
+
+**One-liner:** {value proposition}
+
+**What to do:**
+- {concrete action 1}
+- {concrete action 2}
+- {concrete action 3}
+
+**Target business types:**
+- {company name} ({type}, {size}) — {why it fits}
+- {company name} ({type}, {size}) — {why it fits}
+- *{Q18 city}-specific:* {local company} ({type}, {size})
+
+**Why AI won't replace this:**
+{2-3 sentences referencing AI-resistant properties.}
+
+**Skills bridge:**
+| Already Have | Need to Acquire | How to Get |
+|-------------|-----------------|------------|
+| {skill from data} | {skill gap} | {specific resource/course/path} |
+
+**Salary range:** {range} | **vs current:** {delta} | **Minimum viable?** {yes/no}
+**Timeline:** {estimate with milestones}
+
+---
+
+### L5 — Radical Change: {Title}
+
+**One-liner:** {value proposition}
+
+**What to do:**
+- {concrete action 1}
+- {concrete action 2}
+- {concrete action 3}
+
+**Target business types:**
+- {company name} ({type}, {size}) — {why it fits}
+- {company name} ({type}, {size}) — {why it fits}
+- *{Q18 city}-specific:* {local company} ({type}, {size})
+
+**Why AI won't replace this:**
+{2-3 sentences referencing AI-resistant properties.}
+
+**Skills bridge:**
+| Already Have | Need to Acquire | How to Get |
+|-------------|-----------------|------------|
+| {skill from data} | {skill gap} | {specific resource/course/path} |
+
+**Salary range:** {range} | **vs current:** {delta} | **Minimum viable?** {yes/no}
+**Timeline:** {estimate with milestones}
+
+---
+
+### Comparison Table
+
+| Level | Direction | Risk | Current → Target | Salary Delta | Timeline | AI-Resistant Properties |
+|-------|-----------|------|-------------------|-------------|----------|------------------------|
+| L1 | {title} | {low/med/high} | {current role → target} | {+X% / same / -X%} | {time} | {which of the 7 apply} |
+| L2 | {title} | {risk} | {transition} | {delta} | {time} | {properties} |
+| L3 | {title} | {risk} | {transition} | {delta} | {time} | {properties} |
+| L4 | {title} | {risk} | {transition} | {delta} | {time} | {properties} |
+| L5 | {title} | {risk} | {transition} | {delta} | {time} | {properties} |
 
 ---
 
@@ -150,6 +261,26 @@ itself a career differentiator.}
 - Skill gaps between current role and recommended directions
 - Contrastive analysis findings (self-reported vs observed discrepancies)}
 
+### Sustainability Warning
+(conditional: only if 3+ burnout risk indicators flagged)
+
+{Specific indicators detected and evidence:
+- Which indicators were flagged (e.g., "Night work: 45% of sessions after 22:00")
+- Impact on recommended timelines (all extended by 3-6 months)
+- Concrete recommendations for sustainability
+- If 5/5 flags: "URGENT — consider stabilization before any career moves"}
+
+### Financial Risk Assessment
+(conditional: only if Q16 answered)
+
+{Comparison of current bracket against each direction:
+- Current bracket: {Q16 answer}
+- Which levels meet minimum viable compensation: {list}
+- Which levels need financial runway (savings, side income): {list}
+- Safest path (highest certainty of maintaining income): {L1/L2}
+- Highest upside path: {L4/L5}
+- Risk/reward recommendation based on Q14 risk tolerance}
+
 ---
 
 ## Data Sources Used
@@ -172,9 +303,11 @@ itself a career differentiator.}
 
 - Use stars (e.g., `⭐⭐⭐`) for risk dimension scores
 - Use checkmarks (✅) and crosses (❌) for data source status
-- Keep each direction's analysis to ~150-200 words
+- Target ~100-150 words per amplitude level (shorter per level is fine — 5 total levels replace the old 3-4 at 150-200 words each)
 - Bold key findings and scores
 - Use tables for structured comparisons
 - Keep action items specific and actionable (not vague "learn more about X")
 - Salary ranges should include currency and geography
 - All evidence claims should reference which data source they come from
+- Target business types: name real companies, include at least one local (from Q18) per direction
+- The Comparison Table at the end of Recommended Directions is MANDATORY — never omit it

--- a/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
@@ -60,7 +60,7 @@ import json, sys
 with open('$PLUGIN/.claude-plugin/plugin.json') as f:
     p = json.load(f)
 assert p['name'] == 'ai-fortune', f'wrong name: {p[\"name\"]}'
-assert p['version'] == '0.1.0', f'wrong version: {p[\"version\"]}'
+assert p['version'] == '0.3.0', f'wrong version: {p[\"version\"]}'
 assert 'commands' in p, 'missing commands field'
 print('plugin.json: OK')
 "
@@ -94,7 +94,7 @@ done
 
 **Expected:**
 - ✅ All checks pass
-- ✅ plugin.json has name `ai-fortune`, version `0.1.0`
+- ✅ plugin.json has name `ai-fortune`, version `0.3.0`
 - ✅ SKILL.md starts with `---` and has `name:` + `description:` in frontmatter
 - ✅ Both scripts compile without errors
 
@@ -246,8 +246,8 @@ else:
 | Step | Expected | Actual |
 |------|----------|--------|
 | Data collection | All available sources read | |
-| Interview | 10-15 questions, adaptive logic works | |
-| Web research | 3-5 searches executed | |
+| Interview | 12-18 questions (max 2 per prompt), adaptive logic works | |
+| Web research | 5-8 searches executed | |
 | Report | Full structure, evidence-based | |
 | State save | File written with answers + paths | |
 
@@ -267,6 +267,36 @@ else:
    - Report generates with available data
    - Data Sources table shows ❌ for missing sources
 5. Restore renamed files
+
+### 7. v0.3.0 Feature Acceptance Criteria
+
+**Objective:** Verify all post-launch improvements from epic #194 are working.
+
+**Automation:** ⚠️ Manual
+
+**Criteria:**
+
+| Feature | Acceptance Criterion | Verified |
+|---------|---------------------|----------|
+| Question split Q1→Q1a/Q1b | Interview asks role (free text) and career sentiment (MC) separately | |
+| Question split Q5→Q5a/Q5b | Work AI dependency and personal AI dependency asked separately | |
+| Q3 priming examples | Q3 shows 3 honesty-normalizing examples before asking | |
+| Q13 removed | No career satisfaction question (absorbed into Q1b) | |
+| Q16-Q18 added | Compensation, languages, and local market questions present | |
+| Q18 before Q16 | When both unanswered, market asked first (for currency) | |
+| Pacing (max 2 per call) | No AskUserQuestion call contains more than 2 questions | |
+| Tier 4 one-at-a-time | Q10, Q11, Q12 each asked individually | |
+| 5 amplitude levels | Report contains L1-L5 directions (Optimize→Radical) | |
+| Target business types | Each direction lists real companies with type/size | |
+| Named companies | At least one local company (from Q18) per direction | |
+| Comparison table | Mandatory table at end of directions with all 5 levels | |
+| Salary delta vs current | Each direction shows salary range + delta vs Q16 bracket | |
+| Financial Risk Assessment | Blind Spots includes financial analysis when Q16 answered | |
+| Burnout detection | 3+ session-pattern indicators trigger Sustainability Warning | |
+| Diversity validation | Directions span 3+ skill domains, 2+ industries | |
+| Anti-echo-chamber | At least one direction NOT about building/selling AI | |
+| New state keys | ai-fortune.json saves `career_direction_sentiment`, `ai_dependency_work`, `ai_dependency_personal`, `current_compensation`, `working_languages`, `local_market` | |
+| Backward compat | Old keys `ai_dependency`, `career_satisfaction` ignored but not deleted | |
 
 ---
 


### PR DESCRIPTION
## Summary

Implements all 7 sub-issues from epic #194 — post-launch improvements based on the first real `/ai-fortune` session (2026-03-01):

- **#187** Split compound interview questions: Q1→Q1a (role) + Q1b (career sentiment), Q5→Q5a (work AI) + Q5b (personal AI)
- **#188** Add honesty-priming examples to Q3 (core value) to normalize honest self-assessment
- **#189** Add Q16 (compensation), Q17 (languages), Q18 (local market) for salary/geography context
- **#190** 5-level amplitude spectrum (Optimize Current → Lateral Move → New Company → Career Pivot → Radical Change) replaces flat 3-4 directions
- **#191** Target business types with named companies (AI-native/adopting/consulting/non-AI), mixed local + remote
- **#192** Burnout risk detection from session patterns (5 indicators, 3 thresholds) with timeline extensions
- **#193** Anti-echo-chamber diversity validation (3+ skill domains, 2+ industries, 1+ non-AI direction)

Additional: legacy answer migration (`ai_dependency` → `ai_dependency_work`, `career_satisfaction` → `career_direction_sentiment`) so v0.2.0 users get pre-filled defaults on upgrade.

Closes #187, #188, #189, #190, #191, #192, #193

## Test plan

- [x] Static checks pass (plugin.json valid, SKILL.md frontmatter, scripts compile, reference files exist)
- [x] Version assertion updated to 0.3.0
- [x] Structural verification: Q1a/Q1b, Q5a/Q5b present; Q13 removed; Q16-Q18 added
- [x] New analytical sections present: amplitude classification, business type classification, burnout risk indicators, direction diversity requirements
- [x] Report template has 5-level structure with comparison table, sustainability warning, financial risk assessment
- [ ] Manual: run `/ai-fortune` end-to-end, verify 5 amplitude levels, target business types, salary comparison, burnout detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)