### PR TITLE
feat(statusline-compact): shorten model label + fix progressive hiding (v0.7.0)

### DIFF
--- a/plugins/statusline-compact/.claude-plugin/plugin.json
+++ b/plugins/statusline-compact/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline-compact",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Compact single-line Claude Code statusline with brightness-coded API usage values. Shows 5h/7d rate limits, extra usage, context window, git branch, and model - all on one line.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/statusline-compact/scripts/statusline.sh
+++ b/plugins/statusline-compact/scripts/statusline.sh
@@ -313,8 +313,8 @@ if [ -n "$session_cost_usd" ] && [ "$session_cost_usd" != "null" ]; then
   compact_cost="${dim}${DOLLAR}${rst}${cost_int}${dim}${cost_frac}${rst}"
 fi
 
-# Model segment: strip "Claude " prefix for compactness
-compact_model_name=$(echo "$model" | sed 's/^Claude //')
+# Model segment: strip "Claude " prefix and " context" suffix for compactness
+compact_model_name=$(echo "$model" | sed 's/^Claude //; s/ context)/)/g')
 compact_model_colored=$(colorize_model "$compact_model_name")
 compact_model=$(echo "$compact_model_colored" | sed -E "s/([0-9]+\.[0-9]+)/${dim}\1${rst}/g")
 


### PR DESCRIPTION
## Summary

- Strip ` context` from model display name so `Opus 4.6 (1M context)` shows as `Opus 4.6 (1M)`
- Reduce `NOTIFICATION_RESERVE` from 45 to 20 so session cost (`$0.42`) and directory segments are visible on standard 80-col terminals

The reserve of 45 chars left only 35 chars for the statusline on an 80-col terminal, causing progressive hiding to drop both cost and directory segments.

## Test plan

- [ ] Verify statusline shows `Opus 4.6 (1M)` instead of `Opus 4.6 (1M context)`
- [ ] Verify session cost (`$X.XX`) and directory name are visible on 80-col terminal
- [ ] Verify progressive hiding still drops segments gracefully on very narrow terminals (<60 cols)
- [ ] Verify models without context suffix (e.g. `Sonnet 4.5`) are unaffected