### PR TITLE
feat(playbook): add shell-scripting-safety preset (v0.8.0)

### DIFF
--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/README.md
+++ b/plugins/playbook/README.md
@@ -43,6 +43,7 @@ Then in the next session, run `/playbook-setup` to choose which presets to enabl
 | [`macos-python`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/macos-python.md) | Python 3.12 targeting, no system Python, CWD isolation |
 | [`macos-zsh-quirks`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/macos-zsh-quirks.md) | Zsh/Bash tool quirks: CWD, `echo` escapes, absolute paths |
 | [`readme`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/readme.md) | README as landing page: 5-second test, compact structure, cross-links |
+| [`shell-scripting-safety`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/shell-scripting-safety.md) | Prevent common pitfalls in generated shell scripts |
 | [`verify-before-relay`](https://github.com/Tribe-Coding/claude-plugins/blob/main/plugins/playbook/presets/verify-before-relay.md) | Verify subagent URLs before relaying to user |
 
 Use `/playbook-browse` to read the full reference for any preset.

--- a/plugins/playbook/presets/shell-scripting-safety.md
+++ b/plugins/playbook/presets/shell-scripting-safety.md
@@ -1,0 +1,107 @@
+---
+name: shell-scripting-safety
+description: "Shell script pitfalls: set -euo pipefail, find -path globs, grep/jq edge cases"
+tags: [bash, shell, scripting, safety]
+---
+
+<!-- RULES -->
+## Shell Scripting Safety — Base Rules
+
+MANDATORY: Follow these rules when writing or editing `.sh` scripts.
+
+- ALWAYS use `set -euo pipefail` at the top of scripts
+- NEVER pass `**` globs to `find -path` — `fnmatch(3)` treats `**` as two `*`; convert `**/foo` → `*/foo` or `-name`
+- ALWAYS anchor `find -path` to project dir — `"${DIR}/*/${pat}/*"` not `"*/${pat}/*"` (unanchored matches parent dirs)
+- NEVER pipe `grep` into `while` under pipefail — grep returns 1 on no matches; use `|| true`
+- NEVER use `jq` `// true` to default booleans — `false` passes through; use `if/then/else`
+- Quote `#` in `case` patterns — `#*` is a comment; use `'#'*`
+- Use `${ARR[@]+"${ARR[@]}"}` for empty arrays under `set -u`
+- **ALWAYS invoke `playbook-browse shell-scripting-safety` BEFORE writing shell scripts** to load full reference.
+<!-- /RULES -->
+
+<!-- REFERENCE -->
+## find -path Does Not Support `**` Recursive Globs
+
+`find -path` uses POSIX `fnmatch(3)` pattern matching. `**` is NOT a recursive glob — it equals two `*` wildcards. This is a `.gitignore`/bash `globstar` convention, not POSIX.
+
+```bash
+# BROKEN — ** is not recursive in find; also unanchored, matches parent dirs
+find "$DIR" -type f -not -path "*/${pattern}/*"
+
+# FIX — strip **/ prefix, anchor to project dir
+pattern="${pattern##\*\*/}"  # **/raw → raw
+find "$DIR" -type f -not -path "${DIR}/*/${pattern}/*"
+
+# ALT FIX — use -name for simple patterns
+find "$DIR" -type f -not -name "${pattern}"
+```
+
+**Key gotcha:** unanchored `-not -path "*/${pattern}/*"` matches the pattern anywhere in the absolute path, including parent directories. If the project lives under `~/code/my-project` and the exclude pattern is `code`, every file gets excluded.
+
+## grep | while Fails with pipefail
+
+`grep` returns exit 1 on no matches → `pipefail` propagates → `set -e` kills the script.
+
+```bash
+# BROKEN
+grep -noE 'pattern' "$file" | while IFS= read -r match; do
+  ...
+done
+
+# FIX — redirect to tmpfile
+grep -noE 'pattern' "$file" > "$tmpfile" || true
+while IFS= read -r match; do ...  done < "$tmpfile"
+
+# ALT FIX — process substitution
+while IFS= read -r match; do ...  done < <(grep -noE 'pattern' "$file" || true)
+```
+
+Similarly, `grep -v` returns exit 1 when it filters out ALL lines:
+
+```bash
+# BROKEN
+others=$(grep "^${hash}|" "$file" | grep -v "^${target}$" | head -3)
+
+# FIX
+others=$(grep "^${hash}|" "$file" | { grep -v "^${target}$" || true; } | head -3)
+```
+
+## jq `//` Does Not Catch `false`
+
+`// true` is the "alternative" operator — triggers only for `null` or missing keys. `false` is a valid value and passes through.
+
+```bash
+# BROKEN — returns "true" even when value is false
+CHECK=$(jq -r '.checks.foo // true' "$config")
+
+# FIX — explicit conditional
+CHECK=$(jq -r 'if .checks.foo == false then "false" else "true" end' "$config")
+```
+
+## `#*` in case Patterns Is a Comment
+
+```bash
+# BROKEN — #* starts a comment, syntax error
+case "$var" in
+  http://*|#*) continue ;;
+esac
+
+# FIX — quote the hash
+case "$var" in
+  http://*|'#'*) continue ;;
+esac
+```
+
+## Empty Arrays with set -u
+
+`${ARR[@]}` on an empty array is "unbound variable" under `set -u`.
+
+```bash
+# BROKEN
+ITEMS=()
+printf '%s\n' "${ITEMS[@]}"   # error: unbound variable
+
+# FIX
+printf '%s\n' "${ITEMS[@]+"${ITEMS[@]}"}"
+```
+<!-- /REFERENCE -->

--- a/plugins/playbook/skills/playbook-browse/SKILL.md
+++ b/plugins/playbook/skills/playbook-browse/SKILL.md
@@ -6,7 +6,8 @@ description: >
   GitHub workflow, git safety, debugging, or other configured guidelines.
   Do NOT skip this when RULES zone references it.
   Keywords: guidelines, documentation rules, commit checklist, ADR, PR workflow, playbook,
-  debugging, git safety, planning, subagent verification.
+  debugging, git safety, planning, subagent verification, shell scripting, bash pitfalls,
+  find path, strict mode.
 ---
 
 # Playbook Browse


### PR DESCRIPTION
## Summary
- New playbook preset `shell-scripting-safety` covering common shell script pitfalls
- Prevents `find -path` glob misuse (`**` is not recursive in fnmatch), unanchored path patterns, `grep`/`jq` exit code traps, strict mode edge cases
- Migrates knowledge from project auto-memory (`memory/bash-pitfalls.md`) into a proper playbook preset with RULES/REFERENCE zones
- Motivated by #245 — the `find -path` bug in kb-grooming would have been caught by these rules

## Changes
- **Created** `plugins/playbook/presets/shell-scripting-safety.md` (RULES ~140 words, REFERENCE with full examples)
- **Updated** `plugins/playbook/README.md` — added preset to table
- **Updated** `plugins/playbook/skills/playbook-browse/SKILL.md` — added keywords
- **Bumped** playbook version `0.7.1` → `0.8.0` (MINOR — new preset)

## Test plan
- [ ] Verify RULES zone loads via SessionStart when preset is enabled in `playbook.json`
- [ ] Verify `/playbook-browse shell-scripting-safety` shows REFERENCE zone
- [ ] Verify README table is alphabetically sorted
- [ ] Verify token count stays within Critical budget (~200 tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)