### PR TITLE
docs(technology-explainer): restructure Demo section (v0.2.1)

### DIFF
--- a/plugins/technology-explainer/.claude-plugin/plugin.json
+++ b/plugins/technology-explainer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "technology-explainer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Adapts explanation depth based on user proficiency per technology: expert, intermediate, or learning",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/technology-explainer/README.md
+++ b/plugins/technology-explainer/README.md
@@ -10,6 +10,8 @@ Configure your proficiency level per technology and Claude automatically adjusts
 
 ## 🎬 Demo <a name="demo"></a>
 
+Categorize technologies by experience level:
+
 ```markdown
 > /technology-explainer-update git expert
 
@@ -20,7 +22,7 @@ Updated **git** → **expert**.
 Updated **terraform** → **learning**.
 ```
 
-After restarting:
+Expert-level explanation:
 
 ```markdown
 > How does git stash work?
@@ -28,7 +30,11 @@ After restarting:
 ✦ Using skill: proficiency-guide-expert
 
 `git stash` / `git stash pop`. List: `git stash list`. Keep stash after apply: `git stash apply`.
+```
 
+Learning-level explanation:
+
+```markdown
 > How do Terraform modules work?
 
 ✦ Using skill: proficiency-guide-learning
@@ -51,7 +57,11 @@ Terraform Registry address. Variables go in `variables.tf`, outputs in `outputs.
 Terraform needs to download the module source before it can plan.
 
 See: HashiCorp docs on modules → https://developer.hashicorp.com/terraform/docs
+```
 
+Uncategorized technology:
+
+```markdown
 > How do Claude Code hooks work?
 
 ? Which proficiency level should I use for **Claude Code**?


### PR DESCRIPTION
## Summary
- Split monolithic Demo code block into three labeled examples: expert-level, learning-level, and uncategorized technology
- Added "Categorize technologies by experience level:" intro before the setup commands block
- Removed misleading "After restarting" — changes from `/technology-explainer-update` apply immediately
- Bump version 0.2.0 → 0.2.1

## Test plan
- [ ] Verify README renders correctly on GitHub (labels, code blocks, spacing)
- [ ] Confirm no broken nav links

🤖 Generated with [Claude Code](https://claude.com/claude-code)