### PR TITLE
feat(retroscope): add cross-project daily reports (v0.3.0)

### DIFF
--- a/plugins/retroscope/.claude-plugin/plugin.json
+++ b/plugins/retroscope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "retroscope",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "Retrospective session reports: summarize tasks, decisions, open questions from Claude Code sessions",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/retroscope/commands/retro/SKILL.md
+++ b/plugins/retroscope/commands/retro/SKILL.md
@@ -51,6 +51,7 @@ Config fields used:
 - `model` — report generation model: `haiku`, `sonnet`, or `inherit` (default: `haiku`)
 - `extractMode` — pre-filter sessions to text-only (default: `true`)
 - `sessionSource` — data source for `/retro session`: `logs` (default) or `context`
+- `scope` — report scope: `project` (default, current project only) or `all` (cross-project daily reports)
 - `autoPush` — git push after commit (default: `false`)
 - `timezone` — timezone for date calculations (default: system)
 

--- a/plugins/retroscope/commands/retro/references/daily-mode.md
+++ b/plugins/retroscope/commands/retro/references/daily-mode.md
@@ -2,7 +2,9 @@
 
 ## Step 4: Find Sessions
 
-Run `find-sessions.py` to locate matching session files:
+Where `{SCRIPT_DIR}` = `${CLAUDE_PLUGIN_ROOT}/scripts`.
+
+**If config `scope` is `"project"` (default):**
 
 ```bash
 PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py {today|yesterday} \
@@ -10,11 +12,23 @@ PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py {today|yesterday} \
   --tz "{config.timezone}"
 ```
 
-Where `{SCRIPT_DIR}` = `${CLAUDE_PLUGIN_ROOT}/scripts`.
+Output: one file path per line.
+
+**If config `scope` is `"all"` (cross-project):**
+
+```bash
+PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py {today|yesterday} \
+  --all-projects \
+  --tz "{config.timezone}"
+```
+
+Output: tab-separated `project_name\tfile_path`, one per line. Parse into a map: `{project_name: [file1, file2, ...]}`.
 
 If no sessions found: inform user and stop.
 
 ## Step 5: Check Cache
+
+**If scope is `"project"` (default):**
 
 Determine report output path:
 ```
@@ -23,11 +37,17 @@ Determine report output path:
 
 Where `{project_name}` = basename of `CLAUDE_PROJECT_DIR`.
 
+**If scope is `"all"` (cross-project):**
+
+```
+{storageDir}/reports/_cross-project/daily/{YYYY}/{MM}/{DD}/summary.md
+```
+
 If `force` is set: skip cache check entirely, always regenerate.
 
 Otherwise, if the file exists:
 - Get modification time of summary.md
-- Get modification times of all session files
+- Get modification times of all session files (across all projects if scope is `"all"`)
 - If summary.md is newer than ALL session files → display cached report and stop
 
 ## Step 6: Gather Stats
@@ -43,6 +63,8 @@ From each stats JSON, collect both `estimated_cost_usd` (actual cost with cache 
 
 Aggregate across all sessions for the Overview and Productivity Metrics sections.
 
+**If scope is `"all"` (cross-project):** additionally track per-project aggregates: session count, total duration, estimated cost, and token counts per project. These feed the per-project breakdown table in the Overview section.
+
 ## Step 7: Extract Session Content
 
 **If `extractMode: true` (default):**
@@ -52,7 +74,7 @@ For each session file, run:
 PYTHONPATH="" python3 {SCRIPT_DIR}/find-sessions.py --extract "{session_file}" --date "{YYYY-MM-DD}"
 ```
 
-Concatenate all extracted text (with session separators).
+Concatenate all extracted text (with session separators). **If scope is `"all"`:** include the project name in each session separator, e.g. `--- Session 2/5 (project: claude-plugins) ---`.
 
 **If `extractMode: false`:**
 
@@ -74,28 +96,28 @@ for line in open(sys.argv[1]):
 ## Step 8: Generate Report
 
 1. Read `${SKILL_DIR}/references/report-template.md`
-2. Generate report content based on the template and extracted session data
+2. Generate report content based on the template and extracted session data. **If scope is `"all"`:** pass `is_cross_project: true` and the per-project breakdown data (from Step 6) to the report generator. The template title becomes `Cross-Project` instead of `{project_name}`, and the Overview includes a per-project breakdown table.
 3. **If config `model` is `haiku`**: use the Task tool with `subagent_type: general-purpose` and `model: haiku` to generate the report body. Pass the extracted session text and template as context.
 4. **If config `model` is `sonnet`**: use the Task tool with `subagent_type: general-purpose` and `model: sonnet` to generate the report body. Pass the extracted session text and template as context.
 5. **If config `model` is `inherit`**: generate directly (current session model)
 
 ## Step 9: Save Report
 
-1. Create directory structure:
+1. Create directory structure. Use `{project_name}` for single-project scope, `_cross-project` for `"all"` scope:
    ```bash
-   mkdir -p "{storageDir}/reports/{project_name}/daily/{YYYY}/{MM}/{DD}"
+   mkdir -p "{storageDir}/reports/{project_name|_cross-project}/daily/{YYYY}/{MM}/{DD}"
    ```
 
 2. Write report to `summary.md`:
    ```
-   {storageDir}/reports/{project_name}/daily/{YYYY}/{MM}/{DD}/summary.md
+   {storageDir}/reports/{project_name|_cross-project}/daily/{YYYY}/{MM}/{DD}/summary.md
    ```
    **If the file already exists: Read it first, then use Edit to replace the content.** The Write tool blocks overwriting an unread file. Never skip the Read step when the file may exist from a previous run.
 
 3. Git commit in storage repo:
    ```bash
-   git -C "{storageDir}" add reports/{project_name}/daily/{YYYY}/{MM}/{DD}/summary.md
-   git -C "{storageDir}" commit -m "retro({project_name}): {YYYY-MM-DD} daily summary"
+   git -C "{storageDir}" add reports/{project_name|_cross-project}/daily/{YYYY}/{MM}/{DD}/summary.md
+   git -C "{storageDir}" commit -m "retro({project_name|cross-project}): {YYYY-MM-DD} daily summary"
    ```
 
 4. If `autoPush: true`:

--- a/plugins/retroscope/commands/retro/references/report-template.md
+++ b/plugins/retroscope/commands/retro/references/report-template.md
@@ -7,6 +7,8 @@ Use this template when generating retrospective reports. Fill in all sections ba
 ```markdown
 # 📋 Retroscope: {Project} — {Date}
 
+_(For cross-project reports, use `Cross-Project` as {Project}.)_
+
 ## 📊 Overview
 
 | Metric | Value |
@@ -16,6 +18,13 @@ Use this template when generating retrospective reports. Fill in all sections ba
 | 🤖 Model | {model name} |
 | 🌿 Branch(es) | {comma-separated branches} |
 
+_(For cross-project reports, add a per-project breakdown table:)_
+
+| Project | Sessions | Duration | Est. Cost |
+|---------|----------|----------|-----------|
+| {project_name} | {count} | {duration} | ${cost} |
+| **Total** | **{total}** | **{total_duration}** | **${total_cost}** |
+
 ## 🎯 Performance Assessment
 
 {2–3 sentences on productivity, focus, and efficiency based on the session flow.}
@@ -24,18 +33,18 @@ Use this template when generating retrospective reports. Fill in all sections ba
 
 ## 📝 Tasks & Outcomes
 
-| Status | Task | Links |
-|--------|------|-------|
-| ✅ Done | {completed task} | 📌 PR #N · 🔀 `branch` |
-| 🚧 In progress | {ongoing work} | 🔀 `feature/foo` |
-| ❓ Open | {unresolved question} | 🐛 Issue #N |
-| 🔬 Research | {topic investigated} | 💬 `uuid-short` |
-| ✔️ Decision | {what was decided} | 📋 `plan-file.md` |
-| ❌ Abandoned | {abandoned task and reason} | — |
-| 💡 Idea | {idea for future} | — |
-| ⚠️ Blocked | {what is blocked and why} | 🐛 Issue #N |
+| Status | Task | Project | Links |
+|--------|------|---------|-------|
+| ✅ Done | {completed task} | {project} | 📌 PR #N · 🔀 `branch` |
+| 🚧 In progress | {ongoing work} | {project} | 🔀 `feature/foo` |
+| ❓ Open | {unresolved question} | {project} | 🐛 Issue #N |
+| 🔬 Research | {topic investigated} | {project} | 💬 `uuid-short` |
+| ✔️ Decision | {what was decided} | {project} | 📋 `plan-file.md` |
+| ❌ Abandoned | {abandoned task and reason} | {project} | — |
+| 💡 Idea | {idea for future} | {project} | — |
+| ⚠️ Blocked | {what is blocked and why} | {project} | 🐛 Issue #N |
 
-_(Include only rows that apply. Remove unused status rows.)_
+_(Include only rows that apply. Remove unused status rows. For single-project reports, the Project column may be omitted.)_
 
 **Link icons:** 📌 PR · 🔀 Branch · 💬 Session · 📋 Plan · 🐛 Issue/Discussion
 Use `·` (middle dot) to separate multiple links in one cell.

--- a/plugins/retroscope/commands/retroscope-setup/SKILL.md
+++ b/plugins/retroscope/commands/retroscope-setup/SKILL.md
@@ -37,6 +37,7 @@ Use `AskUserQuestion` to collect settings in this order:
 6. **Session data source** — `logs` (default, reads full JSONL, reliable even after `/compact` or `/clear`) or `context` (current conversation, faster but may be incomplete).
 7. **Suggest /retro on exit?** — Yes (default) or No.
 8. **Auto-push reports?** — No (default, commit locally only) or Yes.
+9. **Report scope** — `project` (default, reports cover current project only) or `all` (cross-project daily reports aggregating sessions from all projects).
 
 For full field descriptions and defaults, see `${SKILL_DIR}/references/config-schema.md`.
 
@@ -53,6 +54,7 @@ For full field descriptions and defaults, see `${SKILL_DIR}/references/config-sc
   "model": "{haiku|sonnet|inherit}",
   "extractMode": true,
   "sessionSource": "logs",
+  "scope": "{project|all}",
   "suggestRetroOnExit": true,
   "autoPush": false
 }

--- a/plugins/retroscope/commands/retroscope-setup/references/config-schema.md
+++ b/plugins/retroscope/commands/retroscope-setup/references/config-schema.md
@@ -10,4 +10,5 @@
 | `extractMode` | boolean | `true` | Pre-filter sessions to text-only content |
 | `sessionSource` | string | `"logs"` | `/retro session` data source: `logs` (full JSONL, reliable) or `context` (current conversation, fast but may be incomplete) |
 | `suggestRetroOnExit` | boolean | `true` | Show /retro reminder in SessionEnd hook |
+| `scope` | string | `"project"` | Report scope: `project` (current project only) or `all` (cross-project daily reports) |
 | `autoPush` | boolean | `false` | Git push after each report commit |

--- a/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/retroscope/docs/ACCEPTANCE_TESTS.md
@@ -239,10 +239,11 @@ python3 -c "
 import json
 with open('$PLUGIN/templates/retroscope.json') as f:
     cfg = json.load(f)
-required = ['storageDir', 'language', 'model', 'extractMode', 'suggestRetroOnExit', 'autoPush']
+required = ['storageDir', 'language', 'model', 'extractMode', 'scope', 'suggestRetroOnExit', 'autoPush']
 for key in required:
     assert key in cfg, f'Missing key: {key}'
 assert cfg['model'] in ('haiku', 'sonnet', 'inherit'), f'Invalid model: {cfg[\"model\"]}'
+assert cfg['scope'] in ('project', 'all'), f'Invalid scope: {cfg[\"scope\"]}'
 assert isinstance(cfg['extractMode'], bool), 'extractMode must be bool'
 assert isinstance(cfg['suggestRetroOnExit'], bool), 'suggestRetroOnExit must be bool'
 assert isinstance(cfg['autoPush'], bool), 'autoPush must be bool'
@@ -387,6 +388,49 @@ grep -A3 "Productivity Metrics" "$STORAGE_DIR/reports/$PROJECT/daily/$DATE/summa
 - ✅ Shows actual cost with `(with cache discounts)` label
 - ✅ Shows naive cost with `(without cache discounts` or `as shown in Claude Code UI)` label
 - ✅ Naive cost ≥ actual cost
+
+---
+
+### 5b. Cross-Project Daily Report
+
+**Objective:** Verify `--all-projects` flag and cross-project report generation.
+
+**Automation:** 🟡 (script output automated, report quality requires human review)
+
+#### 5b.1 find-sessions.py --all-projects
+
+```bash
+SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/find-sessions.py"
+PYTHONPATH="" python3 "$SCRIPT" today --all-projects 2>&1
+```
+
+**Expected result:**
+- ✅ Tab-separated output: `project_name\tfile_path`
+- ✅ Multiple project names present (if user has sessions in multiple projects)
+- ✅ Each file path exists and is a valid `.jsonl` file
+- ✅ No output when `--all-projects` used with `--project-dir` (mutual exclusion error)
+
+#### 5b.2 Cross-Project Report Generation
+
+Set `"scope": "all"` in retroscope config, then run `/retro today`.
+
+**Expected result:**
+- ✅ Report saved to `{storageDir}/reports/_cross-project/daily/{YYYY}/{MM}/{DD}/summary.md`
+- ✅ Overview contains per-project breakdown table (Project, Sessions, Duration, Est. Cost)
+- ✅ Tasks & Outcomes table has Project column
+- ✅ Title is `📋 Retroscope: Cross-Project — {Date}`
+- ✅ Git commit message: `retro(cross-project): {YYYY-MM-DD} daily summary`
+- ✅ Stats are aggregated correctly across all projects
+
+#### 5b.3 Backwards Compatibility
+
+With default config (`"scope": "project"` or field absent), run `/retro today`.
+
+**Expected result:**
+- ✅ Behaves identically to pre-0.3.0: report at `{project_name}/daily/...`
+- ✅ No Project column in Tasks & Outcomes
+- ✅ No per-project breakdown table in Overview
+- ✅ Commit message uses single project name
 
 ---
 

--- a/plugins/retroscope/scripts/find-sessions.py
+++ b/plugins/retroscope/scripts/find-sessions.py
@@ -55,6 +55,42 @@ def get_claude_projects_dir() -> Path:
     return Path.home() / ".claude" / "projects"
 
 
+def decode_project_name(session_dir: Path) -> str:
+    """
+    Extract project name from a session directory.
+    Reads cwd from the first JSONL file for accuracy (encoded path is lossy
+    when directory names contain hyphens). Falls back to encoded dir name.
+    """
+    # Try to read cwd from the first JSONL file
+    jsonl_files = sorted(session_dir.glob("*.jsonl"))
+    for jsonl_file in jsonl_files[:1]:
+        try:
+            with open(jsonl_file, errors="ignore") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                        cwd = obj.get("cwd")
+                        if cwd:
+                            return Path(cwd).name
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            pass
+
+    # Fallback: use the last segment of the encoded dir name
+    # This is lossy for names with hyphens but better than nothing
+    name = session_dir.name
+    if name.startswith("-"):
+        name = name[1:]
+    # Take everything after the last known path separator pattern
+    # Common pattern: -Users-username-devel-projectname
+    parts = name.rsplit("-", 1)
+    return parts[-1] if parts else name
+
+
 def parse_date_arg(date_str: str, tz) -> tuple[date, date]:
     """
     Parse date argument. Returns (start_date, end_date) tuple (inclusive).
@@ -149,6 +185,51 @@ def find_sessions(date_str: str, project_dir: str | None, tz_name: str | None):
 
         if effective_start <= end_dt and effective_end >= start_dt:
             print(str(jsonl_file))
+
+
+def find_sessions_all_projects(date_str: str, tz_name: str | None):
+    """
+    Find session files matching the given date range across ALL projects.
+    Prints tab-separated project_name\\tfile_path lines.
+    """
+    tz = get_timezone(tz_name)
+    start_date, end_date = parse_date_arg(date_str, tz)
+    projects_base = get_claude_projects_dir()
+
+    if not projects_base.exists():
+        sys.stderr.write(f"No projects directory: {projects_base}\n")
+        return
+
+    # Date window
+    start_dt = datetime(start_date.year, start_date.month, start_date.day, 0, 0, 0, tzinfo=tz)
+    end_dt = datetime(end_date.year, end_date.month, end_date.day, 23, 59, 59, 999999, tzinfo=tz)
+
+    for subdir in sorted(projects_base.iterdir()):
+        if not subdir.is_dir():
+            continue
+
+        project_name = decode_project_name(subdir)
+
+        jsonl_files = sorted(subdir.glob("*.jsonl"))
+        if not jsonl_files:
+            continue
+
+        for jsonl_file in jsonl_files:
+            # Quick filter: check file mtime
+            mtime = jsonl_file.stat().st_mtime
+            mtime_dt = datetime.fromtimestamp(mtime, tz=timezone.utc).astimezone(tz)
+            if mtime_dt < start_dt:
+                continue
+
+            session_start, session_end = get_session_time_range(jsonl_file, tz)
+            if session_start is None and session_end is None:
+                continue
+
+            effective_start = session_start or mtime_dt
+            effective_end = session_end or mtime_dt
+
+            if effective_start <= end_dt and effective_end >= start_dt:
+                print(f"{project_name}\t{jsonl_file}")
 
 
 def get_session_time_range(jsonl_file: Path, tz) -> tuple:
@@ -658,17 +739,25 @@ def main():
 
     # Common options
     parser.add_argument("--project-dir", help="Project directory (default: cwd)")
+    parser.add_argument("--all-projects", action="store_true",
+                        help="Search all projects (mutually exclusive with --project-dir)")
     parser.add_argument("--tz", help="Timezone name (default: system timezone)")
     parser.add_argument("--date", dest="date_filter", help="Date filter for --extract mode (YYYY-MM-DD)")
 
     args = parser.parse_args()
+
+    if args.all_projects and args.project_dir:
+        parser.error("--all-projects and --project-dir are mutually exclusive")
 
     if args.extract:
         extract_session(args.extract, args.date_filter)
     elif args.stats:
         get_stats(args.stats)
     elif args.date:
-        find_sessions(args.date, args.project_dir, args.tz)
+        if args.all_projects:
+            find_sessions_all_projects(args.date, args.tz)
+        else:
+            find_sessions(args.date, args.project_dir, args.tz)
     else:
         parser.print_help()
         sys.exit(1)

--- a/plugins/retroscope/scripts/find-sessions.py
+++ b/plugins/retroscope/scripts/find-sessions.py
@@ -78,7 +78,7 @@ def decode_project_name(session_dir: Path) -> str:
                     except json.JSONDecodeError:
                         continue
         except OSError:
-            pass
+            pass  # Fall back to encoded dir name below
 
     # Fallback: use the last segment of the encoded dir name
     # This is lossy for names with hyphens but better than nothing

--- a/plugins/retroscope/templates/retroscope.json
+++ b/plugins/retroscope/templates/retroscope.json
@@ -6,6 +6,7 @@
   "model": "haiku",
   "extractMode": true,
   "sessionSource": "logs",
+  "scope": "project",
   "suggestRetroOnExit": true,
   "autoPush": false
 }


### PR DESCRIPTION
## Summary

- Add `--all-projects` flag to `find-sessions.py` to discover sessions across all projects in `~/.claude/projects/`
- Add `scope` config option (`"project"` default / `"all"`) to `retroscope.json`
- Update daily-mode flow, report template, setup wizard, and acceptance tests for cross-project support
- Version bump: 0.2.9 → 0.3.0

Closes #258

## Test plan

- [x] `find-sessions.py today --all-projects` outputs tab-separated `project\tpath` lines
- [x] `--all-projects` + `--project-dir` produces mutual exclusion error
- [x] Single-project mode (`--project-dir`) unchanged (backwards compat)
- [x] Template config validation passes with new `scope` field
- [ ] `/retro today` with `scope: "all"` generates cross-project report at `_cross-project/` path
- [ ] `/retro today` with default config behaves identically to v0.2.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)