### PR TITLE
fix(kb-grooming): handle ** glob patterns in find -path excludes (v0.1.4)

### DIFF
--- a/plugins/kb-grooming/.claude-plugin/plugin.json
+++ b/plugins/kb-grooming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-grooming",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Documentation health analysis: structural checks, semantic compliance, and GitHub issue creation",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/kb-grooming/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/kb-grooming/docs/ACCEPTANCE_TESTS.md
@@ -173,6 +173,29 @@ print('PASS')
 rm -rf "$TMPDIR" "$CONFIG"
 ```
 
+### 2.5b Scan correctly excludes directories with `**` glob patterns
+
+**Objective:** Exclude patterns with `**/` prefix and directories in parent path do not cause false exclusions.
+
+```bash
+TMPDIR=$(mktemp -d)
+mkdir -p "$TMPDIR/docs" "$TMPDIR/raw/data"
+echo "# Main" > "$TMPDIR/README.md"
+echo "# Docs" > "$TMPDIR/docs/guide.md"
+echo "# Raw" > "$TMPDIR/raw/data/dump.md"
+CONFIG=$(mktemp)
+printf '{"checks":{"brokenLinks":true},"scope":{"include":["*.md"],"exclude":["**/raw/"]}}\n' > "$CONFIG"
+REPORT=$(env CLAUDE_PROJECT_DIR="$TMPDIR" KB_CONFIG_FILE="$CONFIG" bash plugins/kb-grooming/scripts/kb-structural-scan.sh)
+python3 -c "
+import json
+r = json.load(open('$REPORT'))
+scanned = r['summary']['filesScanned']
+assert scanned == 2, f'Expected 2 files (README.md + guide.md), got {scanned}'
+print('PASS')
+"
+rm -rf "$TMPDIR" "$CONFIG"
+```
+
 ### 2.6 Scan with no markdown files produces empty report
 
 **Objective:** Empty directory produces valid empty JSON report.

--- a/plugins/kb-grooming/scripts/kb-structural-scan.sh
+++ b/plugins/kb-grooming/scripts/kb-structural-scan.sh
@@ -46,12 +46,14 @@ build_find_args() {
 import sys, json
 patterns = json.load(sys.stdin)
 for p in patterns:
-    p = p.rstrip('/')
-    print(p)
+    p = p.strip('/')
+    p = p.lstrip('*').lstrip('/')
+    if p:
+        print(p)
 ")
   while IFS= read -r pattern; do
     [ -z "$pattern" ] && continue
-    find_cmd+=" -not -path \"*/${pattern}/*\" -not -path \"*/${pattern}\""
+    find_cmd+=" -not -path \"${PROJECT_DIR}/${pattern}/*\" -not -path \"${PROJECT_DIR}/*/${pattern}/*\""
   done <<< "$excludes"
 
   echo "$find_cmd"


### PR DESCRIPTION
## Summary
- Strip `**/` prefix from exclude patterns before passing to `find -path` — `fnmatch(3)` treats `**` as two `*`, not a recursive glob
- Anchor `-path` patterns to `$PROJECT_DIR` instead of using unanchored `*/${pattern}/*` which matches parent directories
- Add acceptance test 2.5b covering `**` glob exclude patterns

Closes #245

## Test plan
- [x] New test 2.5b: exclude with `**/raw/` pattern — files in `raw/` excluded, others kept
- [x] Existing test 2.5: disabled checks — no regression
- [x] Existing test 2.6: empty dir — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)