### PR TITLE
feat(ai-fortune): add 3 new interview questions and satisfaction alignment v0.6.0

### DIFF
--- a/plugins/ai-fortune/.claude-plugin/plugin.json
+++ b/plugins/ai-fortune/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-fortune",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Career direction analysis: interview + AI usage pattern mining to identify roles AI won't replace",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/ai-fortune/README.md
+++ b/plugins/ai-fortune/README.md
@@ -14,7 +14,7 @@ A Claude Code plugin that analyzes your AI usage patterns, runs an adaptive care
 
 One command that:
 1. Mines up to 8 data sources (insights report, session metadata, plugins, tech proficiency, stats, PDF resume)
-2. Runs an adaptive 18-question interview with sub-questions (skips what it already knows)
+2. Runs an adaptive 21-question interview with sub-questions (skips what it already knows)
 3. Researches your industry's AI landscape via 5-8 targeted web searches
 4. Generates a 5-level amplitude spectrum of career directions — from optimize-in-place to radical change
 5. Detects burnout risk from session patterns and flags sustainability warnings

--- a/plugins/ai-fortune/commands/ai-fortune/SKILL.md
+++ b/plugins/ai-fortune/commands/ai-fortune/SKILL.md
@@ -147,7 +147,7 @@ Collect data from up to 8 sources. Each source is optional — if unavailable, n
 ### Step 7: Adaptive Interview
 
 1. `Read` `${SKILL_DIR}/references/interview-questions.md`
-2. For each question (Q1a, Q1b, Q2, Q3, Q4, Q5a, Q5b, Q6-Q12, Q14-Q18), apply re-ask logic:
+2. For each question (Q1a, Q1b, Q1c, Q2, Q2b, Q3, Q4, Q5a, Q5b, Q6-Q12, Q14-Q19), apply re-ask logic:
 
    **Re-ask decision tree:**
    ```
@@ -179,6 +179,8 @@ Collect data from up to 8 sources. Each source is optional — if unavailable, n
    - Q17 (languages): if memory file or resume mentions languages → pre-fill, confirm
    - Q18 (local market): if Q15 covers geography or memory/resume has location → pre-fill, confirm
    - Q18 should be asked before Q16 when both are unanswered (so currency placeholder adapts)
+   - Q2b (work description): if memory file or resume contains detailed work descriptions → pre-fill, confirm
+   - Q19 (AI monetization): if technology-explainer has expert entries or Q10 already answered → reference as context, still ask
    - **Resume pre-fills always confirm** — never silently skip, since resumes can be outdated
 
 6. **Tier 3 collapse**: If user gives 2+ consecutive minimal answers (picks first option without customizing), skip remaining Tier 3 questions
@@ -197,6 +199,10 @@ Collect data from up to 8 sources. Each source is optional — if unavailable, n
    - Claimed strengths (Q3, Q10) vs impressive_things from insights
    - Compensation (Q16) vs market rates for role (will compare in Step 9)
    - Session timestamps vs Q2 — detect night/weekend work patterns
+   - Work description (Q2b) vs project_areas from insights — discrepancy between described work and actual AI usage
+   - Satisfaction sources (Q1c) vs work description (Q2b) — satisfaction gap: is energy inside or outside work?
+   - Satisfaction sources (Q1c) vs career trajectory (Q1b) — says "Love it" but energy comes from pet projects?
+   - AI monetization vision (Q19) vs AI leverage score — inflated/overlooked opportunity assessment
    - (if resume provided) Resume title vs self-reported role (Q1a) → title inflation/deflation
    - (if resume provided) Resume tenure patterns vs career sentiment (Q1b) → says "Love it" but switches yearly?
    - (if resume provided) Resume skills vs technology-explainer proficiency → over/under-claiming
@@ -204,6 +210,7 @@ Collect data from up to 8 sources. Each source is optional — if unavailable, n
    - (if Q3b answered) Resume vs reality — user's honest disclosure about resume embellishments
 3. Note any discrepancies for the Blind Spots section
 4. Compute preliminary risk scores for each of the 5 dimensions
+5. **Satisfaction Alignment Score (1-5)**: Compare Q1c satisfaction sources against Q2b work description. Score 1 = energy exclusively outside job, 5 = fully aligned with day job. See analysis-framework.md § Satisfaction Alignment Score for scoring table and how it affects directions/blind spots.
 5. **Burnout risk screening**: Count burnout indicators from analysis-framework.md (night work >30%, no rest days 7/7, dual workload, session marathon >3h, escalating volume >50% WoW). Record flag count for report generation.
 
 ---
@@ -214,14 +221,15 @@ Collect data from up to 8 sources. Each source is optional — if unavailable, n
 
 Perform 5-8 targeted `WebSearch` queries based on the user's profile:
 
-1. `WebSearch`: "AI automation {user's industry} 2026 trends"
-2. `WebSearch`: "{user's role title} AI replacement risk 2026"
+1. `WebSearch`: "AI automation {user's industry} {current year} trends"
+2. `WebSearch`: "{user's role title} AI replacement risk {current year}"
 3. `WebSearch`: "AI-resistant careers {user's domain}"
-4. `WebSearch`: "{user's top technology} AI automation capabilities 2026" (if relevant)
-5. `WebSearch`: "{user's role} salary range {Q18 city/market} 2026" (use Q18 answer for geography-specific searches)
+4. `WebSearch`: "{user's top technology} AI automation capabilities {current year}" (if relevant)
+5. `WebSearch`: "{user's role} salary range {Q18 city/market} {current year}" (use Q18 answer for geography-specific searches)
 6. `WebSearch`: "{recommended L3 direction} job market {Q18 city}" (target business discovery)
-7. `WebSearch`: "{recommended L5 direction} freelance market demand 2026" (radical change validation)
+7. `WebSearch`: "{recommended L5 direction} freelance market demand {current year}" (radical change validation)
 8. `WebSearch`: "{recommended direction} salary range {user's geography}" (after directions are drafted, for remaining levels)
+9. `WebSearch`: "{Q19 skill/domain} AI service market demand {current year}" (validates AI monetization opportunities from Q19)
 
 For each search → extract key findings, specific companies/products, salary data.
 Increment `sources_used`.
@@ -236,6 +244,7 @@ Increment `sources_used`.
    - **AI Leverage Score**: compute from plugin count, session complexity, multi-clauding %, task-agent %, delegation maturity
    - **Delegation Maturity Level**: determine from session types, tool distribution, multi-clauding stats
    - (if resume provided) **Career Stability Score** and **Adaptability Evidence Score**: compute per analysis-framework.md § Career Trajectory Analysis
+   - **Satisfaction Alignment Score** (1-5): from Q1c vs Q2b comparison per analysis-framework.md
 5. Generate 5 recommended career directions (one per amplitude level):
    - L1 (Optimize Current): always detailed — baseline reference
    - L2 (Lateral Move): always included — low-friction alternative
@@ -302,7 +311,7 @@ Increment `sources_used`.
      }
    }
    ```
-   New answer keys: `career_direction_sentiment` (Q1b), `resume_vs_reality` (Q3b), `ai_dependency_work` (Q5a), `ai_dependency_personal` (Q5b), `current_compensation` (Q16), `working_languages` (Q17), `local_market` (Q18).
+   New answer keys: `career_direction_sentiment` (Q1b), `satisfaction_sources` (Q1c), `work_description` (Q2b), `resume_vs_reality` (Q3b), `ai_dependency_work` (Q5a), `ai_dependency_personal` (Q5b), `current_compensation` (Q16), `working_languages` (Q17), `local_market` (Q18), `ai_monetization_skills` (Q19).
    Old keys `ai_dependency` and `career_satisfaction` are preserved in state but no longer actively read. They serve as migration sources: on first run after upgrade, their values seed defaults for the new split questions (Q5a/Q1b). See interview-questions.md § Legacy answer migration for the mapping table. Old keys age out naturally after 6 months.
 2. `Write` to `~/.claude/ai-fortune.json`
 3. Confirm: "State saved. Run `/ai-fortune` again anytime — it will remember your answers and skip recent ones."

--- a/plugins/ai-fortune/commands/ai-fortune/references/analysis-framework.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/analysis-framework.md
@@ -164,6 +164,10 @@ Compare self-reported data (interview) vs observed data (sessions/insights):
 | Skills claimed vs verified | Q10 domain expertise | Resume skills + technology-explainer | Over/under-claiming — listed skills not backed by experience descriptions |
 | Experience vs self-report | Q7 years experience | Resume career span computation | Inaccurate self-assessment of career stage |
 | Resume vs reality | Q3b honest disclosure | Resume content | User's own identification of where resume doesn't match reality |
+| Work substance | Q2b work description | project_areas, insights | Discrepancy between described work and actual AI usage |
+| Satisfaction gap | Q1c satisfaction sources vs Q2b work description | project_areas, session diversity | Energy is outside day job → career misalignment signal |
+| Satisfaction vs sentiment | Q1c satisfaction sources vs Q1b direction | satisfaction_distribution | Says "Love it" but energy comes only from pet projects? |
+| AI monetization vision | Q19 ai_monetization_skills | technology-explainer, AI leverage score | Inflated opportunity or overlooked strengths |
 
 ### How to present:
 - If data confirms self-report → reinforce with evidence
@@ -230,6 +234,32 @@ When resume is available, enhance the "Already Have" column in Skills Bridge tab
 - Add **years of experience** for each skill (computed from positions where it appeared)
 - Flag **dormant skills** — listed in resume but not used in last 2 positions (mark with ⚠️)
 - Distinguish **current skills** (last 2 positions) from **historical skills** (earlier only)
+
+---
+
+## Satisfaction Alignment Score (1-5)
+
+Measures how well the user's energy/satisfaction sources (Q1c) align with their actual day job (Q2b).
+
+| Score | Label | Evidence Pattern |
+|-------|-------|------------------|
+| 1 | **Misaligned** | Energy sources exclusively outside day job (only pet projects, hobbies, volunteering mentioned) |
+| 2 | **Mostly outside** | 1 work activity mentioned but majority outside job |
+| 3 | **Split** | Roughly equal energy from work and non-work activities |
+| 4 | **Mostly work** | Most energy from day job, some side interests |
+| 5 | **Fully aligned** | Energy sources are entirely within day job scope |
+
+### Computation rules:
+- Compare Q1c satisfaction sources against Q2b work description
+- Count how many Q1c items relate to day job work (Q2b) vs outside activities
+- If Q1c is empty or vague → default to 3 (Split)
+
+### How it affects the report:
+- **Displayed in Your Profile section:** `**Satisfaction Alignment: {X}/5** — {label}`
+- **Score 1-2** → triggers Satisfaction Gap subsection in Blind Spots. L3-L5 directions should prioritize aligning with Q1c energy sources, not just Q1a/Q2b work skills.
+- **Score 1-2 + Q1b "Love it"** → contrastive finding: "You say you love your career direction, but your energy is elsewhere"
+- **Score 4-5** → reinforce L1 (Optimize Current) as strong baseline
+- **Score 3** → note in Blind Spots as "worth monitoring" but not alarming
 
 ---
 

--- a/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/interview-questions.md
@@ -58,11 +58,23 @@ Questions are organized by tier. Each question specifies:
   - "Want to pivot — actively exploring other paths"
   - "Need change — current path feels unsustainable"
 
+### Q1c: Satisfaction & Energy Sources
+- **key:** `satisfaction_sources`
+- **type:** `free_text`
+- **prompt:** "What activities bring you the most satisfaction or energy — at work, in side projects, or anywhere else? Think about moments when you lose track of time, or things you'd do even for free. Include everything: your day job, pet projects, hobbies with a technical angle, volunteering, community work. (e.g., 'At work — debugging complex production incidents, the detective work energizes me' or 'Side project — built a Telegram bot for my neighborhood, loved seeing people actually use it' or 'I mentor bootcamp grads on weekends and it never feels like work')"
+- **skip_if_data:** none (deeply subjective, no data source can answer this)
+
 ### Q2: Typical Workday Breakdown
 - **key:** `daily_tasks`
 - **type:** `free_text`
 - **prompt:** "How does your typical workday break down by activity? (e.g., '40% coding, 20% architecture, 20% meetings, 10% debugging, 10% docs')"
 - **skip_if_data:** none (subjective)
+
+### Q2b: Work Description
+- **key:** `work_description`
+- **type:** `free_text`
+- **prompt:** "Describe what you actually do at work — not your title (Q1a covers that) or time breakdown (Q2 covers that), but the substance: What problems do you solve? What do you produce? Who benefits from your output? (e.g., 'I design data pipelines that ingest financial feeds for risk calculations — the trading desk relies on my systems being fast and correct')"
+- **skip_if_data:** memory file or resume may contain detailed work descriptions → pre-fill, confirm
 
 ### Q3: Core Value to Team
 - **key:** `core_value`
@@ -235,6 +247,12 @@ Questions are organized by tier. Each question specifies:
 - **prompt:** "Where are you based and what job market do you primarily target? (e.g., 'Kyiv, Ukraine — open to EU remote')"
 - **skip_if_data:** Q15 may cover geography; memory file may mention location
 
+### Q19: AI Monetization Potential
+- **key:** `ai_monetization_skills`
+- **type:** `free_text`
+- **prompt:** "What skills or knowledge do you have that could be monetized in the AI economy — either as an employee at an AI company, or by creating your own AI-powered service/product? Think broadly: domain expertise that AI needs humans for, ability to fine-tune/evaluate models, understanding of a niche market, or technical skills for building AI products. (e.g., 'I understand medical billing rules deeply — could build an AI coding assistant for healthcare' or 'I can evaluate LLM output quality for code — useful for AI dev tools companies' or 'I know the Ukrainian SMB market — could build localized AI tools for small businesses')"
+- **skip_if_data:** if technology-explainer has expert entries or Q10 already answered → mention as context but still ask
+
 ---
 
 ## Adaptive Logic
@@ -247,6 +265,8 @@ Questions are organized by tier. Each question specifies:
 - If memory file mentions languages → Q17 can be pre-filled, confirm
 - If Q15 already covers geography or memory has location → Q18 can be pre-filled, confirm
 - Q18 should be asked before Q16 when both are unanswered (so currency can adapt)
+- Q2b (work description): if memory file or resume contains detailed work descriptions → pre-fill, confirm
+- Q19 (AI monetization): if technology-explainer has expert entries or Q10 already answered → reference as context, still ask (subjective forward-looking question)
 
 ### Resume-based auto-skip rules:
 When a PDF resume is provided, pre-fill the following questions from extracted data. **Always confirm with the user — never silently skip** (resumes can be outdated):

--- a/plugins/ai-fortune/commands/ai-fortune/references/report-template.md
+++ b/plugins/ai-fortune/commands/ai-fortune/references/report-template.md
@@ -20,6 +20,9 @@ Generated: {date} | Sources: {N}/9 used
 **Location:** {from Q18} | **Languages:** {from Q17}
 **AI Adoption at org:** {level} | **AI (work):** {Q5a} | **AI (personal):** {Q5b}
 **Current compensation:** {from Q16}
+**Work summary:** {from Q2b — what problems they solve, what they produce}
+**Energized by:** {from Q1c — may include non-work activities like pet projects, hobbies, volunteering}
+**Satisfaction Alignment: {X}/5** — {label: Misaligned / Mostly outside / Split / Mostly work / Fully aligned}
 **Career stage:** {early/mid/senior/executive — from resume} (conditional: only when resume provided)
 **Education:** {degree, institution — from resume} (conditional: only when resume provided)
 **Career span:** {N years, M companies — from resume} (conditional: only when resume provided)
@@ -261,6 +264,35 @@ Cite specific companies and tools, not vague generalities.}
 
 ---
 
+## AI Monetization Opportunities
+(conditional: only when Q19 has substantive answer)
+
+**Your AI-monetizable assets:**
+- {asset 1 from Q19 + Q10 + tech-explainer — e.g., "Deep healthcare domain expertise (8 yrs)"}
+- {asset 2}
+- {asset 3}
+
+### Path A: AI Employee
+{Best-fit roles at AI companies based on Q19 self-assessment + Q10 domain + tech proficiency}
+
+| Role | Company Type | Why You Fit | Salary Range | Gap to Close |
+|------|-------------|-------------|-------------|--------------|
+| {role} | {AI-native/AI-adopting} | {specific match to Q19/Q10} | {from web research} | {skill gap if any} |
+
+### Path B: AI Founder / Freelancer
+{Concrete product/service ideas synthesized from Q19 + market research}
+
+| Idea | Business Model | Target Market | Competition | Feasibility |
+|------|---------------|---------------|-------------|-------------|
+| {product/service} | {SaaS/Consulting/Marketplace/API} | {niche from Q19 + Q18 market} | {from web research} | {Low/Medium/High based on skills gap} |
+
+**Market validation:** {web research findings for Q19-related AI services/products}
+**Revenue potential:** {realistic range based on business model + market}
+**Time to first revenue:** {estimate}
+**Recommended first step:** {specific action}
+
+---
+
 ## Your Unique Edge: The AI Orchestrator Advantage
 (conditional: only for users with AI Leverage Score >= 7)
 
@@ -305,6 +337,26 @@ itself a career differentiator.}
   what happens if AI tools become unavailable or change?)
 - Skill gaps between current role and recommended directions
 - Contrastive analysis findings (self-reported vs observed discrepancies)}
+
+### Satisfaction Gap
+(conditional: only if Satisfaction Alignment Score ≤ 2)
+
+{Your energy comes from {pet projects/hobbies/volunteering}, not from your day job.
+This misalignment suggests your current role may not be sustainable long-term,
+even if Q1b says "Love it". Evidence:
+- Q1c satisfaction sources: {list — mostly outside work}
+- Q2b work description: {what they do at work}
+- Gap: {specific discrepancy — e.g., "You describe your work as pipeline maintenance,
+  but all your energy comes from mentoring and building Telegram bots"}
+Implication for directions: L3-L5 should prioritize aligning with energy sources, not just current skills.}
+
+### AI Monetization Reality Check
+(conditional: only when Q19 answered)
+
+{Compare Q19 self-assessed monetizable skills against web research evidence:
+- **Validated:** {skills/ideas with market evidence from web research}
+- **Unvalidated:** {skills/ideas without supporting market evidence — flag as requiring more research}
+- **Overlooked:** {monetizable assets from Q10/tech-explainer NOT mentioned in Q19}}
 
 ### Career Pattern Blind Spots
 (conditional: only when PDF resume provided)

--- a/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/ai-fortune/docs/ACCEPTANCE_TESTS.md
@@ -23,11 +23,12 @@ Critical components to test:
 8. PDF resume integration (manual)
 9. v0.4.0 feature criteria (manual)
 10. v0.5.0 feature criteria (manual)
+11. v0.6.0 feature criteria (manual)
 
 ## Automation Status
 
 - ✅ Fully automated: Tests 1, 2, 3, 4
-- ⚠️ Manual only: Tests 5, 6, 7, 8, 9 (require interactive interview + report quality review)
+- ⚠️ Manual only: Tests 5, 6, 7, 8, 9, 10, 11 (require interactive interview + report quality review)
 
 ## Automated Test Results (Last Run)
 
@@ -64,7 +65,7 @@ import json, sys
 with open('$PLUGIN/.claude-plugin/plugin.json') as f:
     p = json.load(f)
 assert p['name'] == 'ai-fortune', f'wrong name: {p[\"name\"]}'
-assert p['version'] == '0.5.0', f'wrong version: {p[\"version\"]}'
+assert p['version'] == '0.6.0', f'wrong version: {p[\"version\"]}'
 assert 'commands' in p, 'missing commands field'
 print('plugin.json: OK')
 "
@@ -98,7 +99,7 @@ done
 
 **Expected:**
 - ✅ All checks pass
-- ✅ plugin.json has name `ai-fortune`, version `0.5.0`
+- ✅ plugin.json has name `ai-fortune`, version `0.6.0`
 - ✅ SKILL.md starts with `---` and has `name:` + `description:` in frontmatter
 - ✅ Both scripts compile without errors
 
@@ -394,6 +395,43 @@ else:
 | Preserved terms | Company names, tech names, URLs, book titles remain in original language in translated report | |
 | Backward compatible | Missing `reportLanguage` (null or absent) → defaults to English, no errors | |
 | Template updated | `templates/ai-fortune.json` has `"reportLanguage": null` field | |
+
+### 11. v0.6.0 Feature Acceptance Criteria
+
+**Objective:** Verify 3 new interview questions, Satisfaction Alignment Score, and expanded AI Monetization section.
+
+**Automation:** ⚠️ Manual
+
+**Criteria:**
+
+| Feature | Acceptance Criterion | Verified |
+|---------|---------------------|----------|
+| Q1c satisfaction sources | Asked after Q1b, free text, covers work + non-work activities | |
+| Q2b work description | Asked after Q2, free text, describes work substance | |
+| Q19 AI monetization | Asked after Q18 (end of Tier 5), free text about monetizable skills | |
+| Q1c no auto-skip | Q1c is always asked — deeply subjective, no data source can answer | |
+| Q2b pre-fill | If memory/resume has work descriptions → pre-fill, confirm | |
+| Q19 context mention | If tech-explainer expert entries or Q10 answered → referenced as context, still asked | |
+| Satisfaction Alignment Score | Displayed in Your Profile: `Satisfaction Alignment: {X}/5 — {label}` | |
+| Score computation | Score 1-5 based on Q1c vs Q2b comparison per analysis-framework.md | |
+| Satisfaction Gap blind spot | Score ≤ 2 → Satisfaction Gap subsection in Blind Spots | |
+| Contrastive: satisfaction gap | Q1c vs Q2b discrepancy noted when energy is outside day job | |
+| Contrastive: satisfaction vs sentiment | Q1c vs Q1b — "Love it" but energy from pet projects flagged | |
+| Contrastive: work substance | Q2b vs project_areas from insights noted | |
+| Contrastive: AI monetization | Q19 vs AI leverage score — inflated/overlooked flagged | |
+| AI Monetization Opportunities section | Appears after Comparison Table when Q19 substantive | |
+| Path A: AI Employee | Table with roles, company types, salary ranges, gaps | |
+| Path B: AI Founder/Freelancer | Table with ideas, business models, markets, feasibility | |
+| Market validation | Web research query for Q19 domain AI service market | |
+| AI monetization reality check | Blind Spots subsection: validated vs unvalidated vs overlooked | |
+| Work summary in Profile | `Work summary:` line from Q2b in Your Profile section | |
+| Energized by in Profile | `Energized by:` line from Q1c in Your Profile section | |
+| Web research query 9 | `"{Q19 skill/domain} AI service market demand {current year}"` executed | |
+| New state keys | `satisfaction_sources`, `work_description`, `ai_monetization_skills` saved in ai-fortune.json | |
+| 21-question count | README says "21-question", interview has Q0-Q19 (with gaps) | |
+| Dynamic year in search | Web search queries use `{current year}` not hardcoded year | |
+| Pacing impact | Q1c+Q2b can pair (both Tier 1), Q19+Q18 can pair (both Tier 5) | |
+| Backward compatible | Missing new keys in state → questions asked normally, no errors | |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add 3 new interview questions: Q1c (satisfaction & energy sources), Q2b (work description), Q19 (AI monetization potential)
- Introduce **Satisfaction Alignment Score** (1-5) comparing energy sources vs day job — triggers Satisfaction Gap blind spot when score ≤ 2
- Add expanded **AI Monetization Opportunities** section with Path A (AI Employee) and Path B (AI Founder/Freelancer) analysis tables
- Add 4 new contrastive analysis rows (work substance, satisfaction gap, satisfaction vs sentiment, AI monetization vision)
- Replace hardcoded `2026` in all WebSearch queries with `{current year}` for future-proofing
- Bump version 0.5.0 → 0.6.0

## Files changed (7)
- `interview-questions.md` — Q1c, Q2b, Q19 definitions + auto-skip rules
- `SKILL.md` — question enumeration, auto-skip, contrastive analysis, satisfaction alignment, web research query, state keys
- `report-template.md` — Your Profile additions, AI Monetization Opportunities section, Satisfaction Gap + AI Monetization Reality Check blind spots
- `analysis-framework.md` — Satisfaction Alignment Score (1-5) section, 4 contrastive analysis rows
- `ACCEPTANCE_TESTS.md` — v0.6.0 acceptance criteria (27 items)
- `README.md` — 18-question → 21-question
- `plugin.json` — 0.5.0 → 0.6.0

## Test plan
- [ ] Verify `plugin.json` version is `0.6.0`
- [ ] Run `/ai-fortune` — Q1c asked after Q1b, Q2b after Q2, Q19 after Q18
- [ ] Profile section shows Work summary, Energized by, Satisfaction Alignment
- [ ] AI Monetization Opportunities section appears with Path A/B when Q19 substantive
- [ ] Blind Spots includes Satisfaction Gap (score ≤ 2) and AI monetization reality check
- [ ] Web search includes Q19-related market demand query with dynamic year
- [ ] State file saves new keys: `satisfaction_sources`, `work_description`, `ai_monetization_skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)