### PR TITLE
feat(context): add threshold warning to /ctx-show token summary (v0.4.0)

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -86,6 +86,29 @@ SessionStart hooks inject text into Claude's system prompt. The Anthropic API ca
 
 ---
 
+## Token Budget
+
+Every source injected at session start costs context tokens. The `context` plugin (`/ctx-show`) warns when total context load exceeds a configurable threshold.
+
+**Per-component budgets:**
+
+| Component | Budget | Notes |
+|-----------|--------|-------|
+| SessionStart hook output | ≤300 tokens | Per plugin. Rules only — no catalogs. |
+| Playbook preset RULES zone | ≤150 tokens | Per preset. Standard ~100-120, critical up to ~200. |
+| Skill description (plugin.json) | ≤50 tokens | Per skill. Lead with trigger signal. |
+
+**Aggregate cap:** ~10,000 tokens (5% of 200K context window).
+
+**Environment variables** (override defaults in `ctx-show.sh`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CTX_CONTEXT_WINDOW` | `200000` | Total context window size in tokens |
+| `CTX_WARN_THRESHOLD` | `CTX_CONTEXT_WINDOW * 5 / 100` | Warning fires when total tokens exceed this |
+
+---
+
 ## Git Hook Installation
 
 Plugins that install git hooks (pre-commit, pre-push, etc.) **must not overwrite** existing hooks. Plugins are additive guests in the user's repository.

--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Inspect full Claude Code session context: CLAUDE.md files, auto-memory, and SessionStart hook output",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -31,6 +31,8 @@
 | Project | Plugin hook     | retroscope@tribe-coding (v0.2.3) · inject-rules    |     8 |     115 |       1% |
 |         | **TOTAL**       |                                                    |   929 |  11,414 |     100% |
 
+⚠️  Context load (11414 tokens) exceeds threshold (10000 tokens = 5% of 200k context window)
+
 Playbook Presets injected by playbook@tribe-coding (v0.5.5)
 
 Summary:
@@ -78,6 +80,8 @@ Collected in load order:
 | Context% | Each source's share of total context |
 
 Playbook presets appear as individual rows when using playbook plugin v0.3.1+.
+
+**Threshold Warning:** When total tokens exceed 5% of the context window (default 10,000 of 200K), a ⚠️ warning is printed after the TOTAL row. Override with `CTX_CONTEXT_WINDOW` and `CTX_WARN_THRESHOLD` env vars.
 
 ## ⚡ Commands <a name="commands"></a>
 

--- a/plugins/context/commands/ctx-show/SKILL.md
+++ b/plugins/context/commands/ctx-show/SKILL.md
@@ -81,3 +81,4 @@ Playbook presets (from `playbook@tribe-coding`) appear as individual rows when u
 - SessionStart hook commands are executed in isolation — their output may differ slightly from a real session start (e.g., different working directory).
 - For plugin hooks, the script uses `${CLAUDE_PLUGIN_ROOT}` substitution with the actual cache path.
 - Playbook preset splitting requires playbook plugin v0.3.1+ in cache (emits `<!-- Source: Plugin playbook@... Preset NAME -->` markers).
+- **Threshold warning:** When total tokens exceed `CTX_WARN_THRESHOLD` (default 5% of `CTX_CONTEXT_WINDOW`), a ⚠️ warning is printed after the TOTAL row. Override defaults: `CTX_CONTEXT_WINDOW=200000` (context window size), `CTX_WARN_THRESHOLD=10000` (warning threshold in tokens).

--- a/plugins/context/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/context/docs/ACCEPTANCE_TESTS.md
@@ -17,7 +17,7 @@ The plugin also prints a summary table to stderr showing scope, type, source, st
 
 ## Automation Status
 
-- ✅ Fully automated: Tests 1–5
+- ✅ Fully automated: Tests 1–5, 7
 - 🟡 Partially automated: Test 6 (Claude invocation requires a fresh session or `/clear`)
 - ⚠️ Manual only: None
 
@@ -25,7 +25,7 @@ The plugin also prints a summary table to stderr showing scope, type, source, st
 
 | Test | Status | Notes |
 |------|--------|-------|
-| 1.1 Static: plugin.json valid | ✅ Pass | version 0.2.0 |
+| 1.1 Static: plugin.json valid | ✅ Pass | version 0.4.0 |
 | 1.2 Static: hooks.json valid | ✅ Pass | |
 | 1.3 Static: SKILL.md frontmatter | ✅ Pass | |
 | 1.4 Static: script is executable | ✅ Pass | |
@@ -42,6 +42,8 @@ The plugin also prints a summary table to stderr showing scope, type, source, st
 | 5.5 Memory hash fix (leading dash) | ✅ Pass | |
 | 6.1 Playbook preset splitting | ✅ Pass | requires playbook v0.3.1 in cache |
 | 6.2 Legend shown when presets present | ✅ Pass | |
+| 7.3 Threshold warning fires when exceeded | ✅ Pass | CTX_WARN_THRESHOLD=1 |
+| 7.4 No warning when under threshold | ✅ Pass | CTX_WARN_THRESHOLD=999999 |
 
 ---
 
@@ -64,7 +66,7 @@ jq '.' "${PLUGIN_DIR}/.claude-plugin/plugin.json"
 **Expected result:**
 - ✅ Valid JSON (no parse error)
 - ✅ Has `name`, `version`, `commands`, `skills` fields
-- ✅ `version` is `0.2.0`
+- ✅ `version` is `0.4.0`
 - ✅ `skills` is `[]` (no auto-invocable skills)
 
 ---
@@ -548,6 +550,52 @@ rm -rf "$FAKE_CACHE" "$FAKE_HOME" "$FAKE_PROJ"
 
 ---
 
+### 7. Threshold Warning Tests
+
+#### 7.3 Warning Fires When Exceeded
+
+**Objective:** Verify ⚠️ warning appears when total tokens exceed `CTX_WARN_THRESHOLD`.
+
+**Automation:** ✅
+
+**Steps:**
+```bash
+PLUGIN_DIR="/Users/artem/devel/claude-plugins/plugins/context"
+TABLE_FILE=$(env CTX_WARN_THRESHOLD=1 \
+  bash "${PLUGIN_DIR}/scripts/ctx-show.sh" --file 2>/dev/null | tail -1)
+
+echo "Warning present (should be 1):"
+grep -c "exceeds threshold" "$TABLE_FILE" || echo "0"
+```
+
+**Expected result:**
+- ✅ Output contains `⚠️  Context load` warning line
+- ✅ Warning mentions threshold value and context window percentage
+
+---
+
+#### 7.4 No Warning When Under Threshold
+
+**Objective:** Verify no warning when total tokens are below `CTX_WARN_THRESHOLD`.
+
+**Automation:** ✅
+
+**Steps:**
+```bash
+PLUGIN_DIR="/Users/artem/devel/claude-plugins/plugins/context"
+TABLE_FILE=$(env CTX_WARN_THRESHOLD=999999 \
+  bash "${PLUGIN_DIR}/scripts/ctx-show.sh" --file 2>/dev/null | tail -1)
+
+echo "Warning absent (should be 0):"
+grep -c "exceeds threshold" "$TABLE_FILE" || echo "0"
+```
+
+**Expected result:**
+- ✅ No `⚠️` warning line in output
+- ✅ Table still has TOTAL row
+
+---
+
 ## Regression Testing Guide
 
 ### When to run
@@ -564,7 +612,7 @@ Run all automated tests in sequence:
 PLUGIN_DIR="/Users/artem/devel/claude-plugins/plugins/context"
 
 echo "=== 1.1 plugin.json ==="
-jq -e '.name == "context" and .version == "0.2.0" and .commands and (.skills | length == 0)' \
+jq -e '.name == "context" and .version == "0.4.0" and .commands and (.skills | length == 0)' \
   "${PLUGIN_DIR}/.claude-plugin/plugin.json" && echo "✅ PASS" || echo "❌ FAIL"
 
 echo "=== 1.2 hooks.json ==="
@@ -605,6 +653,16 @@ echo "$TABLE" | grep "TOTAL" | grep -q "100%" && echo "✅ PASS" || echo "❌ FA
 
 echo "=== 5.5 memory hash leading dash ==="
 echo "$TABLE" | grep "Memory" | grep -q '\-Users' && echo "✅ PASS" || echo "⚠️  Memory not found in this env"
+
+echo "=== 7.3 threshold warning fires ==="
+TABLE_WARN=$(env CTX_WARN_THRESHOLD=1 \
+  bash "${PLUGIN_DIR}/scripts/ctx-show.sh" --file 2>/dev/null | tail -1)
+grep -q "exceeds threshold" "$TABLE_WARN" && echo "✅ PASS" || echo "❌ FAIL"
+
+echo "=== 7.4 no warning under threshold ==="
+TABLE_NOWARN=$(env CTX_WARN_THRESHOLD=999999 \
+  bash "${PLUGIN_DIR}/scripts/ctx-show.sh" --file 2>/dev/null | tail -1)
+grep -q "exceeds threshold" "$TABLE_NOWARN" && echo "❌ FAIL" || echo "✅ PASS"
 ```
 
 ### CI integration

--- a/plugins/context/scripts/ctx-show.sh
+++ b/plugins/context/scripts/ctx-show.sh
@@ -17,6 +17,8 @@ MODE="${1:---file}"
 CLAUDE_DIR="${HOME}/.claude"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 OUTPUT=""
+CTX_CONTEXT_WINDOW="${CTX_CONTEXT_WINDOW:-200000}"
+CTX_WARN_THRESHOLD="${CTX_WARN_THRESHOLD:-$(( CTX_CONTEXT_WINDOW * 5 / 100 ))}"
 
 # ── metadata arrays ───────────────────────────────────────────────────────────
 # Parallel arrays (bash 3.2 compatible — no associative arrays)
@@ -247,6 +249,13 @@ print_table() {
 
   printf '| | **TOTAL** | | **%d** | **%d** | **100%%** |\n' \
     "$total_lines" "$total_tokens"
+
+  if [ "$total_tokens" -gt "$CTX_WARN_THRESHOLD" ]; then
+    printf '\n⚠️  Context load (%d tokens) exceeds threshold (%d tokens = %d%% of %dk context window)\n' \
+      "$total_tokens" "$CTX_WARN_THRESHOLD" \
+      "$(( 100 * CTX_WARN_THRESHOLD / CTX_CONTEXT_WINDOW ))" \
+      "$(( CTX_CONTEXT_WINDOW / 1000 ))"
+  fi
 
   if [ "$has_presets" -eq 1 ]; then
     local legend_id="${PLAYBOOK_PLUGIN_ID:-playbook@tribe-coding}"


### PR DESCRIPTION
## Summary
- Add ⚠️ warning when total context tokens exceed configurable threshold (default 5% of 200K = 10,000 tokens)
- Add per-component token budget guidelines to `docs/conventions.md`
- Configurable via `CTX_CONTEXT_WINDOW` and `CTX_WARN_THRESHOLD` env vars

## Test plan
- [x] Test 7.3: warning fires with `CTX_WARN_THRESHOLD=1` — ✅ PASS
- [x] Test 7.4: no warning with `CTX_WARN_THRESHOLD=999999` — ✅ PASS
- [x] Full batch regression (tests 1.1–5.5) — all ✅ PASS

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)