### PR TITLE
docs: fix KB grooming findings across 5 files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,16 +10,9 @@
 
 ## Plugin(s) Affected
 
-<!-- Check all that apply -->
-- [ ] plantuml
-- [ ] statusline
-- [ ] statusline-compact
-- [ ] git-branch-naming
-- [ ] playbook
-- [ ] semver
-- [ ] retroscope
-- [ ] context
-- [ ] None (only root-level files changed)
+<!-- List affected plugins, or "None" if only root-level files changed -->
+<!-- Example: plantuml, semver -->
+
 
 ## Version Bump Required
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,16 +37,16 @@ A marketplace of reusable Claude Code plugins (`Tribe Coding`). Each plugin live
 ## Plugins
 
 - **ai-fortune** — Career direction analysis: interview + AI usage pattern mining
-- **plantuml** — Keeps PlantUML diagram URLs in sync; provides ASCII rendering in terminal
-- **statusline** — Three-line statusline: rate limits, context/branch, extra usage
-- **statusline-compact** — Single-line statusline with brightness-coded API usage
+- **context** — Inspects full session context in load order
 - **git-branch-naming** — Enforces branch naming conventions (prefix/kebab-case)
 - **kb-grooming** — Documentation health analysis: structural checks, semantic compliance, GitHub issues
+- **plantuml** — Keeps PlantUML diagram URLs in sync; provides ASCII rendering in terminal
 - **playbook** — Injects curated coding guideline presets into sessions
-- **semver** — Enforces semantic versioning on commit/push/PR
 - **retroscope** — Generates retrospective reports summarizing sessions
+- **semver** — Enforces semantic versioning on commit/push/PR
+- **statusline** — Three-line statusline: rate limits, context/branch, extra usage
+- **statusline-compact** — Single-line statusline with brightness-coded API usage
 - **technology-explainer** — Adapts explanation depth based on user proficiency per technology
-- **context** — Inspects full session context in load order
 
 See [`docs/plugin-behavior.md`](docs/plugin-behavior.md) for how plugins use hooks, skills, and PostToolUse to work proactively.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that automate the routines good developers follow anyway — consistent diagrams, clean branches, version discipline, session awareness.
 
 > [!NOTE]
-> [📦 Installation](#installation)
+> [📦 Installation](#installation) · [🤝 Contributing](#contributing)
 
 ## 🧩 Plugins <a name="plugins"></a>
 

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -10,7 +10,7 @@ tags: [docs, readme]
 MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "what is this?" and "why would I use it?".
 
 - When creating/editing README.md → first 5 lines: project name, one-line description, problem it solves, target audience
-- After header block (motto + intro paragraph) → add a nav line as `> [!NOTE]` GitHub Alert. **NEVER include the first H2 section** — it is always visible above the fold. This is a hard rule: do not add it "for completeness", do not add it when there are few sections, do not add it for any reason. Also **exclude GitHub community files** (GitHub surfaces these automatically — see Navigation Line reference section). Include all other H2 sections. Use ` · ` as separator. No "Scroll to:" prefix. Add explicit `<a name="...">` anchor to each emoji heading: `## ⚙️ How it works <a name="how-it-works"></a>`. Then nav links use the explicit anchor: `[⚙️ How it works](#how-it-works)`
+- After header block (motto + intro paragraph) → add a nav line as `> [!NOTE]` GitHub Alert. **NEVER include the first H2 section** — it is always visible above the fold. This is a hard rule: do not add it "for completeness", do not add it when there are few sections, do not add it for any reason. Do NOT include GitHub community files in nav (see Navigation Line reference section) but DO reference them in a section at the bottom. Include all other H2 sections. Use ` · ` as separator. No "Scroll to:" prefix. Add explicit `<a name="...">` anchor to each emoji heading: `## ⚙️ How it works <a name="how-it-works"></a>`. Then nav links use the explicit anchor: `[⚙️ How it works](#how-it-works)`
 - Use emoji in headings (🚀 📦 ⚡ ⚙️) unless user explicitly forbids it
 - For tools/CLIs/plugins → lead with a concrete demo (real input → real output), NOT a feature list
 - Installation: official method only — no workarounds; merge Quick Start + Installation into one section
@@ -30,7 +30,7 @@ MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "w
 <!-- REFERENCE -->
 ## Navigation Line
 
-Add a nav line after the header block (tagline + intro paragraph) using a `[!NOTE]` GitHub Alert. **NEVER include the first H2 section** — no exceptions, regardless of how few sections the README has. Also exclude GitHub community files (see table below). Include all other H2 sections. Use ` · ` as separator:
+Add a nav line after the header block (tagline + intro paragraph) using a `[!NOTE]` GitHub Alert. **NEVER include the first H2 section** — no exceptions, regardless of how few sections the README has. Include all other H2 sections. Use ` · ` as separator:
 
 ```markdown
 > [!NOTE]
@@ -39,16 +39,7 @@ Add a nav line after the header block (tagline + intro paragraph) using a `[!NOT
 
 This gives regulars instant access to any section without scrolling. Keep it on one line — no bullets, no numbering, no "Scroll to:" prefix.
 
-**Do NOT include links to GitHub community files** — GitHub surfaces these automatically in the repository sidebar, tab, or right panel, making README links redundant:
-
-| File | Where GitHub shows it |
-|------|-----------------------|
-| `CONTRIBUTING.md` | Sidebar link + Contributing tab |
-| `LICENSE` / `LICENSE.md` | Right panel (license type) |
-| `CODE_OF_CONDUCT.md` | Community Standards panel |
-| `SECURITY.md` | Security tab |
-| `SUPPORT.md` | Community Standards panel |
-| `GOVERNANCE.md` | Community Standards panel |
+**GitHub community files** (`CONTRIBUTING.md`, `LICENSE`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, `GOVERNANCE.md`) — do NOT include in the nav line (GitHub surfaces them in sidebar/tabs), but DO reference them in a `## References` or `## Contributing` section at the bottom of the README to maintain markdown link connectivity.
 
 **GitHub anchor rules for emoji headings:** GitHub's anchor generation for emoji headings is unreliable — the resulting anchor depends on the specific emoji and may include leading dashes or other artifacts. The only reliable approach is explicit `<a name>` anchors:
 

--- a/plugins/retroscope/README.md
+++ b/plugins/retroscope/README.md
@@ -6,7 +6,7 @@
 A Claude Code plugin that generates retrospective summary reports from your Claude Code sessions. Review what you accomplished, track open questions, and get insights into your productivity and communication patterns.
 
 > [!NOTE]
-> [📦 Installation](#installation) · [🔧 Setup](#setup) · [📄 Report Format](#report-format) · [📂 Storage](#storage-structure) · [⚙️ Configuration](#configuration) · [⚙️ How it works](#how-it-works) · [💲 Cost](#cost-estimates) · [🗺️ Roadmap](#future-roadmap) · [🔧 Troubleshooting](#troubleshooting) · [📚 Reference](#reference)
+> [📦 Installation](#installation) · [🔧 Setup](#setup) · [📄 Report Format](#report-format) · [📂 Storage](#storage-structure) · [⚙️ Configuration](#configuration) · [🔄 How it works](#how-it-works) · [💲 Cost](#cost-estimates) · [🗺️ Roadmap](#future-roadmap) · [🔧 Troubleshooting](#troubleshooting) · [📚 Reference](#reference)
 
 ## ✅ What it does <a name="what-it-does"></a>
 
@@ -112,7 +112,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin
 | `suggestRetroOnExit` | `true` | Show `/retro` reminder on session exit |
 | `autoPush` | `false` | Auto-push after each report commit |
 
-## ⚙️ How it works <a name="how-it-works"></a>
+## 🔄 How it works <a name="how-it-works"></a>
 
 1. **Session discovery** — `find-sessions.py` locates JSONL session files in `~/.claude/projects/` for the target date
 2. **Content extraction** — Filters user prompts and assistant responses (skips tool inputs/outputs when extract mode is on)
@@ -130,7 +130,7 @@ Config is stored at `~/.claude/retroscope.json` (user-level) and `.claude-plugin
 | Sonnet + extract mode ON | 2 avg sessions | ~$0.05–0.15 |
 | Sonnet + extract mode OFF | 2 avg sessions | ~$0.20–0.60 |
 
-## 🗺️ Future Roadmap (v0.2.0+) <a name="future-roadmap"></a>
+## 🗺️ Future Roadmap <a name="future-roadmap"></a>
 
 - `/retro this-week` — aggregate daily reports Mon–today
 - `/retro last-week` — Mon–Sun of previous week


### PR DESCRIPTION
## Summary

- **README.md**: add missing Contributing link to nav line (#293)
- **CLAUDE.md**: sort plugin list alphabetically (#296)
- **PR template**: replace hardcoded plugin checklist with free-text field so it never goes stale (#294)
- **retroscope README**: remove stale `(v0.2.0+)` from roadmap heading, fix duplicate ⚙️ emoji (#295)
- **playbook readme preset**: clarify community files rule — exclude from nav but reference in a bottom section for link connectivity (#293)
- **playbook version**: 0.10.4 → 0.10.5

Closes #293, #294, #295, #296
Parent epic: #297

## Plugin(s) Affected

playbook, retroscope

## Test plan

- [ ] Verify root README nav renders correctly on GitHub
- [ ] Verify PR template shows free-text field instead of checkboxes
- [ ] Verify retroscope README nav has distinct emojis
- [ ] Verify CLAUDE.md plugin list is alphabetical

🤖 Generated with [Claude Code](https://claude.com/claude-code)