### PR TITLE
feat(plantuml): add Mermaid diagram support (v2.0.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "plantuml",
       "source": "./plugins/plantuml",
-      "description": "PlantUML diagram automation: auto-sync URLs in markdown, pre-commit validation, CI checks"
+      "description": "Diagram automation (PlantUML + Mermaid): auto-sync URLs, syntax validation, diagram type guide"
     },
     {
       "name": "statusline",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ A marketplace of reusable Claude Code plugins (`Tribe Coding`). Each plugin live
 ## Plugins
 
 - **ai-fortune** — Career direction analysis: interview + AI usage pattern mining
-- **plantuml** — Keeps PlantUML diagram URLs in sync; provides ASCII rendering in terminal
+- **plantuml** — Diagram automation (PlantUML + Mermaid): auto-sync URLs, syntax validation, type guide
 - **statusline** — Three-line statusline: rate limits, context/branch, extra usage
 - **statusline-compact** — Single-line statusline with brightness-coded API usage
 - **git-branch-naming** — Enforces branch naming conventions (prefix/kebab-case)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/
 | [**context**](plugins/context/README.md) | Show everything loaded into your session — CLAUDE.md files, memory, hooks — with a per-source token breakdown |
 | [**git-branch-naming**](plugins/git-branch-naming/README.md) | Enforce branch naming conventions automatically; warns before push if the name or staged content doesn't match |
 | [**kb-grooming**](plugins/kb-grooming/README.md) | Audit documentation health — broken links, orphan files, README compliance — then create a GitHub epic with linked issues |
-| [**plantuml**](plugins/plantuml/README.md) | Proactively add rendered diagrams to docs (image URLs auto-synced); draw ASCII diagrams inline during terminal conversations |
+| [**plantuml**](plugins/plantuml/README.md) | Diagram automation (PlantUML + Mermaid): auto-sync PlantUML URLs, validate Mermaid syntax, pick the right diagram type from 26 options |
 | [**playbook**](plugins/playbook/README.md) | Inject team coding conventions into every session — git workflow, documentation standards, platform quirks |
 | [**retroscope**](plugins/retroscope/README.md) | Capture what happened each session and generate structured daily retrospective reports |
 | [**semver**](plugins/semver/README.md) | Validate that a version bump is staged before every commit, push, and PR — with configurable enforcement |

--- a/plugins/plantuml/.claude-plugin/plugin.json
+++ b/plugins/plantuml/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plantuml",
-  "version": "1.8.1",
-  "description": "PlantUML diagram automation: auto-sync, validation, diagram type guide",
+  "version": "2.0.0",
+  "description": "Diagram automation (PlantUML + Mermaid): auto-sync, validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"
   },

--- a/plugins/plantuml/CHANGELOG.md
+++ b/plugins/plantuml/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the PlantUML plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-03-29
+
+### Added
+- **Mermaid diagram support** across the entire plugin
+- Mermaid syntax validation in `plantuml-encode.py` (`--check` now validates both formats, `--check-mermaid-only` for mermaid-only)
+- 9 Mermaid-only diagram types in diagram guide: flowchart, pie, gitgraph, timeline, sankey, XY chart, quadrant, requirement, block, journey
+- `references/mermaid-syntax.md` — syntax examples for all Mermaid diagram types
+- PostToolUse hook validates Mermaid syntax on `.md` file edits (non-blocking warnings)
+- Pre-commit template validates both PlantUML URLs and Mermaid syntax
+
+### Changed
+- **BREAKING:** SessionStart rules restructured for dual-format (Mermaid + PlantUML)
+- **BREAKING:** `--check` flag now validates both PlantUML URLs AND Mermaid syntax (previously PlantUML only)
+- Diagram guide SKILL.md expanded from 17 to 26 diagram types with Format column and recommendations
+- Default format preference: Mermaid when both formats support a type
+- Terminal rendering for Mermaid: hand-drawn ASCII approximation (no API call, no raw source shown)
+- Pre-commit error messages updated for both formats
+- Validation command covers both PlantUML and Mermaid
+
 ## [1.8.0] - 2026-03-07
 
 ### Added

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -1,25 +1,25 @@
 # PlantUML
 
 > [!TIP]
-> ✨ ***Add diagrams to your docs and conversations — Claude picks the type, draws, and keeps them in sync.***
+> ✨ ***Add diagrams to your docs and conversations — Claude picks the type, format, and keeps them in sync.***
 
-With this plugin, Claude proactively illustrates architecture, flows, and data structures using [PlantUML](https://plantuml.com): in markdown documentation and directly in the terminal during conversations.
+With this plugin, Claude proactively illustrates architecture, flows, and data structures using [Mermaid](https://mermaid.js.org/) or [PlantUML](https://plantuml.com): in markdown documentation and directly in the terminal during conversations. Mermaid is preferred when supported — it renders natively in GitHub, Obsidian, and Excalidraw without external services.
 
 > [!NOTE]
 > [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🗑️ Uninstall](#uninstall)
 
 ## 🎬 Demo <a name="demo"></a>
 
-A developer asks Claude to document the login flow. Claude adds a diagram to the docs — then, during the conversation, renders the same diagram as ASCII art in the terminal.
+A developer asks Claude to document the login flow. Claude picks Mermaid (native rendering), writes the diagram, and draws an ASCII version in conversation.
 
-### Step 1 — Claude writes `docs/auth.md` and adds a diagram proactively
+### Step 1 — Claude writes `docs/auth.md` with a Mermaid diagram
 
 ```markdown
 > Document the login flow for the auth service.
 
 ✦ Using skill: plantuml-diagram-guide
 
-I'll create docs/auth.md. The flow involves four actors — I'll use a sequence diagram.
+I'll create docs/auth.md. The flow involves four actors — I'll use a Mermaid sequence diagram.
 
 ● Write(docs/auth.md)
   ┌───────────────────────────────────────────────────────────────────┐
@@ -27,82 +27,89 @@ I'll create docs/auth.md. The flow involves four actors — I'll use a sequence 
   │                                                                   │
   │ ## Login Request Flow                                             │
   │                                                                   │
-  │ ```plantuml                                                       │
-  │ @startuml                                                         │
-  │ title Login Request Flow                                          │
+  │ ```mermaid                                                        │
+  │ sequenceDiagram                                                   │
+  │     title Login Request Flow                                      │
+  │     participant User                                              │
+  │     participant Web as Web App                                    │
+  │     participant API as Auth API                                   │
+  │     participant DB as PostgreSQL                                  │
   │                                                                   │
-  │ actor User                                                        │
-  │ participant "Web App" as Web                                      │
-  │ participant "Auth API" as API                                     │
-  │ database "PostgreSQL" as DB                                       │
-  │                                                                   │
-  │ User -> Web : POST /login                                         │
-  │ Web -> API : forward credentials                                  │
-  │ API -> DB : SELECT user WHERE email = ?                           │
-  │ DB --> API : user row                                             │
-  │ API --> Web : 200 OK + token                                      │
-  │ Web --> User : redirect + set cookie                              │
-  │ @enduml                                                           │
+  │     User->>Web: POST /login                                       │
+  │     Web->>API: forward credentials                                │
+  │     API->>DB: SELECT user WHERE email = ?                         │
+  │     DB-->>API: user row                                           │
+  │     API-->>Web: 200 OK + token                                    │
+  │     Web-->>User: redirect + set cookie                            │
   │ ```                                                               │
-  │                                                                   │
-  │ ![Login Request Flow (PNG image)](https://www.plantuml.com/...)   │
   └───────────────────────────────────────────────────────────────────┘
 
-⏺ Done — docs/auth.md created. The image URL stays in sync automatically whenever you edit the source block.
+⏺ Done — docs/auth.md created. The diagram renders natively in GitHub and Obsidian.
 ```
 
-![Login Request Flow](https://www.plantuml.com/plantuml/png/TP7HJi8m58Rl-nGdU6c8H2KYYSh6jcXSmWGCrsKxGBFHCzkpuEDxDWd112-sjVs-_l_IJZnhnys-KcouGaXfQopCyQj1pv1KT50xKo1iY7XDtygNnjRQwJt8cqrkQcqvr7cvTTJOOaeLERYAHybz4lqZaolG7SM79BoBHcUYRvjjZe5pT3XAm_0nZ8ONfDHivB5uALBfd6NwwT6fitRehN0DGLttG7kGyLyODBo387lhg7nLeLcljKVePUHvwt3naNOm2fLgmw7_tCR06BBPOWatLNk0gbqH80a2DkGEsXMGEopGij6LLoqH8Gg5B-8qdYwXQTDMh_4y1jnhKy4Jl2WH-gUWpf1p-TrzAhuT363s3jV0LEAnMs3tTsEGKkCmP-4U6NAYqg2Qe2tardy0)
-
-### Step 2 — Later in the conversation, Claude renders it as ASCII in the terminal
+### Step 2 — Later in conversation, Claude draws ASCII (no API call)
 
 ```markdown
 > Walk me through the login flow step by step.
 
-✦ Using skill: plantuml-diagram-guide
-
 Here's the full flow:
 
-                                     Login Request Flow
+  User          Web App        Auth API      PostgreSQL
+   │               │               │               │
+   │ POST /login   │               │               │
+   │──────────────>│               │               │
+   │               │ forward creds │               │
+   │               │──────────────>│               │
+   │               │               │ SELECT user   │
+   │               │               │──────────────>│
+   │               │               │   user row    │
+   │               │               │<──────────────│
+   │               │  200 + token  │               │
+   │               │<──────────────│               │
+   │ redirect +    │               │               │
+   │ set cookie    │               │               │
+   │<──────────────│               │               │
 
-       ┌─┐                                                                    ,.-^^-._
-       ║"│                                                                   |-.____.-|
-       └┬┘                                                                   |        |
-       ┌┼┐                                                                   |        |
-        │                  ┌───────┐           ┌────────┐                    |        |
-       ┌┴┐                 │Web App│           │Auth API│                    '-.____.-'
-      User                 └───┬───┘           └────┬───┘                   PostgreSQL
-        │     POST /login      │                    │                            │
-        │─────────────────────>│                    │                            │
-        │                      │                    │                            │
-        │                      │forward credentials │                            │
-        │                      │───────────────────>│                            │
-        │                      │                    │                            │
-        │                      │                    │SELECT user WHERE email = ? │
-        │                      │                    │───────────────────────────>│
-        │                      │                    │                            │
-        │                      │                    │         user row           │
-        │                      │                    │<─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│
-        │                      │                    │                            │
-        │                      │  200 OK + token    │                            │
-        │                      │<─ ─ ─ ─ ─ ─ ─ ─ ─ ─│                            │
-        │                      │                    │                            │
-        │redirect + set cookie │                    │                            │
-        │<─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│                    │                            │
-        │                      │                    │                            │
+The flow is straightforward: credentials go in, token comes back.
+```
 
-![Login Request Flow (PNG image)](https://www.plantuml.com/...)
+### PlantUML still works for types Mermaid doesn't support
+
+```markdown
+> Add a deployment diagram showing the infrastructure.
+
+✦ Using skill: plantuml-diagram-guide
+
+Deployment diagrams are PlantUML-only. I'll use PlantUML with an auto-synced image URL.
+
+● Write(docs/deployment.md)
+  ┌──────────────────────────────────────────────────────────────┐
+  │ ```plantuml                                                   │
+  │ @startuml                                                     │
+  │ title Production Deployment                                   │
+  │ node "AWS" {                                                  │
+  │   node "ECS" { component "Auth API" }                         │
+  │   database "RDS" { component "PostgreSQL" }                   │
+  │ }                                                             │
+  │ @enduml                                                       │
+  │ ```                                                           │
+  │                                                               │
+  │ ![Production Deployment](https://www.plantuml.com/plantuml/…) │
+  └──────────────────────────────────────────────────────────────┘
 ```
 
 ## ⚙️ How it works <a name="how-it-works"></a>
 
-Every diagram has two parts: a `plantuml` source block and an image URL below it. Claude writes both — you only edit the source. When you save, the URL updates automatically.
+**Mermaid diagrams** need only a fenced `mermaid` code block — no image URL. Renderers (GitHub, Obsidian, Excalidraw) handle it natively. The PostToolUse hook validates Mermaid syntax on save.
+
+**PlantUML diagrams** have two parts: a `plantuml` source block and an image URL below it. Claude writes both — you only edit the source. When you save, the URL updates automatically.
 
 | Trigger | What happens |
 |---------|-------------|
-| SessionStart | Injects diagram formatting rules and ASCII rendering workflow |
-| PostToolUse (Write/Edit on `.md`) | Auto-updates image URLs when source changes ([validation & CI](docs/VALIDATION.md)) |
-| PreToolUse | Auto-allows all PlantUML operations — no permission prompts |
-| Before creating any diagram | `plantuml-diagram-guide` skill invoked automatically — picks the right type from 17 options |
+| SessionStart | Injects dual-format diagram rules (Mermaid preferred, PlantUML fallback) |
+| PostToolUse (Write/Edit on `.md`) | Auto-syncs PlantUML image URLs; validates Mermaid syntax |
+| PreToolUse | Auto-allows PlantUML encoding operations — no permission prompts |
+| Before creating any diagram | `plantuml-diagram-guide` skill invoked — picks the right type and format from 26 options |
 
 ## 📦 Installation <a name="installation"></a>
 
@@ -118,7 +125,7 @@ Select **plantuml** → enable **auto-update**. Restart your session — done.
 
 ## 🗑️ Uninstall <a name="uninstall"></a>
 
-The plugin installs a pre-commit hook section that validates PlantUML URLs before each commit. To remove it from a project:
+The plugin installs a pre-commit hook section that validates diagram syntax before each commit. To remove it from a project:
 
 ```
 /plantuml-uninstall

--- a/plugins/plantuml/commands/plantuml-validate/SKILL.md
+++ b/plugins/plantuml/commands/plantuml-validate/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: plantuml-validate
 description: >
-  Validate that all PlantUML diagram URLs in markdown files match their
-  source blocks. Reports missing or stale URLs and offers auto-fix.
+  Validate that all PlantUML diagram URLs and Mermaid syntax in markdown files
+  are correct. Reports missing/stale PlantUML URLs and invalid Mermaid blocks,
+  then offers auto-fix for PlantUML issues.
 compatibility: Requires Python 3.x
 ---
 
-# PlantUML Validate
+# Diagram Validate
 
-Validate that all PlantUML diagram URLs in markdown files are in sync with their source blocks.
+Validate that all PlantUML diagram URLs are in sync with their source blocks, and that all Mermaid blocks have valid syntax.
 
 ## Instructions
 
-1. Find all `.md` files in the project that contain PlantUML code blocks:
+1. Find all `.md` files in the project that contain diagram code blocks:
    ```bash
-   grep -rl '```plantuml' . --include='*.md'
+   grep -rlE '```(plantuml|mermaid)' . --include='*.md'
    ```
 
 2. Run the validation check on all found files:
@@ -24,11 +25,14 @@ Validate that all PlantUML diagram URLs in markdown files are in sync with their
    `CLAUDE_PLUGIN_ROOT` is set automatically by Claude Code when running plugin commands.
 
 3. Report results to the user:
-   - If all diagrams are in sync: confirm success with file count
-   - If mismatches found: list each issue with file, line number, and type (missing URL vs stale URL)
-   - Offer to auto-fix by running `--sync` on affected files
+   - If all diagrams are valid: confirm success with file count
+   - If issues found: list each issue with file, line number, and type:
+     - PlantUML: missing URL or stale URL
+     - Mermaid: unrecognized diagram type or empty block
+   - Offer to auto-fix PlantUML issues by running `--sync` on affected files
+   - Mermaid issues require manual correction (fix the diagram type keyword)
 
-4. If the user confirms auto-fix, run:
+4. If the user confirms auto-fix for PlantUML, run:
    ```bash
    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/plantuml-encode.py" --sync <affected-files>
    ```

--- a/plugins/plantuml/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/plantuml/docs/ACCEPTANCE_TESTS.md
@@ -1,16 +1,16 @@
-# PlantUML Plugin Acceptance Tests
+# Diagram Plugin Acceptance Tests (PlantUML + Mermaid)
 
 ## Purpose
 
-This document defines acceptance criteria and test scenarios for the PlantUML plugin. Use it to:
+This document defines acceptance criteria and test scenarios for the diagram plugin (PlantUML + Mermaid). Use it to:
 - Validate all components work correctly before releasing new versions
 - Perform regression testing after refactoring or bug fixes
 - Onboard new contributors by demonstrating expected behavior
 
-The PlantUML plugin provides automatic synchronization of PlantUML diagrams in markdown files through multiple integrated components:
-- **Hooks** (SessionStart, PostToolUse) for automatic rule injection and synchronization
-- **Scripts** (Python encoder, bash wrappers) for processing PlantUML code
-- **Commands/Skills** for manual validation and diagram type selection
+The plugin provides diagram automation in markdown files through multiple integrated components:
+- **Hooks** (SessionStart, PostToolUse) for automatic rule injection, URL synchronization, and syntax validation
+- **Scripts** (Python encoder/validator, bash wrappers) for processing PlantUML and Mermaid code
+- **Commands/Skills** for manual validation and diagram type selection (26 types across both formats)
 - **Templates** for git pre-commit hooks and CI/CD workflows
 
 ## Test Execution Order
@@ -2155,8 +2155,101 @@ Document any known test failures or limitations here:
 
 ---
 
+## Test 13: Mermaid Syntax Validation
+
+**Component:** `plantuml-encode.py --check-mermaid-only` and `--check`
+
+### 13.1: Valid mermaid blocks pass
+
+**Steps:**
+1. Create a `.md` file with valid mermaid blocks (sequenceDiagram, flowchart, erDiagram, etc.)
+2. Run `python3 plantuml-encode.py --check-mermaid-only <file>`
+3. Verify exit code 0 and success message
+
+### 13.2: Invalid mermaid type detected
+
+**Steps:**
+1. Create a `.md` file with `\`\`\`mermaid\nbadtype\n  content\n\`\`\``
+2. Run `python3 plantuml-encode.py --check-mermaid-only <file>`
+3. Verify exit code 1 and error message with "unrecognized diagram type"
+
+### 13.3: Empty mermaid block detected
+
+**Steps:**
+1. Create a `.md` file with `\`\`\`mermaid\n\`\`\``
+2. Run `python3 plantuml-encode.py --check-mermaid-only <file>`
+3. Verify exit code 1 and error message with "empty"
+
+### 13.4: Combined --check validates both formats
+
+**Steps:**
+1. Create a `.md` file with both a PlantUML block (no URL) and a valid mermaid block
+2. Run `python3 plantuml-encode.py --check <file>`
+3. Verify exit code 1 (PlantUML URL missing) but mermaid block passes
+4. Add an invalid mermaid block, re-run
+5. Verify both PlantUML and Mermaid errors reported
+
+## Test 14: Mermaid PostToolUse Validation
+
+**Component:** `sync-plantuml.sh`
+
+### 14.1: PostToolUse validates mermaid syntax
+
+**Steps:**
+1. Write a `.md` file with a valid mermaid block via Claude Code
+2. Verify PostToolUse hook runs without errors (mermaid validation pass)
+3. Write a `.md` file with an invalid mermaid block
+4. Verify PostToolUse outputs mermaid warning but does not block (non-blocking)
+
+### 14.2: PostToolUse does not add URLs to mermaid blocks
+
+**Steps:**
+1. Write a `.md` file with only mermaid blocks (no plantuml)
+2. Verify no image URLs are added after mermaid blocks
+3. File should contain only the `\`\`\`mermaid` code block, nothing else
+
+## Test 15: Mermaid Pre-commit Validation
+
+**Component:** `templates/pre-commit`
+
+### 15.1: Pre-commit blocks invalid mermaid
+
+**Steps:**
+1. Stage a `.md` file with an invalid mermaid block
+2. Attempt `git commit`
+3. Verify commit is blocked with "diagram validation failed" message
+
+### 15.2: Pre-commit passes valid mermaid
+
+**Steps:**
+1. Stage a `.md` file with only valid mermaid blocks
+2. Attempt `git commit`
+3. Verify commit succeeds
+
+## Test 16: Mermaid Terminal Rendering (Manual)
+
+**Component:** Behavioral — Claude's response in conversation
+
+### 16.1: ASCII approximation without API
+
+**Steps:**
+1. Ask Claude to draw a sequence diagram during conversation
+2. Verify Claude uses Mermaid format and draws ASCII approximation
+3. Verify no external API call is made (no WebFetch for mermaid)
+4. Verify raw mermaid source is NOT shown before the ASCII art
+
+### 16.2: Diagram guide recommends mermaid
+
+**Steps:**
+1. Ask Claude to create a sequence diagram
+2. Verify `plantuml-diagram-guide` skill is invoked
+3. Verify Mermaid is recommended as the default format for sequence diagrams
+
+---
+
 ## References
 
 - [Plugin Source Code](../README.md)
 - [agentskills.io Specification](https://agentskills.io/specification)
 - [PlantUML Official Documentation](https://plantuml.com/)
+- [Mermaid Official Documentation](https://mermaid.js.org/)

--- a/plugins/plantuml/scripts/inject-rules.sh
+++ b/plugins/plantuml/scripts/inject-rules.sh
@@ -1,32 +1,34 @@
 #!/bin/bash
-# SessionStart hook: inject PlantUML formatting rules into Claude's context.
-# Outputs compact base rules so Claude always knows the 2-part format.
+# SessionStart hook: inject diagram formatting rules into Claude's context.
+# Outputs compact base rules for both PlantUML and Mermaid formats.
 # The full diagram type catalog is available on-demand via the plantuml-diagram-guide skill.
 
 # Resolve plugin root path (works both as hook and standalone)
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 cat <<RULES
-## PlantUML Diagrams in Markdown — Base Rules
+## Diagrams in Markdown — Base Rules
 
+**Format preference:** Use Mermaid when the diagram type supports it (renders natively in GitHub, Obsidian, Excalidraw). Use PlantUML for types Mermaid doesn't support or when you need PlantUML-specific features (advanced styling, deployment, timing, etc.).
+
+### Mermaid format
+Mermaid diagrams need only ONE part: a fenced \`mermaid\` code block. No image URL needed — renderers handle it natively.
+- In markdown files: write only the \`\`\`mermaid block. Nothing else.
+- In terminal/conversation: draw a hand-drawn ASCII approximation directly from the mermaid source. Do NOT call any external API. Do NOT show the raw mermaid source block before the ASCII — show ONLY the ASCII diagram, then a brief note of what it represents.
+
+### PlantUML format
 Every PlantUML diagram MUST have two parts, in this order:
 1. A fenced \`plantuml\` code block with raw source
 2. A blank line, then a Markdown image link to \`https://www.plantuml.com/plantuml/svg/<encoded>\`
 
-Proactive usage:
-- When creating/updating \`.md\` docs, proactively add PlantUML diagrams for architecture, sequences, state machines, data flow, and component relationships.
-- When explaining in terminal, determine diagram type, then render:
-  - **Encode**: \`encoded=\$(echo "\$source" | python3 ${PLUGIN_ROOT}/scripts/plantuml-encode.py --encode-only)\`
-  - **ASCII-friendly types** (sequence, activity, state, class, component, object, usecase): fetch ASCII via WebFetch from \`https://www.plantuml.com/plantuml/txt/<encoded>\`, display it, then show \`[View SVG](https://www.plantuml.com/plantuml/svg/<encoded>)\`. On failure: retry once simpler, then fall back to box-drawing ASCII.
-  - **Link-only types** (timing, gantt, mindmap, WBS, wireframe, network, JSON, YAML, ER, deployment): show source in fenced \`plantuml\` block + SVG link.
-  - Do NOT paste raw source without a code block. Do NOT manually draw ASCII if API is available.
-- **ALWAYS invoke the \`plantuml-diagram-guide\` skill BEFORE creating any PlantUML diagram** to choose the correct diagram type. This is MANDATORY — do not skip this step even if you think you know which type to use.
-
-Rules:
-- Always keep both parts in sync. When you modify PlantUML source, the PostToolUse hook auto-updates the image URL.
+- **Encode**: \`encoded=\$(echo "\$source" | python3 ${PLUGIN_ROOT}/scripts/plantuml-encode.py --encode-only)\`
+- In terminal: for ASCII-friendly types, fetch via WebFetch from \`https://www.plantuml.com/plantuml/txt/<encoded>\`. For other types, show source + SVG link.
+- The PostToolUse hook auto-syncs PlantUML image URLs when you edit .md files.
 - Use SVG format (\`/svg/\` path) unless PNG is specifically requested.
-- The alt text in the image link should be a short description of the diagram.
-- Place a blank line between the closing \`\`\` and the image link.
 - Every sequence diagram MUST include \`skinparam sequenceArrowThickness 1.5\` and \`skinparam LifeLineBorderColor #C0C0C0\` after \`@startuml\`.
 - For sequence diagrams: consult \`references/sequence.md\` (via plantuml-diagram-guide skill) for ACK suppression rules and arrow style conventions.
+
+### Shared rules
+- **ALWAYS invoke the \`plantuml-diagram-guide\` skill BEFORE creating any diagram** to choose the correct type and format. This is MANDATORY — do not skip this step.
+- When creating/updating \`.md\` docs, proactively add diagrams for architecture, sequences, state machines, data flow, and component relationships.
 RULES

--- a/plugins/plantuml/scripts/plantuml-encode.py
+++ b/plugins/plantuml/scripts/plantuml-encode.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Encode PlantUML text into a URL for https://www.plantuml.com/plantuml/
+Diagram tool: encode PlantUML URLs and validate Mermaid syntax in markdown.
 
 Usage:
-    # Encode from stdin
+    # Encode PlantUML from stdin
     echo '@startuml\nAlice -> Bob: Hello\n@enduml' | python3 plantuml-encode.py
 
     # Encode from file
@@ -18,8 +18,11 @@ Usage:
     # Sync all PlantUML blocks in a markdown file (auto-fix)
     python3 plantuml-encode.py --sync README.md
 
-    # Check for mismatches without modifying files (exit 1 if errors)
+    # Check both PlantUML URLs and Mermaid syntax (exit 1 if errors)
     python3 plantuml-encode.py --check README.md docs/*.md
+
+    # Check only Mermaid syntax (exit 1 if errors)
+    python3 plantuml-encode.py --check-mermaid-only README.md
 """
 
 import sys
@@ -93,6 +96,72 @@ def render_ascii(text):
     except Exception as e:
         print(f"Error: Unexpected error while rendering ASCII: {e}", file=sys.stderr)
         return None
+
+
+MERMAID_DIAGRAM_KEYWORDS = {
+    'sequenceDiagram', 'flowchart', 'graph', 'classDiagram', 'stateDiagram',
+    'stateDiagram-v2', 'erDiagram', 'gantt', 'pie', 'mindmap', 'gitGraph',
+    'timeline', 'sankey-beta', 'xychart-beta', 'quadrantChart',
+    'requirementDiagram', 'block-beta', 'journey', 'C4Context', 'C4Container',
+    'C4Component', 'C4Deployment', 'packet-beta', 'kanban', 'architecture-beta',
+}
+
+
+def validate_mermaid_block(source, block_num=1, line_num=1, filepath=""):
+    """
+    Validate a single mermaid code block using structural checks.
+    Returns a list of error dicts (empty = valid).
+    """
+    errors = []
+    stripped = source.strip()
+
+    if not stripped:
+        errors.append({
+            'file': filepath,
+            'block': block_num,
+            'line': line_num,
+            'type': 'mermaid_empty',
+            'message': f"Mermaid block #{block_num} (line {line_num}) is empty."
+        })
+        return errors
+
+    first_line = stripped.split('\n')[0].strip()
+    # Extract the keyword (first word, possibly with direction like "flowchart TD")
+    first_word = first_line.split()[0] if first_line.split() else ''
+
+    if first_word not in MERMAID_DIAGRAM_KEYWORDS:
+        errors.append({
+            'file': filepath,
+            'block': block_num,
+            'line': line_num,
+            'type': 'mermaid_unknown_type',
+            'message': (
+                f"Mermaid block #{block_num} (line {line_num}): "
+                f"unrecognized diagram type '{first_word}'. "
+                f"Expected one of: {', '.join(sorted(MERMAID_DIAGRAM_KEYWORDS))}"
+            )
+        })
+
+    return errors
+
+
+def check_markdown_mermaid(filepath):
+    """
+    Validate all Mermaid code blocks in a markdown file.
+    Returns a list of error dicts. Empty list = all OK.
+    """
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    errors = []
+    pattern = re.compile(r'```mermaid\s*\n(.*?)```', re.DOTALL)
+
+    for i, match in enumerate(pattern.finditer(content), 1):
+        source = match.group(1)
+        line_num = content[:match.start()].count('\n') + 1
+        errors.extend(validate_mermaid_block(source, i, line_num, filepath))
+
+    return errors
 
 
 def check_markdown(filepath):
@@ -195,36 +264,56 @@ def sync_markdown(filepath):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="PlantUML URL encoder")
+    parser = argparse.ArgumentParser(description="Diagram tool: PlantUML URL encoder + Mermaid validator")
     parser.add_argument('--format', '-f', default='svg', choices=['svg', 'png', 'txt'],
                         help='Output format (default: svg)')
     parser.add_argument('--sync', '-s', metavar='FILE', nargs='+',
                         help='Sync PlantUML image URLs in markdown file(s)')
     parser.add_argument('--check', '-c', metavar='FILE', nargs='+',
-                        help='Check PlantUML image URLs match source (exit 1 if mismatch)')
+                        help='Check PlantUML URLs and Mermaid syntax (exit 1 if errors)')
+    parser.add_argument('--check-mermaid-only', metavar='FILE', nargs='+',
+                        help='Check only Mermaid syntax in markdown file(s)')
     parser.add_argument('--encode-only', '-e', action='store_true',
                         help='Output only the encoded string, not full URL')
     parser.add_argument('--render-ascii', '-r', action='store_true',
                         help='Render ASCII diagram directly from PlantUML API (reads from stdin)')
     args = parser.parse_args()
 
-    if args.check:
+    if args.check_mermaid_only:
         all_errors = []
-        for filepath in args.check:
-            errors = check_markdown(filepath)
-            all_errors.extend(errors)
+        for filepath in args.check_mermaid_only:
+            all_errors.extend(check_markdown_mermaid(filepath))
         if all_errors:
             print(f"\n{'='*60}", file=sys.stderr)
-            print(f"PLANTUML SYNC ERRORS: {len(all_errors)} issue(s) found", file=sys.stderr)
+            print(f"MERMAID SYNTAX ERRORS: {len(all_errors)} issue(s) found", file=sys.stderr)
             print(f"{'='*60}\n", file=sys.stderr)
             for err in all_errors:
                 print(f"  ✗ {err['file']}: {err['message']}\n", file=sys.stderr)
-            print(f"Fix all issues by running:", file=sys.stderr)
-            files = ' '.join(sorted(set(e['file'] for e in all_errors)))
-            print(f"  plantuml-encode.py --sync {files}\n", file=sys.stderr)
             sys.exit(1)
         else:
-            print(f"All PlantUML diagrams are in sync across {len(args.check)} file(s).")
+            print(f"All Mermaid diagrams valid across {len(args.check_mermaid_only)} file(s).")
+    elif args.check:
+        all_errors = []
+        for filepath in args.check:
+            all_errors.extend(check_markdown(filepath))
+            all_errors.extend(check_markdown_mermaid(filepath))
+        if all_errors:
+            plantuml_errors = [e for e in all_errors if not e['type'].startswith('mermaid_')]
+            mermaid_errors = [e for e in all_errors if e['type'].startswith('mermaid_')]
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"DIAGRAM VALIDATION ERRORS: {len(all_errors)} issue(s) found", file=sys.stderr)
+            print(f"{'='*60}\n", file=sys.stderr)
+            for err in all_errors:
+                print(f"  ✗ {err['file']}: {err['message']}\n", file=sys.stderr)
+            if plantuml_errors:
+                files = ' '.join(sorted(set(e['file'] for e in plantuml_errors)))
+                print(f"Fix PlantUML issues: plantuml-encode.py --sync {files}", file=sys.stderr)
+            if mermaid_errors:
+                print(f"Fix Mermaid issues: check diagram type keywords in source blocks", file=sys.stderr)
+            print("", file=sys.stderr)
+            sys.exit(1)
+        else:
+            print(f"All diagrams valid across {len(args.check)} file(s).")
     elif args.sync:
         for filepath in args.sync:
             sync_markdown(filepath)

--- a/plugins/plantuml/scripts/sync-plantuml.sh
+++ b/plugins/plantuml/scripts/sync-plantuml.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Claude Code PostToolUse hook: auto-sync PlantUML URLs after editing .md files
+# Claude Code PostToolUse hook: auto-sync PlantUML URLs and validate Mermaid after editing .md files
 # Called by Claude Code after every Write/Edit operation.
-# Reads tool input from stdin, checks if the file is .md, and runs sync.
+# Reads tool input from stdin, checks if the file is .md, and runs sync + validation.
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
@@ -10,6 +10,7 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 if [[ "$FILE_PATH" == *.md ]]; then
   python3 "$PLUGIN_ROOT/scripts/plantuml-encode.py" --sync "$FILE_PATH" 2>&1
+  python3 "$PLUGIN_ROOT/scripts/plantuml-encode.py" --check-mermaid-only "$FILE_PATH" 2>&1 || true
 fi
 
 exit 0

--- a/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
+++ b/plugins/plantuml/skills/plantuml-diagram-guide/SKILL.md
@@ -1,73 +1,101 @@
 ---
 name: plantuml-diagram-guide
 description: >
-  Invoked automatically before creating PlantUML diagrams to select the correct type.
-  Covers 17 types: sequence, activity, state, class, ER, component, deployment,
-  timing, mindmap, gantt, WBS, JSON, YAML, network, object, usecase, wireframe.
-  Do NOT create PlantUML without consulting this guide.
-  Keywords: diagram type, which diagram, best diagram, choose diagram, UML.
+  Invoked automatically before creating diagrams (PlantUML or Mermaid) to select
+  the correct type and format. Covers 26 diagram types across both formats.
+  Do NOT create diagrams without consulting this guide.
+  Keywords: diagram type, which diagram, mermaid, plantuml, flowchart, UML.
 ---
 
-# PlantUML Diagram Type Guide
+# Diagram Type Guide
 
-Use this guide to choose the right PlantUML diagram type for documentation. When creating or updating `.md` files, proactively suggest and use the appropriate diagram type.
+Use this guide to choose the right diagram type and format. When creating or updating `.md` files, proactively suggest and use the appropriate diagram type.
+
+**Format preference:** Use Mermaid when both formats support a type - it renders natively in GitHub, Obsidian, and Excalidraw. Use PlantUML when Mermaid doesn't support the type or when you need advanced features.
 
 **IMPORTANT:** Every diagram MUST include a `title` directive immediately after the opening tag. This makes diagrams self-documenting. Example: `title User Authentication Flow`
 
-> **Color coding:** Read `references/colors.md` for the muted pastel palette, color support by diagram type, and legend guidance.
+> **PlantUML color coding:** Read `references/colors.md` for the muted pastel palette, color support by diagram type, and legend guidance.
+>
+> **Mermaid syntax:** Read `references/mermaid-syntax.md` for syntax examples of all Mermaid diagram types.
 
-## Behavioral Diagrams (how things work)
+## Behavioral diagrams (how things work)
 
-| Type | When to use | When to suggest | Syntax |
-|------|-------------|-----------------|--------|
-| **Sequence** | Interactions between processes/services, API call flows, request-response chains. For ≤ 10 arrows add `hide footbox`; for longer diagrams keep footbox for navigation | Spec files with pipeline/API descriptions; new inter-process communication | `@startuml` with `->`, `-->`, `->>` |
-| **Activity** | Algorithms, business logic, decision trees, branching flows, parallel processes | Decision log entries; complex functions with many branches; CI/CD procedures | `@startuml` with `start`, `:action;`, `if/then/else`, `fork` |
-| **State** | State machines, object lifecycles, connection/session/process states | Code with if/else chains that implement a state machine; specs describing behavior with distinct states | `@startuml` with `[*] -->`, `state` |
-| **Use Case** | Functional requirements, actor-system interactions, feature overview | PRD files; new feature overview; user stories | `@startuml` with `actor`, `usecase`, `-->` |
-| **Timing** | Time-based event characteristics, latency profiling, synchronization, timeout/retry logic | Performance documentation; pipeline latency analysis | `@startuml` with `concise`/`robust`, `@` |
+| Type | Format | When to use | When to suggest |
+|------|--------|-------------|-----------------|
+| **Sequence** | Both (prefer Mermaid) | Interactions between processes/services, API call flows, request-response chains | Spec files with pipeline/API descriptions; new inter-process communication |
+| **Activity** | PlantUML only | Algorithms, business logic, decision trees, branching flows, parallel processes | Decision log entries; complex functions with many branches; CI/CD procedures |
+| **State** | Both (prefer Mermaid) | State machines, object lifecycles, connection/session/process states | Code with if/else chains that implement a state machine; specs with distinct states |
+| **Use Case** | PlantUML only | Functional requirements, actor-system interactions, feature overview | PRD files; new feature overview; user stories |
+| **Timing** | PlantUML only | Time-based event characteristics, latency profiling, synchronization, timeout/retry logic | Performance documentation; pipeline latency analysis |
+| **Flowchart** | Mermaid only | General-purpose flow diagrams, decision flows, process maps | Any flow that isn't a strict algorithm (use Activity for those) |
+| **Journey** | Mermaid only | User journey maps showing satisfaction across touchpoints | UX documentation; customer experience mapping |
 
 > **Before creating any sequence diagram**, read `references/sequence.md` for ACK suppression rules, arrow conventions, and visual styling defaults.
 
-## Structural Diagrams (how things are built)
+## Structural diagrams (how things are built)
 
-| Type | When to use | When to suggest | Syntax |
-|------|-------------|-----------------|--------|
-| **Component / Package** | High-level system architecture, layers, module dependencies | Architecture docs; adding new modules; specs showing system composition | `@startuml` with `package`, `component`, `[name]` |
-| **Class** | Class hierarchies, interfaces, data models (dataclasses, Pydantic), entity relationships | Adding new classes/models; refactoring class hierarchy; storage/query models | `@startuml` with `class`, `interface`, inheritance arrows |
-| **Object** | Snapshot of object instances with actual data at a specific point in time | Debugging documentation; showing concrete state examples; test data illustration | `@startuml` with `object`, field values |
-| **ER (Entity-Relationship)** | Database schemas, table relationships with cardinalities (1:N, M:N) | Database storage design; any database work | `@startuml` with `entity`, field definitions, `\|\|--o{` |
-| **Deployment** | Physical deployment topology: processes, threads, file system, cache, network | Architecture deployment docs; Web UI with server + WebSocket | `@startuml` with `node`, `artifact`, `database` |
-| **Network (nwdiag)** | Network topology, servers, subnets, ports | Infrastructure documentation; service communication topology | `@startuml` with `nwdiag { network ... }` |
+| Type | Format | When to use | When to suggest |
+|------|--------|-------------|-----------------|
+| **Component / Package** | PlantUML only | High-level system architecture, layers, module dependencies | Architecture docs; adding new modules; specs showing system composition |
+| **Class** | Both (prefer Mermaid) | Class hierarchies, interfaces, data models (dataclasses, Pydantic) | Adding new classes/models; refactoring class hierarchy |
+| **Object** | PlantUML only | Snapshot of object instances with actual data at a specific point in time | Debugging documentation; showing concrete state examples |
+| **ER (Entity-Relationship)** | Both (prefer Mermaid) | Database schemas, table relationships with cardinalities (1:N, M:N) | Database storage design; any database work |
+| **Deployment** | PlantUML only | Physical deployment topology: processes, threads, file system, cache, network | Architecture deployment docs; infrastructure topology |
+| **Network (nwdiag)** | PlantUML only | Network topology, servers, subnets, ports | Infrastructure documentation; service communication topology |
+| **Block** | Mermaid only | Block diagrams for system architecture, abstract layouts | High-level system overviews where component diagram is overkill |
+| **Requirement** | Mermaid only | Requirements traceability, element-requirement relationships | Requirements documentation; compliance tracing |
 
-## Data & Structure Visualization
+## Data and visualization
 
-| Type | When to use | When to suggest | Syntax |
-|------|-------------|-----------------|--------|
-| **JSON** | Visualize data structures, config files, API request/response formats | API contract documentation; config file structure | `@startjson` |
-| **YAML** | Same as JSON but for YAML-formatted configs | YAML config documentation | `@startyaml` |
+| Type | Format | When to use | When to suggest |
+|------|--------|-------------|-----------------|
+| **JSON** | PlantUML only | Visualize data structures, config files, API request/response formats | API contract documentation; config file structure |
+| **YAML** | PlantUML only | Same as JSON but for YAML-formatted configs | YAML config documentation |
+| **Pie** | Mermaid only | Distribution charts, percentage breakdowns | Usage statistics; resource allocation; survey results |
+| **XY Chart** | Mermaid only | Line/bar charts with numeric axes | Performance metrics; trend visualization |
+| **Sankey** | Mermaid only | Flow volume visualization between nodes | Data flow analysis; resource distribution |
+| **Quadrant** | Mermaid only | Four-quadrant prioritization charts | Priority matrices; risk assessment; effort-impact analysis |
 
-## Project Management & Planning
+## Project management and planning
 
-| Type | When to use | When to suggest | Syntax |
-|------|-------------|-----------------|--------|
-| **MindMap** | Brainstorming, idea hierarchies, feature categorization, project structure overview | Planning new phases; feature overview; backlog/roadmap organization | `@startmindmap` with `*`, `**`, `***` |
-| **Gantt** | Project timelines, phase planning, task dependencies, milestones | Roadmap documentation; sprint/phase planning | `@startgantt` with `[Task] lasts X days` |
-| **WBS** | Work decomposition, task hierarchy, scope visualization | Planning a new phase; breaking Epic into Stories/Tasks | `@startwbs` with `*`, `**` |
-| **Wireframe (Salt)** | UI mockups, interface layouts, form structures | UI design; UI-related PRDs | `@startsalt` with `{ }` layout blocks |
+| Type | Format | When to use | When to suggest |
+|------|--------|-------------|-----------------|
+| **MindMap** | Both (prefer Mermaid) | Brainstorming, idea hierarchies, feature categorization, project structure overview | Planning new phases; feature overview; backlog/roadmap organization |
+| **Gantt** | Both (prefer Mermaid) | Project timelines, phase planning, task dependencies, milestones | Roadmap documentation; sprint/phase planning |
+| **WBS** | PlantUML only | Work decomposition, task hierarchy, scope visualization | Planning a new phase; breaking Epic into Stories/Tasks |
+| **Wireframe (Salt)** | PlantUML only | UI mockups, interface layouts, form structures | UI design; UI-related PRDs |
+| **Timeline** | Mermaid only | Chronological event visualization, historical progressions | Milestone history; release timelines; incident postmortems |
+| **GitGraph** | Mermaid only | Git branch and merge visualization | Branching strategy documentation; release flow |
 
-## Quick Selection Guide
+## Terminal rendering reference
 
-- **"Who sends what to whom?"** → Sequence
-- **"What are the system parts?"** → Component / Package
-- **"What states can this be in?"** → State
-- **"What's the algorithm/flow?"** → Activity
-- **"What can users do?"** → Use Case
-- **"What do the classes look like?"** → Class
-- **"What's in the database?"** → ER Diagram
-- **"Where does it run?"** → Deployment
-- **"What's the config/data format?"** → JSON/YAML
-- **"How long does each step take?"** → Timing
-- **"What's the plan/scope?"** → MindMap, WBS, or Gantt
-- **"What will the UI look like?"** → Wireframe (Salt)
-- **"What's the network setup?"** → Network (nwdiag)
-- **"What does a concrete instance look like?"** → Object
+When showing diagrams in terminal/conversation (not writing to files):
+
+**Mermaid:** Draw a hand-drawn ASCII approximation directly from the source. Do NOT call any external API. Do NOT show the raw mermaid source before the ASCII.
+
+**PlantUML ASCII-friendly types** (sequence, activity, state, class, component, object, usecase): fetch ASCII via WebFetch from `https://www.plantuml.com/plantuml/txt/<encoded>`, display it, then show `[View SVG](https://www.plantuml.com/plantuml/svg/<encoded>)`. On failure: retry simpler, then fall back to box-drawing ASCII.
+
+**PlantUML link-only types** (timing, gantt, mindmap, WBS, wireframe, network, JSON, YAML, ER, deployment): show source in fenced `plantuml` block + SVG link.
+
+## Quick selection guide
+
+- **"Who sends what to whom?"** - Sequence (Mermaid)
+- **"What's the flow?"** - Flowchart (Mermaid) or Activity (PlantUML for complex branching)
+- **"What are the system parts?"** - Component (PlantUML) or Block (Mermaid)
+- **"What states can this be in?"** - State (Mermaid)
+- **"What can users do?"** - Use Case (PlantUML)
+- **"What do the classes look like?"** - Class (Mermaid)
+- **"What's in the database?"** - ER Diagram (Mermaid)
+- **"Where does it run?"** - Deployment (PlantUML)
+- **"What's the config/data format?"** - JSON/YAML (PlantUML)
+- **"How long does each step take?"** - Timing (PlantUML)
+- **"What's the plan/scope?"** - MindMap (Mermaid), WBS (PlantUML), or Gantt (Mermaid)
+- **"What will the UI look like?"** - Wireframe/Salt (PlantUML)
+- **"What's the network setup?"** - Network/nwdiag (PlantUML)
+- **"What does a concrete instance look like?"** - Object (PlantUML)
+- **"Show the distribution/percentage"** - Pie (Mermaid)
+- **"Show the git branching strategy"** - GitGraph (Mermaid)
+- **"Show the user journey"** - Journey (Mermaid)
+- **"Show trends or metrics"** - XY Chart (Mermaid)
+- **"Prioritize items in quadrants"** - Quadrant (Mermaid)

--- a/plugins/plantuml/skills/plantuml-diagram-guide/references/mermaid-syntax.md
+++ b/plugins/plantuml/skills/plantuml-diagram-guide/references/mermaid-syntax.md
@@ -1,0 +1,245 @@
+# Mermaid Syntax Reference
+
+Quick syntax examples for each Mermaid diagram type. For full documentation see [mermaid.js.org](https://mermaid.js.org/).
+
+## Behavioral diagrams
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    title Order Processing
+    participant C as Client
+    participant S as Server
+    participant DB as Database
+    C->>S: POST /orders
+    S->>DB: INSERT order
+    DB-->>S: order_id
+    S-->>C: 201 Created
+```
+
+Arrow types: `->>` sync request, `-->>` sync response, `-)` async fire-and-forget, `--)` async response.
+
+Fragments: `alt`/`else`, `opt`, `loop`, `par`, `critical`, `break`.
+
+### Flowchart
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Is valid?}
+    B -->|Yes| C[Process]
+    B -->|No| D[Reject]
+    C --> E[End]
+    D --> E
+```
+
+Directions: `TD` (top-down), `LR` (left-right), `BT` (bottom-top), `RL` (right-left).
+
+Node shapes: `[rectangle]`, `(rounded)`, `{diamond}`, `([stadium])`, `[[subroutine]]`, `[(cylinder)]`, `((circle))`.
+
+### State
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing : submit
+    Processing --> Done : success
+    Processing --> Error : failure
+    Error --> Idle : retry
+    Done --> [*]
+```
+
+Use `stateDiagram-v2` (not `stateDiagram`). Supports composite states, forks, joins, notes.
+
+### Journey
+
+```mermaid
+journey
+    title User Onboarding
+    section Sign Up
+      Visit landing page: 5: User
+      Fill registration form: 3: User
+      Verify email: 2: User
+    section First Use
+      Complete tutorial: 4: User
+      Create first project: 5: User
+```
+
+Numbers 1-5 represent satisfaction (1 = frustrating, 5 = great).
+
+## Structural diagrams
+
+### Class
+
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        +makeSound() void
+    }
+    class Dog {
+        +fetch() void
+    }
+    Animal <|-- Dog
+```
+
+Relationships: `<|--` inheritance, `*--` composition, `o--` aggregation, `-->` association, `..>` dependency, `..|>` realization.
+
+### ER (Entity-Relationship)
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "is in"
+    USER {
+        int id PK
+        string name
+        string email UK
+    }
+    ORDER {
+        int id PK
+        int user_id FK
+        date created_at
+    }
+```
+
+Cardinality: `||` exactly one, `o|` zero or one, `}|` one or more, `}o` zero or more.
+
+### Block
+
+```mermaid
+block-beta
+    columns 3
+    A["Frontend"] B["API Gateway"] C["Backend"]
+    D["Cache"]:2 E["Database"]
+    A --> B --> C
+    C --> D
+    C --> E
+```
+
+### Requirement
+
+```mermaid
+requirementDiagram
+    requirement auth_req {
+        id: REQ-001
+        text: System shall authenticate users via OAuth2
+        risk: medium
+        verifymethod: test
+    }
+    element auth_module {
+        type: module
+    }
+    auth_module - satisfies -> auth_req
+```
+
+## Data and visualization
+
+### Pie
+
+```mermaid
+pie title Traffic Sources
+    "Organic" : 45
+    "Direct" : 30
+    "Referral" : 15
+    "Social" : 10
+```
+
+### XY Chart
+
+```mermaid
+xychart-beta
+    title "Monthly Revenue"
+    x-axis [Jan, Feb, Mar, Apr, May]
+    y-axis "Revenue ($K)" 0 --> 100
+    bar [30, 45, 60, 55, 80]
+    line [30, 45, 60, 55, 80]
+```
+
+### Sankey
+
+```mermaid
+sankey-beta
+    Source A,Target X,25
+    Source A,Target Y,15
+    Source B,Target X,10
+    Source B,Target Y,30
+```
+
+### Quadrant
+
+```mermaid
+quadrantChart
+    title Priority Matrix
+    x-axis Low Effort --> High Effort
+    y-axis Low Impact --> High Impact
+    quadrant-1 Do First
+    quadrant-2 Schedule
+    quadrant-3 Delegate
+    quadrant-4 Eliminate
+    Feature A: [0.8, 0.9]
+    Feature B: [0.2, 0.7]
+    Feature C: [0.6, 0.3]
+```
+
+## Project management and planning
+
+### MindMap
+
+```mermaid
+mindmap
+    root((Project))
+        Backend
+            API
+            Database
+            Auth
+        Frontend
+            Components
+            State
+            Routing
+        DevOps
+            CI/CD
+            Monitoring
+```
+
+### Gantt
+
+```mermaid
+gantt
+    title Release Plan
+    dateFormat YYYY-MM-DD
+    section Phase 1
+        Design     :a1, 2026-01-01, 14d
+        Implement  :a2, after a1, 21d
+    section Phase 2
+        Testing    :b1, after a2, 14d
+        Deploy     :b2, after b1, 7d
+```
+
+### Timeline
+
+```mermaid
+timeline
+    title Product History
+    2024 : MVP Launch
+         : First 100 users
+    2025 : Series A
+         : Mobile app
+    2026 : International expansion
+```
+
+### GitGraph
+
+```mermaid
+gitGraph
+    commit
+    branch feature
+    checkout feature
+    commit
+    commit
+    checkout main
+    merge feature
+    commit
+```

--- a/plugins/plantuml/templates/pre-commit
+++ b/plugins/plantuml/templates/pre-commit
@@ -1,5 +1,5 @@
 # >>> tribe-coding/plantuml >>>
-# PlantUML URL sync check — installed by plantuml Claude Code plugin.
+# Diagram validation (PlantUML + Mermaid) — installed by plantuml Claude Code plugin.
 # Do not edit between markers; managed automatically by setup-project.sh.
 PLANTUML_STAGED_MD=$(git diff --cached --name-only --diff-filter=ACM -- '*.md')
 
@@ -16,11 +16,12 @@ if [ -n "$PLANTUML_STAGED_MD" ]; then
     done
 
     if [ -n "$PLANTUML_ENCODER" ]; then
-        echo "Checking PlantUML diagrams in: $PLANTUML_STAGED_MD"
+        echo "Checking diagrams in: $PLANTUML_STAGED_MD"
         if ! python3 "$PLANTUML_ENCODER" --check $PLANTUML_STAGED_MD; then
             echo ""
-            echo "Commit blocked: PlantUML URLs out of sync."
-            echo "  Fix: python3 $PLANTUML_ENCODER --sync <file.md>"
+            echo "Commit blocked: diagram validation failed."
+            echo "  PlantUML fix: python3 $PLANTUML_ENCODER --sync <file.md>"
+            echo "  Mermaid fix: check diagram type keywords in source blocks"
             exit 1
         fi
     fi

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -261,7 +261,7 @@ Add architecture or flow diagrams when:
 - The data flow is non-obvious
 - Onboarding without a diagram requires reading 3+ files
 
-Use PlantUML (integrate with the plantuml plugin if available).
+Use Mermaid (preferred for native rendering) or PlantUML (integrate with the plantuml plugin if available).
 
 ## Size Guidelines
 


### PR DESCRIPTION
## Summary

- Evolve plantuml plugin into a multi-format diagram tool supporting both Mermaid and PlantUML
- Mermaid is preferred when both formats support a type (renders natively in GitHub, Obsidian, Excalidraw)
- Add mermaid syntax validation (`--check` validates both, new `--check-mermaid-only` flag)
- Expand diagram guide from 17 to 26 types with Format column and recommendations
- SessionStart rules restructured for dual-format, PostToolUse validates mermaid syntax, pre-commit covers both

## Breaking changes

- `--check` flag now validates both PlantUML URLs AND Mermaid syntax (was PlantUML-only)
- SessionStart output restructured with Mermaid + PlantUML sections (was PlantUML-only)

## Files changed (15)

**Core scripts:**
- `plantuml-encode.py` - mermaid validation functions + `--check-mermaid-only`
- `inject-rules.sh` - dual-format SessionStart rules
- `sync-plantuml.sh` - mermaid validation pass in PostToolUse

**Skills & references:**
- `plantuml-diagram-guide/SKILL.md` - 26 types, Format column, mermaid recommendations
- `references/mermaid-syntax.md` (new) - syntax examples for all Mermaid types

**Templates & commands:**
- `templates/pre-commit` - updated messaging for both formats
- `plantuml-validate/SKILL.md` - covers both formats

**Docs & metadata:**
- `plugin.json` bumped to 2.0.0
- README rewritten for dual-format with mermaid demo
- CHANGELOG, ACCEPTANCE_TESTS updated
- Root CLAUDE.md, README.md, marketplace.json, playbook preset updated

## Test plan

- [x] `--check` on .md with both plantuml (missing URL) and valid mermaid - catches plantuml error, mermaid passes
- [x] `--check-mermaid-only` catches invalid diagram types and empty blocks
- [x] `--sync` leaves mermaid blocks untouched (no URLs added)
- [x] `--encode-only` and full URL encoding still work (no regression)
- [x] `inject-rules.sh` outputs dual-format rules with mermaid and plantuml sections
- [x] Pre-commit hook passes with valid diagrams (validated on commit)
- [ ] Manual: new session loads dual-format rules from SessionStart
- [ ] Manual: PostToolUse validates mermaid syntax on .md edit (non-blocking)
- [ ] Manual: Claude uses mermaid by default for supported types and draws ASCII in terminal