### PR TITLE
chore(statusline-compact): remove session name display (v0.4.0)

### DIFF
--- a/plugins/statusline-compact/.claude-plugin/plugin.json
+++ b/plugins/statusline-compact/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "statusline-compact",
-  "version": "0.3.0",
-  "description": "Compact single-line Claude Code statusline with brightness-coded API usage values. Shows 5h/7d rate limits, extra usage, context window, git branch, model, and session name - all on one line.",
+  "version": "0.4.0",
+  "description": "Compact single-line Claude Code statusline with brightness-coded API usage values. Shows 5h/7d rate limits, extra usage, context window, git branch, and model - all on one line.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",
   "commands": [

--- a/plugins/statusline-compact/README.md
+++ b/plugins/statusline-compact/README.md
@@ -11,11 +11,11 @@ Single-line statusline with brightness-coded API usage values.
 ## 🎬 Demo <a name="demo"></a>
 
 ```markdown
-5h 92% 50m !!   7d 22% ~5d   extra $4.79   Sonnet 4.6   context 30%   my-project/   main*   session my-feature !!
+5h 92% 50m !!   7d 22% ~5d   extra $4.79   Sonnet 4.6   context 30%   my-project/   main*
 ```
 
 Values dim at low usage and brighten as they climb: yellow above 90%, red at 100%.
-`!!` = warning, `XX` = exhausted. Session `!!` = no custom name set (use `/rename` to fix).
+`!!` = warning, `XX` = exhausted.
 
 ## ⚙️ How it works <a name="how-it-works"></a>
 
@@ -28,7 +28,7 @@ Values dim at low usage and brighten as they climb: yellow above 90%, red at 100
 - Model brightness = capability tier: Opus bright, Sonnet default, Haiku dim
 - Usage values: dim at low, brighten as they climb, yellow > 90%, red at 100%
 
-**Tracked values:** 5h rate limit · 7d rate limit · extra usage ($ amount) · context % · directory · git branch · model name · session name
+**Tracked values:** 5h rate limit · 7d rate limit · extra usage ($ amount) · context % · directory · git branch · model name
 
 ## 📦 Installation <a name="installation"></a>
 

--- a/plugins/statusline-compact/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/statusline-compact/docs/ACCEPTANCE_TESTS.md
@@ -6,7 +6,6 @@ The statusline-compact plugin provides a single-line compact status display for 
 - 5h/7d rate limits with brightness-coded percentages
 - Extra usage (monthly billing) with dollar amount
 - Model name, context window usage, directory, git branch
-- Session name (custom via `/rename`, slug fallback, or session ID prefix)
 
 Features:
 - Single-line output - most space-efficient option
@@ -14,7 +13,6 @@ Features:
 - Text indicators: `!!` at >90%, `XX` at 100%
 - Branch shown yellow with `*` when dirty
 - `>>` suffix on extra label when extra usage actively consumed
-- Session name: normal text when custom, dimmed with `!!` when using auto-generated name
 
 ## Test execution order
 
@@ -110,7 +108,6 @@ fi
 echo "$clean" | grep -q 'Sonnet' && echo "✅ Model present" || echo "❌ Missing model"
 echo "$clean" | grep -q 'context' && echo "✅ context label present" || echo "❌ Missing context label"
 echo "$clean" | grep -q 'my-project' && echo "✅ Directory present" || echo "❌ Missing directory"
-echo "$clean" | grep -q 'session' && echo "✅ session label present" || echo "❌ Missing session label"
 ```
 
 **Acceptance criteria:**
@@ -118,7 +115,6 @@ echo "$clean" | grep -q 'session' && echo "✅ session label present" || echo "�
 - ✅ No emoji characters
 - ✅ No progress bar characters
 - ✅ Model name, context label, and directory present
-- ✅ Session label present
 
 ---
 
@@ -251,40 +247,6 @@ echo "$output" | grep -q "Test" && echo "✅ Shows basic info despite API failur
 
 ---
 
-#### 3.5 Session name display
-
-**Objective:** Verify session name appears with correct style based on name source
-
-**Automation:** ✅
-
-**Steps:**
-```bash
-cd plugins/statusline-compact
-
-# Test: session ID fallback (no transcript) - should show dimmed name + !!
-output=$(echo '{"workspace":{"current_dir":"/test"},"model":{"display_name":"Test"},"context_window":{"used_percentage":50},"session_id":"abc123-def456"}' | bash scripts/statusline.sh | sed 's/\x1b\[[0-9;]*m//g')
-echo "$output" | grep -q 'session' && echo "✅ Session label present" || echo "❌ Missing session label"
-echo "$output" | grep -q 'abc123' && echo "✅ Session ID prefix shown" || echo "❌ Missing session ID"
-echo "$output" | grep -q '!!' && echo "✅ !! indicator for auto-generated name" || echo "❌ Missing !! indicator"
-
-# Test: custom name - should show name without !!
-session_id="test-session-$(date +%s)"
-cache_file="/tmp/claude-statusline-session-${UID}-${session_id}"
-echo "custom:My Custom Project" > "$cache_file"
-output=$(echo "{\"workspace\":{\"current_dir\":\"/test\"},\"model\":{\"display_name\":\"Test\"},\"context_window\":{\"used_percentage\":50},\"session_id\":\"${session_id}\"}" | bash scripts/statusline.sh | sed 's/\x1b\[[0-9;]*m//g')
-echo "$output" | grep -q 'My Custom Project' && echo "✅ Custom name shown" || echo "❌ Missing custom name"
-echo "$output" | grep -qv '!!' && echo "✅ No !! for custom name" || echo "❌ Should not have !!"
-rm -f "$cache_file"
-```
-
-**Acceptance criteria:**
-- ✅ Session label present in output
-- ✅ Auto-generated names (slug/ID) show `!!` indicator
-- ✅ Custom names (set via `/rename`) show without `!!`
-- ✅ Cache file written to `/tmp/claude-statusline-session-${UID}-<session_id>`
-
----
-
 ### 4. Visual verification (manual)
 
 #### 4.1 Live Claude Code integration
@@ -310,19 +272,16 @@ claude
 
 Expected appearance:
 ```
-5h 12% ~2h14m   7d 45% ~3d5h   extra $4.79   Sonnet 4.5   context 52%   claude-plugins/   main   session my-slug !!
+5h 12% ~2h14m   7d 45% ~3d5h   extra $4.79   Sonnet 4.5   context 52%   claude-plugins/   main
 ```
 
 Visual checklist:
 - ✅ Single line visible
-- ✅ Dim labels (5h, 7d, extra, context, session)
+- ✅ Dim labels (5h, 7d, extra, context)
 - ✅ Brightness-coded percentages
 - ✅ Model name with brightness = capability tier
 - ✅ Directory with trailing /
 - ✅ Branch (yellow with * when dirty)
-- ✅ Session name at end of line
-- ✅ `!!` after session name when using auto-generated name
-- ✅ No `!!` after session name when custom name set via `/rename`
 
 ---
 
@@ -354,6 +313,10 @@ echo '{"model":{"display_name":"Claude Sonnet 4.5"},"workspace":{"current_dir":"
 ---
 
 ## Version history
+
+### 0.4.0
+
+- Removed session name display (now built into Claude Code natively)
 
 ### 0.3.0
 

--- a/plugins/statusline-compact/scripts/statusline.sh
+++ b/plugins/statusline-compact/scripts/statusline.sh
@@ -3,7 +3,7 @@
 # Reads JSON from stdin (piped by Claude Code)
 #
 # Layout:
-#   5h 12% ~2h14m   7d 45% ~3d5h   extra $4.79   $0.42   Sonnet 4.5   context 52%   my-project/   main   session my-project-name
+#   5h 12% ~2h14m   7d 45% ~3d5h   extra $4.79   $0.42   Sonnet 4.5   context 52%   my-project/   main
 #
 # Brightness-coded values: dim at low usage, brighter as they climb,
 # yellow >90%, red at 100%. Text indicators: !! warning, XX exhausted.
@@ -137,8 +137,6 @@ dim_time_units() {
 cwd=$(echo "$input" | jq -r '.workspace.current_dir')
 model=$(echo "$input" | jq -r '.model.display_name')
 used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
-session_id=$(echo "$input" | jq -r '.session_id // empty')
-transcript_path=$(echo "$input" | jq -r '.transcript_path // empty')
 
 # Git branch + dirty indicator
 branch=""
@@ -197,68 +195,6 @@ else
       if [ -f "$cache_file" ]; then
         usage_json=$(cat "$cache_file" 2>/dev/null)
       fi
-    fi
-  fi
-fi
-
-# ===== SESSION NAME =====
-reverse_file() {
-  if command -v tac > /dev/null 2>&1; then
-    tac "$1"
-  else
-    tail -r "$1"
-  fi
-}
-
-session_name=""
-session_style=""
-if [ -n "$session_id" ]; then
-  session_cache="/tmp/claude-statusline-session-${UID}-${session_id}"
-  session_cache_valid=false
-
-  if [ -f "$session_cache" ]; then
-    if [ "$(uname)" = "Darwin" ]; then
-      scache_mtime=$(stat -f %m "$session_cache" 2>/dev/null || echo 0)
-    else
-      scache_mtime=$(stat -c %Y "$session_cache" 2>/dev/null || echo 0)
-    fi
-    scache_age=$(( $(date +%s) - scache_mtime ))
-    if [ "$scache_age" -lt 300 ]; then
-      session_cache_valid=true
-    fi
-  fi
-
-  if [ "$session_cache_valid" = true ]; then
-    cached_value=$(cat "$session_cache" 2>/dev/null)
-    session_style="${cached_value%%:*}"
-    session_name="${cached_value#*:}"
-  else
-    if [ -n "$transcript_path" ] && [ -f "$transcript_path" ]; then
-      title_line=$(reverse_file "$transcript_path" 2>/dev/null | grep -m1 '"type":"custom-title"')
-      if [ -n "$title_line" ]; then
-        session_name=$(echo "$title_line" | jq -r '.customTitle // empty' 2>/dev/null)
-        if [ -n "$session_name" ]; then
-          session_style="custom"
-          echo "custom:${session_name}" > "$session_cache"
-        fi
-      fi
-
-      if [ -z "$session_name" ]; then
-        slug_line=$(reverse_file "$transcript_path" 2>/dev/null | grep -m1 '"slug"')
-        if [ -n "$slug_line" ]; then
-          session_name=$(echo "$slug_line" | jq -r '.slug // empty' 2>/dev/null)
-          if [ -n "$session_name" ]; then
-            session_style="dimmed"
-            echo "dimmed:${session_name}" > "$session_cache"
-          fi
-        fi
-      fi
-    fi
-
-    if [ -z "$session_name" ]; then
-      session_name="${session_id%%-*}"
-      session_style="dimmed"
-      echo "dimmed:${session_name}" > "$session_cache"
     fi
   fi
 fi
@@ -381,19 +317,9 @@ if [ -n "$branch" ]; then
   fi
 fi
 
-# Session segment
-compact_session=""
-if [ -n "$session_name" ]; then
-  if [ "$session_style" = "custom" ]; then
-    compact_session="${dim}session${rst} ${session_name}"
-  else
-    compact_session="${dim}session${rst} ${dim}${session_name}${rst} ${yellow}!!${rst}"
-  fi
-fi
-
 # Assemble single line with 3-space gaps
 compact_line=""
-for seg in "$compact_5h" "$compact_7d" "$compact_mo" "$compact_cost" "$compact_model" "$compact_ctx" "$compact_dir" "$compact_branch" "$compact_session"; do
+for seg in "$compact_5h" "$compact_7d" "$compact_mo" "$compact_cost" "$compact_model" "$compact_ctx" "$compact_dir" "$compact_branch"; do
   if [ -n "$seg" ]; then
     if [ -n "$compact_line" ]; then
       compact_line="${compact_line}   ${seg}"


### PR DESCRIPTION
## Summary

- Remove session name display from statusline-compact - Claude Code now ships built-in prominent session name display, making it redundant
- Remove all session-related code: extraction, caching, reverse_file helper, segment construction
- Update README, plugin.json description, and acceptance tests
- Bump version 0.3.0 -> 0.4.0

## Test plan

- [x] Smoke test: single-line output without session segment
- [x] `jq empty` validates plugin.json
- [x] `grep -r session` shows no session name references (only unrelated `session_cost_usd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)