### PR TITLE
feat(ai-fortune): PDF resume support v0.4.0

### DIFF
--- a/plugins/ai-fortune/.claude-plugin/plugin.json
+++ b/plugins/ai-fortune/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-fortune",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Career direction analysis: interview + AI usage pattern mining to identify roles AI won't replace",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/ai-fortune/README.md
+++ b/plugins/ai-fortune/README.md
@@ -13,7 +13,7 @@ A Claude Code plugin that analyzes your AI usage patterns, runs an adaptive care
 - **`/ai-fortune`** — Run a full career direction analysis: data collection → adaptive interview → web research → structured report
 
 One command that:
-1. Mines 7 data sources (insights report, session metadata, plugins, tech proficiency, stats)
+1. Mines up to 8 data sources (insights report, session metadata, plugins, tech proficiency, stats, PDF resume)
 2. Runs an adaptive 18-question interview with sub-questions (skips what it already knows)
 3. Researches your industry's AI landscape via 5-8 targeted web searches
 4. Generates a 5-level amplitude spectrum of career directions — from optimize-in-place to radical change
@@ -38,14 +38,15 @@ You: /ai-fortune
 Claude: 📂 Loading persistent state...
         ✅ Found previous answers from 2026-02-15 (14 days ago)
 
-        📊 Phase 1: Collecting data from 7 sources...
+        📊 Phase 1: Collecting data from 8 sources...
         ✅ Memory chat file — extracted industry: Tech, role context
+        ✅ PDF resume — 26 years, 8 companies, Steady Climber career velocity
         ✅ Insights report — 182 sessions, 5 project areas, plan-driven power user
         ✅ Session metadata (7d) — 23 sessions, 4 projects
         ✅ Technology explainer — 8 expert, 5 intermediate, 3 learning
         ✅ Installed plugins — 10 plugins (sophisticated AI augmentation)
         ✅ Stats cache — 299 total sessions over 39 days
-        Sources: 6/7 used
+        Sources: 7/8 used
 
         🎤 Phase 2: Adaptive interview...
         Using your previous answer from Feb 15: "Software Engineer, Tech"
@@ -72,7 +73,7 @@ You: I bridge the gap between infrastructure and product — no one else speaks 
 
 # Career Direction Report
 
-Generated: 2026-03-01 | Sources: 7/8 used
+Generated: 2026-03-01 | Sources: 8/9 used
 
 ## Your Profile
 **Role:** Software Engineer | **Industry:** Tech | **Experience:** 6-10 years
@@ -121,19 +122,21 @@ Generated: 2026-03-01 | Sources: 7/8 used
 | # | Source | What it reveals | Required? |
 |---|--------|----------------|-----------|
 | 1 | Memory chat file | Industry, interests, domain context | Optional |
-| 2 | CC Insights report | Usage patterns, strengths, friction | Optional |
-| 3 | Session metadata (7d) | Recent work diversity, tool usage | Optional |
-| 4 | Technology explainer | Skill proficiency map | Optional |
-| 5 | Installed plugins | AI augmentation sophistication | Optional |
-| 6 | Stats cache | Longitudinal usage trends | Optional |
-| 7 | Web research | Industry AI landscape, salary data | Optional |
-| 8 | Interview | Self-assessment, aspirations | **Required** |
+| 2 | PDF resume | Career history, tenure patterns, skill verification | Optional |
+| 3 | CC Insights report | Usage patterns, strengths, friction | Optional |
+| 4 | Session metadata (7d) | Recent work diversity, tool usage | Optional |
+| 5 | Technology explainer | Skill proficiency map | Optional |
+| 6 | Installed plugins | AI augmentation sophistication | Optional |
+| 7 | Stats cache | Longitudinal usage trends | Optional |
+| 8 | Web research | Industry AI landscape, salary data | Optional |
+| 9 | Interview | Self-assessment, aspirations | **Required** |
 
 The report can be generated with just the interview, but quality improves dramatically with more data sources. The plugin gracefully handles missing sources.
 
 ## 🎯 Report Sections <a name="report-sections"></a>
 
 - **Your Profile** — role, industry, location, languages, compensation, tech proficiency map
+- **Career Trajectory Analysis** — (when resume provided) career timeline, velocity classification, tenure stats, domain analysis, skill currency (current/dormant/emerging), and resume vs reality assessment
 - **AI Leverage Profile** — AI Leverage Score (0-10) and Delegation Maturity Model (Level 1-5), measuring how effectively you use AI as a force multiplier
 - **Risk Assessment** — 5-dimension risk matrix with evidence-backed scores
 - **Industry AI Landscape** — real-time web research on AI in your industry
@@ -148,7 +151,7 @@ Interview answers are saved to `~/.claude/ai-fortune.json` with timestamps. On r
 
 - **Recent answers (< 6 months):** Skipped, shown as "Using your previous answer from {date}"
 - **Stale answers (>= 6 months):** Re-asked with previous value as default option
-- **File paths:** Saved so you don't re-enter them each time
+- **File paths:** Saved (memory file, resume, insights report) so you don't re-enter them each time
 
 Reports are automatically saved to a user-chosen directory (default: `/tmp/ai-fortune-reports/`) with timestamped filenames (e.g., `2026-03-01_14-30-45.md`). The chosen directory is remembered for future runs. Browse past reports to track how recommendations evolve over time.
 

--- a/plugins/ai-fortune/commands/ai-fortune/SKILL.md
+++ b/plugins/ai-fortune/commands/ai-fortune/SKILL.md
@@ -2,7 +2,7 @@
 name: ai-fortune
 description: >
   Career direction analysis: interview + AI usage pattern mining to identify
-  roles AI won't replace. Collects data from 7 sources, runs adaptive interview,
+  roles AI won't replace. Collects data from 8 data sources, runs adaptive interview,
   performs web research, and generates a structured career risk report.
   Keywords: ai fortune, career analysis, career risk, ai displacement, career direction,
   job future, ai resistant, career pivot.
@@ -19,13 +19,13 @@ Run all phases in order. Each step specifies the exact tools to use.
 1. Read `~/.claude/ai-fortune.json`
    - If exists → load `dataSources` (saved file paths), `answers` (interview answers with timestamps), `reportsDir` (saved report directory)
    - If not found → start with empty state: `dataSources = {}`, `answers = {}`, `reportsDir = null`
-2. Set `sources_used = 0` counter to track how many of the 8 data sources produce data
+2. Set `sources_used = 0` counter to track how many of the 9 data sources produce data
 
 ---
 
 ## Phase 1: Data Collection (Steps 1-6)
 
-Collect data from up to 7 sources. Each source is optional — if unavailable, note it and continue.
+Collect data from up to 8 sources. Each source is optional — if unavailable, note it and continue.
 
 ### Step 1: Memory Chat File
 
@@ -40,6 +40,21 @@ Collect data from up to 7 sources. Each source is optional — if unavailable, n
 4. If not skipped → `Read` the file
 5. Extract: industry, tech stack, interests, projects, domain expertise, personal context
 6. Save chosen path to `dataSources.memoryFilePath`
+7. Increment `sources_used`
+
+### Step 1.5: PDF Resume
+
+**Purpose:** Extract complete career history, tenure patterns, skill timeline, and education.
+
+1. Check `dataSources.resumePath` in loaded state
+2. If saved path exists and file readable → `AskUserQuestion`: "PDF resume: use saved `{path}`?"
+   - Options: "Use saved path", "Enter different path", "Skip"
+3. If no saved path → `AskUserQuestion`: "Do you have a PDF resume (LinkedIn export or any format)? Adds career history, tenure patterns, and skill verification to the analysis."
+   - Options: "Skip this source"
+   - Free text for path
+4. If not skipped → `Read` the PDF (Claude reads PDFs natively)
+5. Extract structured data per `${SKILL_DIR}/references/resume-extraction.md`
+6. Save path to `dataSources.resumePath`
 7. Increment `sources_used`
 
 ### Step 2: Insights Report
@@ -116,15 +131,19 @@ Collect data from up to 7 sources. Each source is optional — if unavailable, n
 
 4. **Q3 presentation**: When asking Q3 (core value), present the `examples_for_priming` from the question bank as context before the question. Expect free text answer — the examples normalize honest self-assessment, not constrain answers.
 
+4b. **Q3b (conditional)**: If a PDF resume was provided in Step 1.5, ask Q3b immediately after Q3. Populate `{skills_from_resume}` with the top skills extracted from the resume. Skip Q3b entirely if no resume was provided.
+
 5. **Auto-skip rules** (use data to pre-answer):
-   - Q1a (role/industry): if memory file contains clear role/industry info
+   - Q1a (role/industry): if memory file or resume contains clear role/industry info; resume pre-fills from most recent position title + company
    - Q5a (AI dependency, work): if session data shows >5 sessions/day → pre-fill "Essential"
    - Q5b (AI dependency, personal): if session data shows per-project diversity with personal projects → use as signal
-   - Q7 (years experience): if memory file mentions experience level
-   - Q10 (domain expertise): if technology-explainer has expert-level entries
-   - Q17 (languages): if memory file mentions languages → pre-fill, confirm
-   - Q18 (local market): if Q15 covers geography or memory has location → pre-fill, confirm
+   - Q7 (years experience): if memory file mentions experience level; resume computes total years from first position start date
+   - Q8 (management vs IC): if resume has title patterns (Manager/Director → management; Engineer/Developer → IC)
+   - Q10 (domain expertise): if technology-explainer has expert-level entries; resume extracts domain knowledge from experience descriptions
+   - Q17 (languages): if memory file or resume mentions languages → pre-fill, confirm
+   - Q18 (local market): if Q15 covers geography or memory/resume has location → pre-fill, confirm
    - Q18 should be asked before Q16 when both are unanswered (so currency placeholder adapts)
+   - **Resume pre-fills always confirm** — never silently skip, since resumes can be outdated
 
 6. **Tier 3 collapse**: If user gives 2+ consecutive minimal answers (picks first option without customizing), skip remaining Tier 3 questions
 
@@ -142,6 +161,11 @@ Collect data from up to 7 sources. Each source is optional — if unavailable, n
    - Claimed strengths (Q3, Q10) vs impressive_things from insights
    - Compensation (Q16) vs market rates for role (will compare in Step 9)
    - Session timestamps vs Q2 — detect night/weekend work patterns
+   - (if resume provided) Resume title vs self-reported role (Q1a) → title inflation/deflation
+   - (if resume provided) Resume tenure patterns vs career sentiment (Q1b) → says "Love it" but switches yearly?
+   - (if resume provided) Resume skills vs technology-explainer proficiency → over/under-claiming
+   - (if resume provided) Resume career span vs self-reported experience (Q7) → inaccurate self-assessment
+   - (if Q3b answered) Resume vs reality — user's honest disclosure about resume embellishments
 3. Note any discrepancies for the Blind Spots section
 4. Compute preliminary risk scores for each of the 5 dimensions
 5. **Burnout risk screening**: Count burnout indicators from analysis-framework.md (night work >30%, no rest days 7/7, dual workload, session marathon >3h, escalating volume >50% WoW). Record flag count for report generation.
@@ -170,11 +194,13 @@ Increment `sources_used`.
 
 1. `Read` `${SKILL_DIR}/references/analysis-framework.md`
 2. `Read` `${SKILL_DIR}/references/report-template.md`
-3. Compute final scores:
+3. If resume was provided → `Read` `${SKILL_DIR}/references/resume-extraction.md` for metric computation reference
+4. Compute final scores:
    - **Risk Matrix**: score each of 5 dimensions (1-5) with evidence
    - **AI Leverage Score**: compute from plugin count, session complexity, multi-clauding %, task-agent %, delegation maturity
    - **Delegation Maturity Level**: determine from session types, tool distribution, multi-clauding stats
-4. Generate 5 recommended career directions (one per amplitude level):
+   - (if resume provided) **Career Stability Score** and **Adaptability Evidence Score**: compute per analysis-framework.md § Career Trajectory Analysis
+5. Generate 5 recommended career directions (one per amplitude level):
    - L1 (Optimize Current): always detailed — baseline reference
    - L2 (Lateral Move): always included — low-friction alternative
    - L3 (New Company): detailed if Q1b ≠ "Love it" OR risk ≥ MODERATE
@@ -182,24 +208,26 @@ Increment `sources_used`.
    - L5 (Radical Change): always included — stretch option
    - Each direction must reference specific AI-resistant properties
    - Each must include target business types (real companies, mixed local + remote, diverse industries)
-   - L3-L5 must include a skills bridge table with concrete resources
+   - L3-L5 must include a skills bridge table with concrete resources; when resume available, use enhanced 4-column format with "Years" column and dormant flags (⚠️) per report-template.md
    - Each must cite web research findings and salary ranges
-5. **Anti-echo-chamber validation**: Run the 5-point checklist from analysis-framework.md. If any check fails → revise directions before finalizing:
+6. **Anti-echo-chamber validation**: Run the 5-point checklist from analysis-framework.md. If any check fails → revise directions before finalizing:
    - Not all 5 in same industry
    - Not all 5 require same primary skill
    - At least one direction NOT about building/selling AI
    - At least one leverages an unconsidered skill
    - L5 is genuinely radical
-6. **Salary anchoring** (if Q16 answered):
+7. **Salary anchoring** (if Q16 answered):
    - For each direction, compute delta vs current bracket from Q16
    - Populate "vs current" and "Minimum viable?" fields
    - Generate the Comparison Table with salary deltas
    - Add Financial Risk Assessment to Blind Spots section
-7. **Burnout integration** (if 3+ burnout flags from Step 8):
+8. **Burnout integration** (if 3+ burnout flags from Step 8):
    - Add Sustainability Warning subsection to Blind Spots
    - Extend all direction timelines by 3-6 months (or 6-12 months if 5/5 flags)
    - Recommend L1 as primary path if 5/5 flags
-8. Generate the complete report following `report-template.md` structure
+9. (if resume provided) **Career Trajectory section**: Generate per report-template.md — career timeline table, velocity classification, tenure stats, domain analysis, skill currency, and Resume vs Reality subsection (if Q3b answered)
+10. (if resume provided) **Career Pattern Blind Spots**: Add to Blind Spots section — skill atrophy, stagnation indicators, education-career misalignment, resume embellishment patterns, predicted next transition window
+11. Generate the complete report following `report-template.md` structure
 9. **Display the report** in the terminal
 10. **Save the report to disk:**
     - If `reportsDir` exists in loaded state → use it as default option
@@ -221,6 +249,7 @@ Increment `sources_used`.
      "reportsDir": "{chosen directory from Step 10}",
      "dataSources": {
        "memoryFilePath": "{path from Step 1}",
+       "resumePath": "{path from Step 1.5}",
        "insightsReportPath": "{path from Step 2}"
      },
      "answers": {
@@ -231,7 +260,7 @@ Increment `sources_used`.
      }
    }
    ```
-   New answer keys: `career_direction_sentiment` (Q1b), `ai_dependency_work` (Q5a), `ai_dependency_personal` (Q5b), `current_compensation` (Q16), `working_languages` (Q17), `local_market` (Q18).
+   New answer keys: `career_direction_sentiment` (Q1b), `resume_vs_reality` (Q3b), `ai_dependency_work` (Q5a), `ai_dependency_personal` (Q5b), `current_compensation` (Q16), `working_languages` (Q17), `local_market` (Q18).
    Old keys `ai_dependency` and `career_satisfaction` are preserved in state but no longer actively read. They serve as migration sources: on first run after upgrade, their values seed defaults for the new split questions (Q5a/Q1b). See interview-questions.md § Legacy answer migration for the mapping table. Old keys age out naturally after 6 months.
 2. `Write` to `~/.claude/ai-fortune.json`
 3. Confirm: "State saved. Run `/ai-fortune` again anytime — it will remember your answers and skip recent ones."
@@ -250,6 +279,6 @@ Increment `sources_used`.
 ## Important Notes
 
 - **Auto-save**: The report is displayed in the terminal and saved to a user-chosen directory (default: `/tmp/ai-fortune-reports/`). The chosen directory is remembered for future runs.
-- **Privacy**: No data leaves the local machine except WebSearch queries (which use general terms, not personal data)
+- **Privacy**: No data leaves the local machine except WebSearch queries (which use general terms, not personal data). Resume data stays local. Only aggregate career metrics (years, industry) inform WebSearch queries — never personal details (name, email, company names).
 - **Re-runnability**: Running `/ai-fortune` again will skip recent answers and use saved file paths
 - **Time estimate**: Full run with all sources takes ~5-10 minutes depending on interview length

--- a/plugins/ai-fortune/commands/ai-fortune/references/analysis-framework.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/analysis-framework.md
@@ -159,6 +159,11 @@ Compare self-reported data (interview) vs observed data (sessions/insights):
 | Compensation vs market | Q16 bracket | web search salary data for Q18 market | Under/over-compensated for role |
 | Work/life balance | Q2 daily tasks | time_distribution, session timestamps | Night/weekend work patterns |
 | Transition capacity | Q14 risk tolerance | burnout indicators, session intensity | Stated risk tolerance vs actual bandwidth |
+| Resume title vs self-report | Q1a current role | Resume most recent title | Title inflation/deflation — does resume overstate or understate? |
+| Career stability vs sentiment | Q1b career direction | Resume tenure patterns | Says "Love it" but switches yearly? Says "Need change" but 10yr tenure? |
+| Skills claimed vs verified | Q10 domain expertise | Resume skills + technology-explainer | Over/under-claiming — listed skills not backed by experience descriptions |
+| Experience vs self-report | Q7 years experience | Resume career span computation | Inaccurate self-assessment of career stage |
+| Resume vs reality | Q3b honest disclosure | Resume content | User's own identification of where resume doesn't match reality |
 
 ### How to present:
 - If data confirms self-report → reinforce with evidence
@@ -183,6 +188,48 @@ Screen for burnout risk using session metadata and interview answers. These indi
 - **0-2 flags**: Normal — no burnout mention in report
 - **3-4 flags**: **Sustainability Warning** — dedicated subsection in Blind Spots; extend all direction timelines by 3-6 months to account for recovery
 - **5 flags**: **URGENT** — prominent warning at top of Blind Spots; strongly recommend L1 (Optimize Current) as primary path; extend all timelines by 6-12 months
+
+---
+
+## Career Trajectory Analysis
+(conditional: only when PDF resume provided)
+
+### Career Stability Score (1-5)
+
+| Score | Label | Avg Tenure | Evidence Pattern |
+|-------|-------|------------|------------------|
+| 1 | Stable | >4 years | Long tenures, few transitions |
+| 2 | Steady | 3-4 years | Regular but not frequent moves |
+| 3 | Moderate | 2-3 years | Industry-normal transitions |
+| 4 | Mobile | 1-2 years | Frequent moves, short stints |
+| 5 | Volatile | ≤1 year | Very short tenures, pattern of exits |
+
+### Adaptability Evidence Score (1-5)
+
+| Score | Label | Evidence Pattern |
+|-------|-------|------------------|
+| 1 | Single-track | Same domain, same role type throughout career |
+| 2 | Minor variation | Same domain, 1-2 role type changes |
+| 3 | Moderate | 2-3 domain or role type changes |
+| 4 | Versatile | Multiple domains, successful transitions |
+| 5 | Radical adapter | Radical successful pivots across unrelated fields |
+
+### How trajectory affects risk dimensions:
+- **High domain diversity** → lowers Task Repeatability risk (proven ability to handle novel contexts)
+- **Cross-domain experience** → increases Creative Synthesis score (cross-pollination potential)
+- **Long single-domain tenure** → may increase Task Repeatability risk but lowers Regulation/Trust risk (deep expertise)
+
+### How trajectory affects directions:
+- **Long avg tenure** → predicts comfort with L1 (Optimize Current); L2/L3 may feel risky
+- **History of lateral moves** → predicts L2 success; user has done this before
+- **Past domain switches** → predicts L4 feasibility; demonstrated pivot capability
+- **Short avg tenure** → may indicate difficulty with L1 long-term; consider L3-L5
+
+### Skills Bridge Enhancement:
+When resume is available, enhance the "Already Have" column in Skills Bridge tables:
+- Add **years of experience** for each skill (computed from positions where it appeared)
+- Flag **dormant skills** — listed in resume but not used in last 2 positions (mark with ⚠️)
+- Distinguish **current skills** (last 2 positions) from **historical skills** (earlier only)
 
 ---
 

--- a/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
@@ -43,6 +43,13 @@ Questions are organized by tier. Each question specifies:
   - "No one else wants to maintain the CI/CD pipeline, so I do it" (only willing worker)
   - "I translate between the backend team and the product team" (cross-team coordination)
 
+### Q3b: Resume vs Reality (conditional)
+- **key:** `resume_vs_reality`
+- **type:** `free_text`
+- **prompt:** "Looking at your resume, it highlights {skills_from_resume}. Is there anything that doesn't fully reflect your current reality? (e.g., skills you listed but rarely use now, titles that over/understate your role, descriptions that are more aspirational than factual). Be honest — this helps us identify where the market sees you vs where you actually are."
+- **skip_if_data:** skip if no resume provided
+- **tier:** 1 (always ask when resume available)
+
 ---
 
 ## Tier 2: AI Context (always ask)
@@ -209,6 +216,15 @@ Questions are organized by tier. Each question specifies:
 - If memory file mentions languages → Q17 can be pre-filled, confirm
 - If Q15 already covers geography or memory has location → Q18 can be pre-filled, confirm
 - Q18 should be asked before Q16 when both are unanswered (so currency can adapt)
+
+### Resume-based auto-skip rules:
+When a PDF resume is provided, pre-fill the following questions from extracted data. **Always confirm with the user — never silently skip** (resumes can be outdated):
+- Q1a (current role): pre-fill from most recent position title + company
+- Q7 (years experience): compute total years from first position start date
+- Q8 (management vs IC): infer from title patterns (Manager/Director → management; Engineer/Developer → IC)
+- Q10 (domain expertise): extract domain knowledge from experience descriptions
+- Q17 (languages): if resume mentions languages spoken
+- Q18 (local market): pre-fill from resume header location
 
 ### Re-ask rules (persistent state):
 - Answer < 6 months old → skip question, show "Using your previous answer from {date}: {value}"

--- a/plugins/ai-fortune/commands/ai-fortune/references/report-template.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/report-template.md
@@ -10,7 +10,7 @@ Display the report in the terminal, then save it to the user-chosen directory (s
 ```
 # Career Direction Report
 
-Generated: {date} | Sources: {N}/8 used
+Generated: {date} | Sources: {N}/9 used
 
 ---
 
@@ -20,6 +20,9 @@ Generated: {date} | Sources: {N}/8 used
 **Location:** {from Q18} | **Languages:** {from Q17}
 **AI Adoption at org:** {level} | **AI (work):** {Q5a} | **AI (personal):** {Q5b}
 **Current compensation:** {from Q16}
+**Career stage:** {early/mid/senior/executive — from resume} (conditional: only when resume provided)
+**Education:** {degree, institution — from resume} (conditional: only when resume provided)
+**Career span:** {N years, M companies — from resume} (conditional: only when resume provided)
 
 **Technology Proficiency Map** (from technology-explainer):
 - Expert: {list}
@@ -30,6 +33,39 @@ Generated: {date} | Sources: {N}/8 used
 - {data-derived strength 1}
 - {data-derived strength 2}
 - {interview-derived strength 3}
+
+---
+
+## Career Trajectory Analysis
+(conditional: only when PDF resume provided)
+
+**Career span:** {N} years across {M} companies
+
+**Career timeline:**
+| Period | Company | Title | Duration | Industry |
+|--------|---------|-------|----------|----------|
+| {dates} | {company} | {title} | {duration} | {industry} |
+
+**Career velocity:** {classification} — {evidence}
+**Average tenure:** {N} yrs/role | **Longest:** {company, N yrs} | **Shortest:** {company, N months}
+**Domain switches:** {N} across {M} industries
+**Company pattern:** {trajectory, e.g., "startup → enterprise" or "consistently mid-size"}
+**Career trajectory:** {direction, e.g., "IC deepening" or "Management track"}
+
+**Key career patterns:**
+- {observation 1 — e.g., "Progressive seniority with 3-year cycles"}
+- {observation 2 — e.g., "Consistent fintech domain with one lateral into healthtech"}
+- {observation 3 — e.g., "Recent shift from hands-on coding to architecture roles"}
+
+**Skill currency:**
+- **Current** (used in last 2 years): {list}
+- **Dormant** (listed but not recent): {list}
+- **Emerging** (recent only): {list}
+
+**Resume vs Reality:** (conditional: only when Q3b answered)
+{User's honest assessment of discrepancies between resume and reality.
+Frame constructively: "Your resume positions you as X, but you note that Y —
+this gap creates both risk (market mismatch) and opportunity (hidden strengths)."}
 
 ---
 
@@ -60,6 +96,9 @@ aggressive interruptor, meta-learning feedback loop builder"}
 | Physical Presence | {stars} | {evidence} |
 | Regulatory/Trust | {stars} | {evidence} |
 | Creative Synthesis | {stars} | {evidence} |
+
+**Career Stability Score: {1-5}** — {evidence} (conditional: resume-enhanced)
+**Adaptability Evidence: {1-5}** — {evidence} (conditional: resume-enhanced)
 
 **Timeline:** {when AI can handle core functions of this role}
 
@@ -141,9 +180,11 @@ Cite specific companies and tools, not vague generalities.}
 {2-3 sentences referencing AI-resistant properties.}
 
 **Skills bridge:**
-| Already Have | Need to Acquire | How to Get |
-|-------------|-----------------|------------|
-| {skill from data} | {skill gap} | {specific resource/course/path} |
+| Already Have (verified) | Years | Need to Acquire | How to Get |
+|------------------------|-------|-----------------|------------|
+| {skill from data} | {N} | {skill gap} | {specific resource/course/path} |
+| {dormant skill} ⚠️ | {N} | {refresh needed} | {specific resource} |
+(When resume not available, omit "Years" column and dormant flags — use standard 3-column format)
 
 **Salary range:** {range} | **vs current:** {delta} | **Minimum viable?** {yes/no}
 **Timeline:** {estimate with milestones}
@@ -168,9 +209,11 @@ Cite specific companies and tools, not vague generalities.}
 {2-3 sentences referencing AI-resistant properties.}
 
 **Skills bridge:**
-| Already Have | Need to Acquire | How to Get |
-|-------------|-----------------|------------|
-| {skill from data} | {skill gap} | {specific resource/course/path} |
+| Already Have (verified) | Years | Need to Acquire | How to Get |
+|------------------------|-------|-----------------|------------|
+| {skill from data} | {N} | {skill gap} | {specific resource/course/path} |
+| {dormant skill} ⚠️ | {N} | {refresh needed} | {specific resource} |
+(When resume not available, omit "Years" column and dormant flags — use standard 3-column format)
 
 **Salary range:** {range} | **vs current:** {delta} | **Minimum viable?** {yes/no}
 **Timeline:** {estimate with milestones}
@@ -195,9 +238,11 @@ Cite specific companies and tools, not vague generalities.}
 {2-3 sentences referencing AI-resistant properties.}
 
 **Skills bridge:**
-| Already Have | Need to Acquire | How to Get |
-|-------------|-----------------|------------|
-| {skill from data} | {skill gap} | {specific resource/course/path} |
+| Already Have (verified) | Years | Need to Acquire | How to Get |
+|------------------------|-------|-----------------|------------|
+| {skill from data} | {N} | {skill gap} | {specific resource/course/path} |
+| {dormant skill} ⚠️ | {N} | {refresh needed} | {specific resource} |
+(When resume not available, omit "Years" column and dormant flags — use standard 3-column format)
 
 **Salary range:** {range} | **vs current:** {delta} | **Minimum viable?** {yes/no}
 **Timeline:** {estimate with milestones}
@@ -261,6 +306,16 @@ itself a career differentiator.}
 - Skill gaps between current role and recommended directions
 - Contrastive analysis findings (self-reported vs observed discrepancies)}
 
+### Career Pattern Blind Spots
+(conditional: only when PDF resume provided)
+
+{Resume-derived observations the user may not see:
+- **Skill atrophy:** skills listed on resume but unused in last 2+ positions — market may expect proficiency the user no longer has
+- **Stagnation indicators:** same title for 5+ years without scope expansion — may signal plateau
+- **Education-career misalignment:** degree field vs actual career path — untapped potential or irrelevant credential
+- **Resume embellishment patterns** (from Q3b): where user admits resume doesn't match reality — reframe as actionable gaps
+- **Predicted next transition window:** based on avg tenure and current position duration — "Based on your pattern, you typically transition around {N} years. You're at {M} years now."}
+
 ### Sustainability Warning
 (conditional: only if 3+ burnout risk indicators flagged)
 
@@ -288,6 +343,7 @@ itself a career differentiator.}
 | Source | Status | Key Insight |
 |--------|--------|-------------|
 | Memory Chat File | {check/cross} | {one-line summary} |
+| PDF Resume | {check/cross} | {N years, M companies, career velocity} |
 | CC Insights Report | {check/cross} | {summary} |
 | Session Metadata ({N}d) | {check/cross} | {N sessions, M projects} |
 | Technology Explainer | {check/cross} | {expert/intermediate/learning counts} |

--- a/plugins/ai-fortune/commands/ai-fortune/references/resume-extraction.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/resume-extraction.md
@@ -1,0 +1,105 @@
+# Resume Extraction Template
+
+Extract career data from the user's PDF resume (LinkedIn export, Europass, or any structured format). Claude reads PDFs natively via the Read tool — no external parsing needed.
+
+**Minimum required:** 2+ positions with dates.
+
+---
+
+## Raw Extraction Fields
+
+### Contact & Identity
+- Name, current title, location, email (if present)
+
+### Skills
+- Explicitly listed skills section
+- Technologies/tools mentioned in position descriptions
+
+### Experience Timeline
+Array of positions, each with:
+```
+{
+  "company": "Company Name",
+  "title": "Job Title",
+  "startDate": "YYYY-MM",
+  "endDate": "YYYY-MM or Present",
+  "duration": "N years M months",
+  "location": "City, Country (or Remote)",
+  "description": "Key responsibilities and achievements",
+  "technologies": ["tech1", "tech2"]
+}
+```
+
+### Education
+```
+{
+  "institution": "University Name",
+  "degree": "Degree Type",
+  "field": "Field of Study",
+  "dates": "YYYY-YYYY"
+}
+```
+
+### Certifications
+List of certifications with issuing body and date (if present).
+
+---
+
+## Computed Metrics
+
+### Career Timeline
+- **Total years:** from first position start date to now
+- **Role count:** number of distinct positions
+- **Average tenure:** total years / role count
+- **Longest tenure:** company name + duration
+- **Shortest tenure:** company name + duration
+
+### Career Velocity Classification
+Classify based on promotion/transition patterns:
+
+| Classification | Pattern | Evidence |
+|---------------|---------|----------|
+| **Rocket** | 1-2 year promotions within same company | Multiple title changes at same employer |
+| **Steady Climber** | 2-4 year tenure, progressive titles | Regular upward moves |
+| **Deep Specialist** | Same level across different companies | Title stays similar, company changes |
+| **Explorer** | Frequent domain switches | Different industries every 2-3 years |
+| **Settled** | Long tenure at one company | 5+ years at current employer |
+
+### Domain Analysis
+- **Distinct industries:** count unique industries across positions
+- **Domain switches:** number of times industry changed between consecutive positions
+- **Diversification score:** industries / roles (0-1 scale; 1 = every role in different industry)
+- **Primary domain:** industry with most total years
+
+### Company Pattern
+- **Trajectory:** startup → enterprise, enterprise → startup, mixed, consistent size
+- **Geographic mobility:** same city, same country, international
+
+### Technology Adoption Timeline
+- Group technologies by era (which positions they appeared in)
+- **Adoption speed:** early adopter (uses tech within 1-2 years of release) vs late adopter
+
+### Skill Currency
+- **Current** (used in last 2 positions): actively practiced skills
+- **Dormant** (listed in skills but not in recent descriptions): may be rusty
+- **Emerging** (appear only in most recent position): newly acquired
+
+### Career Trajectory Direction
+Classify the overall trajectory:
+- **IC deepening** — progressively senior IC titles (Junior → Senior → Staff → Principal)
+- **Management track** — IC → Lead → Manager → Director
+- **IC recovery** — Management → back to IC roles
+- **Lateral exploration** — similar seniority, different domains/functions
+- **Entrepreneurial** — employee → founder/freelance
+- **Stabilization** — long tenure in current role, no recent transitions
+
+---
+
+## Format-Agnostic Notes
+
+This template works with any structured PDF resume:
+- **LinkedIn exports:** Usually well-structured with clear sections
+- **Europass:** Standardized EU format with dates and skills sections
+- **Custom resumes:** Extract whatever career data is available
+
+If the resume is minimal (freelance portfolio, academic CV, etc.), extract what's available and note gaps. The analysis adapts to available data — partial extraction is better than skipping.

--- a/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
@@ -19,11 +19,14 @@ Critical components to test:
 4. Data access tests (automated)
 5. Full flow (manual)
 6. Graceful degradation (manual)
+7. v0.3.0 feature criteria (manual)
+8. PDF resume integration (manual)
+9. v0.4.0 feature criteria (manual)
 
 ## Automation Status
 
 - ✅ Fully automated: Tests 1, 2, 3, 4
-- ⚠️ Manual only: Tests 5, 6 (require interactive interview + report quality review)
+- ⚠️ Manual only: Tests 5, 6, 7, 8, 9 (require interactive interview + report quality review)
 
 ## Automated Test Results (Last Run)
 
@@ -60,7 +63,7 @@ import json, sys
 with open('$PLUGIN/.claude-plugin/plugin.json') as f:
     p = json.load(f)
 assert p['name'] == 'ai-fortune', f'wrong name: {p[\"name\"]}'
-assert p['version'] == '0.3.0', f'wrong version: {p[\"version\"]}'
+assert p['version'] == '0.4.0', f'wrong version: {p[\"version\"]}'
 assert 'commands' in p, 'missing commands field'
 print('plugin.json: OK')
 "
@@ -87,14 +90,14 @@ python3 -m py_compile $PLUGIN/scripts/aggregate-sessions.py && echo "aggregate-s
 python3 -c "import json; json.load(open('$PLUGIN/templates/ai-fortune.json'))" && echo "template: OK"
 
 # 1.5 Reference files exist
-for f in interview-questions.md analysis-framework.md report-template.md; do
+for f in interview-questions.md analysis-framework.md report-template.md resume-extraction.md; do
   test -f "$PLUGIN/commands/ai-fortune/references/$f" && echo "$f: OK" || echo "$f: MISSING"
 done
 ```
 
 **Expected:**
 - ✅ All checks pass
-- ✅ plugin.json has name `ai-fortune`, version `0.3.0`
+- ✅ plugin.json has name `ai-fortune`, version `0.4.0`
 - ✅ SKILL.md starts with `---` and has `name:` + `description:` in frontmatter
 - ✅ Both scripts compile without errors
 
@@ -297,6 +300,75 @@ else:
 | Anti-echo-chamber | At least one direction NOT about building/selling AI | |
 | New state keys | ai-fortune.json saves `career_direction_sentiment`, `ai_dependency_work`, `ai_dependency_personal`, `current_compensation`, `working_languages`, `local_market` | |
 | Backward compat | Old keys `ai_dependency`, `career_satisfaction` ignored but not deleted | |
+
+### 8. PDF Resume Integration (Manual)
+
+**Objective:** Verify PDF resume data extraction, auto-fill, Career Trajectory section, and Q3b.
+
+**Automation:** ⚠️ Manual
+
+**Procedure:**
+
+#### 8.1: Full flow with resume
+1. Run `/ai-fortune` with a PDF resume (LinkedIn export or custom)
+2. Verify:
+   - Resume is read and career data extracted (positions, dates, skills)
+   - Q3b ("Resume vs Reality") is asked with extracted skills listed
+   - Auto-fill works for Q1a (role), Q7 (years), Q8 (IC/management), Q18 (location)
+   - Career Trajectory Analysis section appears in report (after Your Profile)
+   - Resume vs Reality subsection appears in Career Trajectory (from Q3b answer)
+   - Skills Bridge tables use enhanced 4-column format with "Years" column and dormant flags (⚠️)
+   - Career Pattern Blind Spots subsection appears in Blind Spots
+   - Data Sources table shows 9 rows with PDF Resume row
+   - Header shows `Sources: {N}/9 used`
+
+#### 8.2: Skip flow (no resume)
+1. Run `/ai-fortune`, skip resume when asked
+2. Verify:
+   - No Career Trajectory Analysis section in report
+   - No Q3b question asked
+   - No Career Pattern Blind Spots subsection
+   - Skills Bridge tables use standard 3-column format
+   - Data Sources table shows PDF Resume as ❌
+   - Report still generates normally with all other sections
+
+#### 8.3: Re-use saved resume path
+1. Run `/ai-fortune` after a previous run that used a resume
+2. Verify:
+   - AskUserQuestion offers "Use saved path `{path}`?" with saved path
+   - Selecting "Use saved path" reads the same file
+   - Selecting "Enter different path" allows changing the file
+
+**Outcomes:**
+
+| Step | Expected | Actual |
+|------|----------|--------|
+| 8.1 Full flow | Resume extracted, Q3b asked, Career Trajectory in report | |
+| 8.2 Skip flow | No resume sections, report works normally | |
+| 8.3 Re-use path | Saved path offered and works | |
+
+### 9. v0.4.0 Feature Acceptance Criteria
+
+**Objective:** Verify all PDF resume integration features from v0.4.0.
+
+**Automation:** ⚠️ Manual
+
+**Criteria:**
+
+| Feature | Acceptance Criterion | Verified |
+|---------|---------------------|----------|
+| Resume as 9th source | Data Sources table has 9 rows, counter /9 | |
+| Any PDF format | Works with LinkedIn, Europass, custom resumes | |
+| Q3b resume vs reality | Asked when resume provided, skipped otherwise | |
+| Career Trajectory section | Appears after Your Profile when resume provided | |
+| Career velocity | Computed and classified (Rocket/Steady/Deep/Explorer/Settled) | |
+| Skill currency | Current/dormant/emerging listed | |
+| Auto-fill from resume | Q1a, Q7, Q8, Q10, Q17, Q18 pre-filled, confirmed | |
+| Enhanced Skills Bridge | "Years" column + dormant flags (⚠️) when resume available | |
+| Career Pattern Blind Spots | Subsection with resume-derived observations | |
+| Resume vs Reality in report | Q3b response integrated into Career Trajectory | |
+| No resume = no crash | All resume sections gracefully absent | |
+| State persistence | resumePath saved in dataSources | |
 
 ---
 

--- a/plugins/ai-fortune/templates/ai-fortune.json
+++ b/plugins/ai-fortune/templates/ai-fortune.json
@@ -4,6 +4,7 @@
   "reportsDir": null,
   "dataSources": {
     "memoryFilePath": null,
+    "resumePath": null,
     "insightsReportPath": "~/.claude/usage-data/report.html"
   },
   "answers": {}


### PR DESCRIPTION
## Summary
- Add optional PDF resume (LinkedIn, Europass, any format) as the 8th automated data source for career direction analysis
- New `resume-extraction.md` reference file with extraction fields and computed metrics (career velocity, domain analysis, skill currency, trajectory direction)
- New interview question Q3b "Resume vs Reality" — asks user to honestly identify where their resume doesn't match reality (conditional: only when resume provided)
- Career Trajectory Analysis report section with career timeline, velocity classification, tenure stats, skill currency (current/dormant/emerging), and resume vs reality assessment
- Enhanced Skills Bridge tables with "Years" column and dormant skill flags (⚠️) when resume available
- Career Pattern Blind Spots subsection (skill atrophy, stagnation indicators, predicted next transition window)
- Resume-based auto-fill for 6 interview questions (Q1a, Q7, Q8, Q10, Q17, Q18) — always confirms, never silently skips
- 5 new contrastive analysis rows comparing resume data vs self-reported answers
- Version bump `0.3.0` → `0.4.0` (MINOR: new backwards-compatible feature)

## Test plan
- [x] Static checks pass (plugin.json, SKILL.md frontmatter, reference files, template JSON)
- [ ] Manual: Full flow with PDF resume — extraction, Q3b, auto-fill, Career Trajectory in report
- [ ] Manual: Skip flow without resume — no resume sections, report generates normally
- [ ] Manual: Re-use saved resume path on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)