### PR TITLE
feat(statusline-compact): display per-model 7d weekly limits (v0.5.0)

### DIFF
--- a/plugins/statusline-compact/.claude-plugin/plugin.json
+++ b/plugins/statusline-compact/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline-compact",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Compact single-line Claude Code statusline with brightness-coded API usage values. Shows 5h/7d rate limits, extra usage, context window, git branch, and model - all on one line.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/statusline-compact/README.md
+++ b/plugins/statusline-compact/README.md
@@ -11,7 +11,7 @@ Single-line statusline with brightness-coded API usage values.
 ## 🎬 Demo <a name="demo"></a>
 
 ```markdown
-5h 92% 50m !!   7d 22% ~5d   extra $4.79   Sonnet 4.6   context 30%   my-project/   main*
+5h 92% 50m !!   7d 22% ~5d   7d:sonnet 8% ~5d   extra $4.79   Sonnet 4.6   context 30%   my-project/   main*
 ```
 
 Values dim at low usage and brighten as they climb: yellow above 90%, red at 100%.
@@ -28,7 +28,7 @@ Values dim at low usage and brighten as they climb: yellow above 90%, red at 100
 - Model brightness = capability tier: Opus bright, Sonnet default, Haiku dim
 - Usage values: dim at low, brighten as they climb, yellow > 90%, red at 100%
 
-**Tracked values:** 5h rate limit · 7d rate limit · extra usage ($ amount) · context % · directory · git branch · model name
+**Tracked values:** 5h rate limit · 7d rate limit (all models) · 7d per-model limit (e.g., sonnet) · extra usage ($ amount) · context % · directory · git branch · model name
 
 ## 📦 Installation <a name="installation"></a>
 

--- a/plugins/statusline-compact/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/statusline-compact/docs/ACCEPTANCE_TESTS.md
@@ -4,6 +4,7 @@
 
 The statusline-compact plugin provides a single-line compact status display for Claude Code, showing:
 - 5h/7d rate limits with brightness-coded percentages
+- Per-model 7d limits (e.g., sonnet-only weekly limit)
 - Extra usage (monthly billing) with dollar amount
 - Model name, context window usage, directory, git branch
 
@@ -131,7 +132,7 @@ cd plugins/statusline-compact
 create_mock_cache() {
   local five_h=$1
   cat > /tmp/claude-statusline-usage-cache-${UID} <<EOF
-{"five_hour":{"utilization":$five_h,"resets_at":"2026-02-20T12:00:00+00:00"},"seven_day":{"utilization":50.0,"resets_at":"2026-02-25T12:00:00+00:00"},"extra_usage":{"is_enabled":false}}
+{"five_hour":{"utilization":$five_h,"resets_at":"2026-02-20T12:00:00+00:00"},"seven_day":{"utilization":50.0,"resets_at":"2026-02-25T12:00:00+00:00"},"seven_day_sonnet":{"utilization":10.0,"resets_at":"2026-02-25T16:00:00+00:00"},"seven_day_opus":null,"extra_usage":{"is_enabled":false}}
 EOF
 }
 
@@ -229,7 +230,46 @@ rm -rf "$test_dir"
 
 ---
 
-#### 3.4 API timeout/failure
+#### 3.4 Per-model 7d limits
+
+**Objective:** Verify per-model weekly limits (e.g., `seven_day_sonnet`) are displayed
+
+**Automation:** ✅
+
+**Steps:**
+```bash
+cd plugins/statusline-compact
+
+# Mock cache with sonnet-only limit
+cat > /tmp/claude-statusline-usage-cache-${UID} <<EOF
+{"five_hour":{"utilization":10.0,"resets_at":"2026-02-20T12:00:00+00:00"},"seven_day":{"utilization":20.0,"resets_at":"2026-02-25T12:00:00+00:00"},"seven_day_sonnet":{"utilization":5.0,"resets_at":"2026-02-25T16:00:00+00:00"},"seven_day_opus":null,"extra_usage":{"is_enabled":false}}
+EOF
+output=$(echo '{"workspace":{"current_dir":"/test"},"model":{"display_name":"Test"},"context_window":{"used_percentage":50}}' | bash scripts/statusline.sh | sed 's/\x1b\[[0-9;]*m//g')
+echo "$output" | grep -q '7d:sonnet' && echo "✅ Per-model segment present" || echo "❌ FAIL: Missing 7d:sonnet"
+
+# Mock cache with all per-model limits null
+cat > /tmp/claude-statusline-usage-cache-${UID} <<EOF
+{"five_hour":{"utilization":10.0,"resets_at":"2026-02-20T12:00:00+00:00"},"seven_day":{"utilization":20.0,"resets_at":"2026-02-25T12:00:00+00:00"},"seven_day_sonnet":null,"seven_day_opus":null,"extra_usage":{"is_enabled":false}}
+EOF
+output=$(echo '{"workspace":{"current_dir":"/test"},"model":{"display_name":"Test"},"context_window":{"used_percentage":50}}' | bash scripts/statusline.sh | sed 's/\x1b\[[0-9;]*m//g')
+echo "$output" | grep -q '7d:' && echo "❌ FAIL: Per-model segment shown when null" || echo "✅ No per-model segment when all null"
+
+# Mock cache with multiple per-model limits - highest shown
+cat > /tmp/claude-statusline-usage-cache-${UID} <<EOF
+{"five_hour":{"utilization":10.0,"resets_at":"2026-02-20T12:00:00+00:00"},"seven_day":{"utilization":20.0,"resets_at":"2026-02-25T12:00:00+00:00"},"seven_day_sonnet":{"utilization":15.0,"resets_at":"2026-02-25T16:00:00+00:00"},"seven_day_opus":{"utilization":30.0,"resets_at":"2026-02-25T16:00:00+00:00"},"extra_usage":{"is_enabled":false}}
+EOF
+output=$(echo '{"workspace":{"current_dir":"/test"},"model":{"display_name":"Test"},"context_window":{"used_percentage":50}}' | bash scripts/statusline.sh | sed 's/\x1b\[[0-9;]*m//g')
+echo "$output" | grep -q '7d:opus' && echo "✅ Highest utilization per-model shown" || echo "❌ FAIL: Expected 7d:opus (highest)"
+```
+
+**Acceptance criteria:**
+- ✅ Per-model segment shows when API returns non-null per-model limits
+- ✅ Per-model segment hidden when all per-model limits are null
+- ✅ When multiple per-model limits exist, the highest utilization is shown
+
+---
+
+#### 3.5 API timeout/failure
 
 **Objective:** Verify graceful degradation when API fails
 
@@ -272,7 +312,7 @@ claude
 
 Expected appearance:
 ```
-5h 12% ~2h14m   7d 45% ~3d5h   extra $4.79   Sonnet 4.5   context 52%   claude-plugins/   main
+5h 12% ~2h14m   7d 45% ~3d5h   7d:sonnet 8% ~5d   extra $4.79   Sonnet 4.5   context 52%   claude-plugins/   main
 ```
 
 Visual checklist:
@@ -313,6 +353,10 @@ echo '{"model":{"display_name":"Claude Sonnet 4.5"},"workspace":{"current_dir":"
 ---
 
 ## Version history
+
+### 0.5.0
+
+- Per-model 7d limits: shows highest-utilization per-model weekly limit (e.g., `7d:sonnet 1% ~5d`)
 
 ### 0.4.0
 

--- a/plugins/statusline-compact/scripts/statusline.sh
+++ b/plugins/statusline-compact/scripts/statusline.sh
@@ -3,7 +3,7 @@
 # Reads JSON from stdin (piped by Claude Code)
 #
 # Layout:
-#   5h 12% ~2h14m   7d 45% ~3d5h   extra $4.79   $0.42   Sonnet 4.5   context 52%   my-project/   main
+#   5h 12% ~2h14m   7d 45% ~3d5h   7d:sonnet 8% ~5d   extra $4.79   $0.42   Sonnet 4.5   context 52%   my-project/   main
 #
 # Brightness-coded values: dim at low usage, brighter as they climb,
 # yellow >90%, red at 100%. Text indicators: !! warning, XX exhausted.
@@ -249,6 +249,52 @@ if [ -n "$usage_json" ]; then
   fi
 fi
 
+# Per-model 7d segment: "7d:sonnet 1% ~5d" (highest utilization non-null per-model limit)
+compact_7d_model=""
+if [ -n "$usage_json" ]; then
+  # Extract all seven_day_* entries that are non-null with utilization
+  per_model_lines=$(echo "$usage_json" | jq -r '
+    to_entries[]
+    | select(.key | startswith("seven_day_"))
+    | select(.value != null and (.value | type) == "object" and .value.utilization != null)
+    | "\(.key | ltrimstr("seven_day_"))|\(.value.utilization)|\(.value.resets_at)"
+  ' 2>/dev/null)
+
+  if [ -n "$per_model_lines" ]; then
+    # Find the entry with the highest utilization
+    best_name=""
+    best_pct=""
+    best_resets=""
+    best_val=0
+    while IFS='|' read -r pm_name pm_pct pm_resets; do
+      pm_int=${pm_pct%.*}
+      if [ "$pm_int" -gt "$best_val" ] 2>/dev/null || [ -z "$best_name" ]; then
+        best_name="$pm_name"
+        best_pct="$pm_pct"
+        best_resets="$pm_resets"
+        best_val="$pm_int"
+      fi
+    done <<< "$per_model_lines"
+
+    if [ -n "$best_name" ]; then
+      pm_int=${best_pct%.*}
+      pm_remaining=$(format_time_remaining "$best_resets" 48)
+      pm_time_with_dim=$(dim_time_units "$pm_remaining")
+
+      pm_color=$(pct_color "$pm_int")
+      pm_pct_fmt="${pm_color}${pm_int}%${rst}"
+      pm_suffix=""
+      [ "$pm_int" -ge 100 ] 2>/dev/null && pm_suffix=" ${bright_red}XX${rst}"
+      [ "$pm_int" -gt 90 ] 2>/dev/null && [ "$pm_int" -lt 100 ] 2>/dev/null && pm_suffix=" ${yellow}!!${rst}"
+      pm_time=""
+      if [ -n "$pm_remaining" ]; then
+        pm_time=" ${pm_time_with_dim}"
+      fi
+      compact_7d_model="${dim}7d:${best_name}${rst} ${pm_pct_fmt}${pm_time}${pm_suffix}"
+    fi
+  fi
+fi
+
 # Extra usage segment: "extra $4.79" or "extra>> $13.87"
 compact_mo=""
 if [ -n "$usage_json" ]; then
@@ -319,7 +365,7 @@ fi
 
 # Assemble single line with 3-space gaps
 compact_line=""
-for seg in "$compact_5h" "$compact_7d" "$compact_mo" "$compact_cost" "$compact_model" "$compact_ctx" "$compact_dir" "$compact_branch"; do
+for seg in "$compact_5h" "$compact_7d" "$compact_7d_model" "$compact_mo" "$compact_cost" "$compact_model" "$compact_ctx" "$compact_dir" "$compact_branch"; do
   if [ -n "$seg" ]; then
     if [ -n "$compact_line" ]; then
       compact_line="${compact_line}   ${seg}"


### PR DESCRIPTION
## Summary

- The Anthropic usage API returns per-model weekly limits (`seven_day_sonnet`, `seven_day_opus`, etc.) that the plugin was ignoring
- Added a new `7d:<model>` segment showing the highest-utilization per-model weekly limit
- Hidden when all per-model limits are null

Fixes discrepancy between Claude AI dashboard (which shows "Sonnet only" weekly limit) and the statusline (which only showed "All models").

## Test plan

- [x] Per-model segment shows when API returns non-null per-model limits
- [x] Per-model segment hidden when all per-model limits are null
- [x] When multiple per-model limits exist, the highest utilization is shown
- [ ] Visual verification in live Claude Code session