### PR TITLE
fix(context): explicitly forbid summarizing ctx-show table output (v0.7.1)

### DIFF
--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Inspect full Claude Code session context: CLAUDE.md files, auto-memory, SessionStart hook output, and skill listings",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/context/commands/ctx-show/SKILL.md
+++ b/plugins/context/commands/ctx-show/SKILL.md
@@ -65,7 +65,7 @@ Playbook presets (from `playbook@tribe-coding`) appear as individual rows when u
    bash "${CLAUDE_PLUGIN_ROOT}/scripts/ctx-show.sh" --file
    ```
 
-3. After running the script, **always** read the table file (second line of output) using the Read tool and display its contents verbatim in the response. Example — if the script output is:
+3. After running the script, **always** read the table file (second line of output) using the Read tool and display its contents **verbatim** in the response — do NOT summarize, collapse, group, or reformat rows. Show the exact table the script produced. Example — if the script output is:
    ```
    /tmp/claude-context-20260225-123456.md
    /tmp/claude-ctx-table-20260225-123456.txt


### PR DESCRIPTION
## Summary
- Strengthen the "verbatim" instruction in ctx-show SKILL.md to explicitly forbid summarizing, collapsing, grouping, or reformatting table rows
- Previously the LLM would collapse 21 skill rows into a single summary line despite the "verbatim" wording

## Test plan
- [ ] Run `/ctx-show` and verify the full table is displayed as-is without any row grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)