### PR TITLE
docs(CLAUDE.md): add --admin flag to merge command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## PR Merge
 
-`allow_auto_merge` is **disabled** in this repo — `gh pr merge --auto` will fail. Always use:
+`allow_auto_merge` is **disabled** in this repo — `gh pr merge --auto` will fail. Branch protection requires `--admin` for immediate merge. Always use:
 ```bash
-gh pr merge <N> --squash
+gh pr merge <N> --squash --admin
 ```
 
 ## ⚠️ CRITICAL: Version Bump Requirement


### PR DESCRIPTION
## Summary
- Add `--admin` flag to the documented `gh pr merge` command in CLAUDE.md
- Branch protection rules require `--admin` for immediate merge when bypassing the review queue

Closes #266

## Test plan
- [ ] Verify CLAUDE.md shows `gh pr merge <N> --squash --admin`
- [ ] Verify next PR merge uses the updated command without failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)