### PR TITLE
refactor(plantuml): extract color guidelines to loadable reference

### DIFF
--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plantuml",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
+++ b/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
@@ -14,36 +14,7 @@ Use this guide to choose the right PlantUML diagram type for documentation. When
 
 **IMPORTANT:** Every diagram MUST include a `title` directive immediately after the opening tag. This makes diagrams self-documenting. Example: `title User Authentication Flow`
 
-## Color Coding Guidelines
-
-Use color coding to improve diagram readability. Apply a **muted pastel palette** on white background (default). Do NOT set `skinparam backgroundColor` unless the user explicitly requests it.
-
-**Recommended palette:**
-
-| Color | Hex | Use for |
-|-------|-----|---------|
-| Soft blue | `#E8F4FD` / `#5B9BD5` | Primary elements, main flow |
-| Soft green | `#E8F5E9` / `#70AD47` | Success paths, approved states |
-| Soft red | `#FDE8E8` / `#E74C3C` | Error paths, rejected states |
-| Soft yellow | `#FFF8E1` / `#F4B942` | Warnings, pending states |
-| Soft purple | `#F3E8FD` / `#9B59B6` | External systems, third-party |
-| Soft gray | `#F5F5F5` / `#95A5A6` | Inactive, deprecated |
-
-**Color support by diagram type:**
-
-| Support | Types |
-|---------|-------|
-| ✅ Full (skinparam, arrows, groups) | Sequence, Activity, State, Class, Component, Object, ER, Deployment |
-| 🟡 Limited | Timing, Network, MindMap, Gantt, WBS |
-| ❌ Not supported | JSON, YAML, Wireframe (Salt) |
-
-**When to add a `legend`:**
-- Colors encode specific meaning (error/success, internal/external, sync/async)
-- Diagram has 5+ elements with distinct color-coded roles
-
-**When NOT to color:**
-- Diagram has only 2–3 simple elements (coloring adds noise)
-- JSON, YAML, or Wireframe diagrams (no skinparam support)
+> **Color coding:** Read `references/colors.md` for the muted pastel palette, color support by diagram type, and legend guidance.
 
 ## Behavioral Diagrams (how things work)
 

--- a/plugins/plantuml/skills/plantuml-diagram-guide/references/colors.md
+++ b/plugins/plantuml/skills/plantuml-diagram-guide/references/colors.md
@@ -1,0 +1,30 @@
+# Color Coding Guidelines
+
+Use color coding to improve diagram readability. Apply a **muted pastel palette** on white background (default). Do NOT set `skinparam backgroundColor` unless the user explicitly requests it.
+
+**Recommended palette:**
+
+| Color | Hex | Use for |
+|-------|-----|---------|
+| Soft blue | `#E8F4FD` / `#5B9BD5` | Primary elements, main flow |
+| Soft green | `#E8F5E9` / `#70AD47` | Success paths, approved states |
+| Soft red | `#FDE8E8` / `#E74C3C` | Error paths, rejected states |
+| Soft yellow | `#FFF8E1` / `#F4B942` | Warnings, pending states |
+| Soft purple | `#F3E8FD` / `#9B59B6` | External systems, third-party |
+| Soft gray | `#F5F5F5` / `#95A5A6` | Inactive, deprecated |
+
+**Color support by diagram type:**
+
+| Support | Types |
+|---------|-------|
+| ✅ Full (skinparam, arrows, groups) | Sequence, Activity, State, Class, Component, Object, ER, Deployment |
+| 🟡 Limited | Timing, Network, MindMap, Gantt, WBS |
+| ❌ Not supported | JSON, YAML, Wireframe (Salt) |
+
+**When to add a `legend`:**
+- Colors encode specific meaning (error/success, internal/external, sync/async)
+- Diagram has 5+ elements with distinct color-coded roles
+
+**When NOT to color:**
+- Diagram has only 2–3 simple elements (coloring adds noise)
+- JSON, YAML, or Wireframe diagrams (no skinparam support)


### PR DESCRIPTION
## Summary

- Extract Color Coding Guidelines section (~30 lines) from `plantuml-diagram-guide` SKILL.md to `references/colors.md`
- Replace with a compact one-line pointer, following the existing `references/sequence.md` pattern
- SKILL.md reduced from 103 to 73 lines of always-loaded context
- PATCH bump: v1.8.0 → v1.8.1

## Test plan

- [ ] Verify `references/colors.md` contains complete palette table, support matrix, legend guidance, and when-not-to-color rules
- [ ] Verify SKILL.md pointer references the correct file path
- [ ] Verify no color content is duplicated or lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)