### PR TITLE
feat(statusline-compact): compact layout for pwd visibility on 80-col

### DIFF
--- a/plugins/statusline-compact/.claude-plugin/plugin.json
+++ b/plugins/statusline-compact/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline-compact",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Compact single-line Claude Code statusline with brightness-coded API usage values. Shows 5h/7d rate limits, context window, git branch, and model - all on one line.",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/statusline-compact/scripts/statusline.sh
+++ b/plugins/statusline-compact/scripts/statusline.sh
@@ -3,7 +3,7 @@
 # Reads JSON from stdin (piped by Claude Code)
 #
 # Layout:
-#   5h 12% ~2h14m   7d 45% ~3d5h   $0.42   Sonnet 4.5   context 52%   my-project/   main
+#   5h 12% ~2h14m  7d 45% ~3d5h  $0.42  Sonnet 4.5  52%  my-project/  main
 #
 # Progressive hiding: when terminal is narrow, drops segments to leave room
 # for Claude Code system notifications. Drop order: dir, cost.
@@ -29,13 +29,13 @@ visual_width() {
   printf '%s' "$1" | sed $'s/\x1b\\[[0-9;]*m//g' | wc -m | tr -d ' '
 }
 
-# Join non-empty segments with 3-space gaps
+# Join non-empty segments with 2-space gaps
 assemble_line() {
   local line=""
   for seg in "$@"; do
     if [ -n "$seg" ]; then
       if [ -n "$line" ]; then
-        line="${line}   ${seg}"
+        line="${line}  ${seg}"
       else
         line="${seg}"
       fi
@@ -241,7 +241,7 @@ if [ -n "$usage_json" ]; then
     [ "$five_int" -ge 100 ] 2>/dev/null && c5_suffix=" ${bright_red}XX${rst}"
     [ "$five_int" -gt 90 ] 2>/dev/null && [ "$five_int" -lt 100 ] 2>/dev/null && c5_suffix=" ${yellow}!!${rst}"
     c5_time=""
-    if [ -n "$five_remaining" ]; then
+    if [ -n "$five_remaining" ] && [ "$five_int" -ge 60 ] 2>/dev/null; then
       c5_time=" ${five_time_with_dim}"
     fi
     compact_5h="${dim}5h${rst} ${c5_pct}${c5_time}${c5_suffix}"
@@ -265,7 +265,7 @@ if [ -n "$usage_json" ]; then
     [ "$seven_int" -ge 100 ] 2>/dev/null && c7_suffix=" ${bright_red}XX${rst}"
     [ "$seven_int" -gt 90 ] 2>/dev/null && [ "$seven_int" -lt 100 ] 2>/dev/null && c7_suffix=" ${yellow}!!${rst}"
     c7_time=""
-    if [ -n "$seven_remaining" ]; then
+    if [ -n "$seven_remaining" ] && [ "$seven_int" -ge 60 ] 2>/dev/null; then
       c7_time=" ${seven_time_with_dim}"
     fi
     compact_7d="${dim}7d${rst} ${c7_pct}${c7_time}${c7_suffix}"
@@ -284,17 +284,17 @@ if [ -n "$session_cost_usd" ] && [ "$session_cost_usd" != "null" ]; then
   compact_cost="${dim}${DOLLAR}${rst}${cost_int}${dim}${cost_frac}${rst}"
 fi
 
-# Model segment: strip "Claude " prefix and " context" suffix for compactness
-compact_model_name=$(echo "$model" | sed 's/^Claude //; s/ context)/)/g')
+# Model segment: strip "Claude " prefix and parenthetical suffix (e.g. "(1M context)")
+compact_model_name=$(echo "$model" | sed 's/^Claude //; s/ ([^)]*)$//g')
 compact_model_colored=$(colorize_model "$compact_model_name")
 compact_model=$(echo "$compact_model_colored" | sed -E "s/([0-9]+\.[0-9]+)/${dim}\1${rst}/g")
 
-# Context segment
+# Context segment: bare percentage (distinguishable from 5h/7d by lack of prefix)
 compact_ctx=""
 if [ -n "$used_pct" ]; then
   context_int=${used_pct%.*}
   ctx_c=$(pct_color "$context_int")
-  compact_ctx="${dim}context${rst} ${ctx_c}${used_pct}%${rst}"
+  compact_ctx="${ctx_c}${used_pct}%${rst}"
   [ "$context_int" -ge 80 ] 2>/dev/null && compact_ctx="${compact_ctx} ${bright_red}!!${rst}"
 fi
 
@@ -333,9 +333,9 @@ fi
 
 # ===== PROGRESSIVE HIDING =====
 # Claude Code appends system notifications to the right of the last statusline line.
-# Reserve space so notifications aren't truncated. 20 chars fits most short alerts.
+# Reserve: 0 because notifications are rare and the statusline is already tight.
 
-NOTIFICATION_RESERVE=10
+NOTIFICATION_RESERVE=0
 
 term_width=$(tput cols 2>/dev/null)
 if ! [ "$term_width" -ge 40 ] 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Reduce segment gaps from 3 to 2 spaces
- Strip parenthetical model suffix (e.g. "(1M context)") - just show "Opus 4.6"
- Drop "context" label - show bare percentage (distinguishable from 5h/7d by lack of prefix)
- Only show time-remaining when rate limit usage >= 60% (saves 4-8 chars when low)
- Set notification reserve to 0

**User impact:** The current directory name is now visible on standard 80-column terminals when rate limits are below 60%. Previously, the directory was always hidden due to insufficient horizontal space.

Before: `5h 30% 40m   7d 52% 3h40m   Opus 4.6 (1M)   context 11%   chore/status..-label`
After:  `5h 30%  7d 52%  $0.42  Opus 4.6  11%  claude-plugins/  chore/status..-label`

## Test plan
- [ ] `echo '{"workspace":{"current_dir":"/tmp/my-project"},"model":{"display_name":"Claude Opus 4.6 (1M context)"},"context_window":{"used_percentage":11},"cost":{"total_cost_usd":0.42}}' | COLUMNS=80 bash plugins/statusline-compact/scripts/statusline.sh` - dir should be visible
- [ ] Same with COLUMNS=120 - all segments visible
- [ ] Verify time-remaining hidden when usage <60%, shown when >=60%