### PR TITLE
feat(ai-fortune): add report language configuration v0.5.0

### DIFF
--- a/plugins/ai-fortune/.claude-plugin/plugin.json
+++ b/plugins/ai-fortune/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-fortune",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Career direction analysis: interview + AI usage pattern mining to identify roles AI won't replace",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/ai-fortune/README.md
+++ b/plugins/ai-fortune/README.md
@@ -159,6 +159,8 @@ Reports are automatically saved to a user-chosen directory (default: `/tmp/ai-fo
 
 No setup wizard needed — just run `/ai-fortune`. The plugin discovers data sources automatically and asks about any it can't find.
 
+**Report language:** Before the interview, the plugin asks which language to generate the report in. If your `~/.claude/settings.json` has a non-English language preference, it appears as the first option. You can also type any language. The choice is saved and reused on future runs (re-asked if settings language changes or after 6 months).
+
 State file: `~/.claude/ai-fortune.json`
 
 ## 🔧 Troubleshooting <a name="troubleshooting"></a>

--- a/plugins/ai-fortune/commands/ai-fortune/SKILL.md
+++ b/plugins/ai-fortune/commands/ai-fortune/SKILL.md
@@ -17,8 +17,8 @@ Run all phases in order. Each step specifies the exact tools to use.
 ### Step 0: Load State
 
 1. Read `~/.claude/ai-fortune.json`
-   - If exists → load `dataSources` (saved file paths), `answers` (interview answers with timestamps), `reportsDir` (saved report directory)
-   - If not found → start with empty state: `dataSources = {}`, `answers = {}`, `reportsDir = null`
+   - If exists → load `reportLanguage` (language preference), `dataSources` (saved file paths), `answers` (interview answers with timestamps), `reportsDir` (saved report directory)
+   - If not found → start with empty state: `reportLanguage = null`, `dataSources = {}`, `answers = {}`, `reportsDir = null`
 2. Set `sources_used = 0` counter to track how many of the 9 data sources produce data
 
 ---
@@ -103,6 +103,42 @@ Collect data from up to 8 sources. Each source is optional — if unavailable, n
 2. If exists → extract: total sessions, messages/day, model distribution, date range
 3. If not found → note as unavailable, continue
 4. Increment `sources_used` if found
+
+### Step 6.5: Report Language Preference
+
+**Purpose:** Determine the language for the generated report before starting the interview.
+
+1. Check `reportLanguage` in loaded state (top-level field, not inside `answers`)
+2. Apply re-ask logic per `interview-questions.md` § Tier 0 / Q0:
+
+   **Decision tree:**
+   ```
+   reportLanguage exists in state?
+   ├── YES → How old is the value?
+   │   ├── < 6 months AND source == "settings" AND settings.json language changed → RE-ASK
+   │   ├── < 6 months (otherwise) → SKIP: Display "Report language: {value}"
+   │   └── >= 6 months → RE-ASK with previous value as default
+   └── NO → ASK
+   ```
+
+3. When asking, build options dynamically:
+   - Read `~/.claude/settings.json` for language preference
+   - If non-English language detected → first option: `"{language} (from settings)"`
+   - Always include: `"English"`
+   - User can type any language via free text
+4. Store chosen language in state as:
+   ```json
+   {
+     "reportLanguage": {
+       "value": "{chosen language}",
+       "answeredAt": "{ISO 8601}",
+       "source": "settings|explicit|custom"
+     }
+   }
+   ```
+   - `source: "settings"` — picked the option detected from settings.json
+   - `source: "explicit"` — picked "English"
+   - `source: "custom"` — typed a custom language
 
 ---
 
@@ -228,6 +264,7 @@ Increment `sources_used`.
 9. (if resume provided) **Career Trajectory section**: Generate per report-template.md — career timeline table, velocity classification, tenure stats, domain analysis, skill currency, and Resume vs Reality subsection (if Q3b answered)
 10. (if resume provided) **Career Pattern Blind Spots**: Add to Blind Spots section — skill atrophy, stagnation indicators, education-career misalignment, resume embellishment patterns, predicted next transition window
 11. Generate the complete report following `report-template.md` structure
+12. **Report language**: If `reportLanguage` value is not "English", generate the entire report in the configured language. Translate all narrative text, section headers, analysis, action items, and table headers. Keep company names, technology names, product names, URLs, and book titles in their original language.
 9. **Display the report** in the terminal
 10. **Save the report to disk:**
     - If `reportsDir` exists in loaded state → use it as default option
@@ -244,6 +281,11 @@ Increment `sources_used`.
 1. Build state object:
    ```json
    {
+     "reportLanguage": {
+       "value": "{chosen language from Step 6.5}",
+       "answeredAt": "{ISO 8601 timestamp}",
+       "source": "settings|explicit|custom"
+     },
      "lastRun": "{ISO 8601 timestamp}",
      "lastReportPath": "{full path to saved report from Step 10}",
      "reportsDir": "{chosen directory from Step 10}",

--- a/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
@@ -9,6 +9,37 @@ Questions are organized by tier. Each question specifies:
 
 ---
 
+## Tier 0: Report Settings (before interview)
+
+### Q0: Report Language
+- **key:** `reportLanguage`
+- **type:** `multiple_choice`
+- **prompt:** "What language should the report be generated in?"
+- **storage:** Top-level field in `~/.claude/ai-fortune.json` (NOT inside `answers`):
+  ```json
+  {
+    "reportLanguage": {
+      "value": "English",
+      "answeredAt": "2026-03-02T...",
+      "source": "explicit"
+    }
+  }
+  ```
+- **source values:** `"settings"` (detected from settings.json), `"explicit"` (English or picked from options), `"custom"` (user typed a language)
+- **options:** Dynamic — built at runtime:
+  1. If `~/.claude/settings.json` contains a non-English language preference → show `"{settingsLanguage} (from settings)"` as first option
+  2. `"English"`
+  3. Free text for any other language
+- **re-ask logic:**
+  - If `reportLanguage` exists and is < 6 months old:
+    - If `source == "settings"` AND settings.json language has changed since `answeredAt` → RE-ASK (settings changed)
+    - Otherwise → SKIP: display "Report language: {value}"
+  - If `reportLanguage` exists and is >= 6 months old → RE-ASK with previous value as default
+  - If `reportLanguage` is null → ASK
+- **default:** English (when no settings language detected and user doesn't specify)
+
+---
+
 ## Tier 1: Role & Industry (always ask)
 
 ### Q1a: Current Role & Industry (factual)

--- a/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
@@ -22,6 +22,7 @@ Critical components to test:
 7. v0.3.0 feature criteria (manual)
 8. PDF resume integration (manual)
 9. v0.4.0 feature criteria (manual)
+10. v0.5.0 feature criteria (manual)
 
 ## Automation Status
 
@@ -63,7 +64,7 @@ import json, sys
 with open('$PLUGIN/.claude-plugin/plugin.json') as f:
     p = json.load(f)
 assert p['name'] == 'ai-fortune', f'wrong name: {p[\"name\"]}'
-assert p['version'] == '0.4.0', f'wrong version: {p[\"version\"]}'
+assert p['version'] == '0.5.0', f'wrong version: {p[\"version\"]}'
 assert 'commands' in p, 'missing commands field'
 print('plugin.json: OK')
 "
@@ -97,7 +98,7 @@ done
 
 **Expected:**
 - ✅ All checks pass
-- ✅ plugin.json has name `ai-fortune`, version `0.4.0`
+- ✅ plugin.json has name `ai-fortune`, version `0.5.0`
 - ✅ SKILL.md starts with `---` and has `name:` + `description:` in frontmatter
 - ✅ Both scripts compile without errors
 
@@ -369,6 +370,30 @@ else:
 | Resume vs Reality in report | Q3b response integrated into Career Trajectory | |
 | No resume = no crash | All resume sections gracefully absent | |
 | State persistence | resumePath saved in dataSources | |
+
+### 10. v0.5.0 Feature Acceptance Criteria
+
+**Objective:** Verify report language configuration feature.
+
+**Automation:** ⚠️ Manual
+
+**Criteria:**
+
+| Feature | Acceptance Criterion | Verified |
+|---------|---------------------|----------|
+| Language question before interview | Step 6.5 asks language preference before Phase 2 interview starts | |
+| Settings detection | If `~/.claude/settings.json` has non-English language, it appears as first option | |
+| English default | When no settings language detected, "English" is the default | |
+| Custom language | User can type any language (e.g., "Français", "日本語") via free text | |
+| Persistence | `reportLanguage` saved as top-level field in `~/.claude/ai-fortune.json` (not inside `answers`) | |
+| Source tracking | `source` field correctly set: `"settings"`, `"explicit"`, or `"custom"` | |
+| Skip if recent | Answer < 6 months old → skip, show "Report language: {value}" | |
+| Re-ask on settings change | If `source: "settings"` and settings.json language changed → re-ask regardless of age | |
+| Re-ask if stale | Answer >= 6 months old → re-ask with previous value as default | |
+| Report in language | Non-English language → entire report generated in chosen language | |
+| Preserved terms | Company names, tech names, URLs, book titles remain in original language in translated report | |
+| Backward compatible | Missing `reportLanguage` (null or absent) → defaults to English, no errors | |
+| Template updated | `templates/ai-fortune.json` has `"reportLanguage": null` field | |
 
 ---
 

--- a/plugins/ai-fortune/templates/ai-fortune.json
+++ b/plugins/ai-fortune/templates/ai-fortune.json
@@ -1,4 +1,5 @@
 {
+  "reportLanguage": null,
   "lastRun": null,
   "lastReportPath": null,
   "reportsDir": null,


### PR DESCRIPTION
## Summary
- Add `reportLanguage` as a persistent top-level config field in `~/.claude/ai-fortune.json`
- New Step 6.5 asks language preference before interview, with auto-detection from `settings.json`
- Reports generate in the configured language (company/tech names preserved in original)
- Re-ask logic: skip if < 6 months old, re-ask if settings language changed or stale

## Changed files (6)
- `SKILL.md` — Step 0 loads, Step 6.5 asks, Step 10 generates, Step 11 saves
- `interview-questions.md` — Tier 0 / Q0 section
- `templates/ai-fortune.json` — `reportLanguage: null` field
- `plugin.json` — 0.4.0 → 0.5.0
- `ACCEPTANCE_TESTS.md` — v0.5.0 section (13 criteria)
- `README.md` — Configuration section updated

## Test plan
- [ ] Verify `templates/ai-fortune.json` has `reportLanguage` field
- [ ] Run `/ai-fortune` — confirm Step 6.5 asks language before interview
- [ ] Pick non-English language — confirm report generates in that language
- [ ] Re-run `/ai-fortune` — confirm language is skipped (< 6 months)
- [ ] Verify backward compat: delete `reportLanguage` from state → defaults to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)