### PR TITLE
feat(fresh-guides): add fast-changing technology verification plugin (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,6 +57,11 @@
       "name": "technology-explainer",
       "source": "./plugins/technology-explainer",
       "description": "Adapts explanation depth based on user proficiency per technology: expert, intermediate, or learning"
+    },
+    {
+      "name": "fresh-guides",
+      "source": "./plugins/fresh-guides",
+      "description": "Watchlist for fast-changing technologies: verifies advice against official docs before responding"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ A marketplace of reusable Claude Code plugins (`Tribe Coding`). Each plugin live
 
 - **ai-fortune** — Career direction analysis: interview + AI usage pattern mining
 - **context** — Inspects full session context in load order
+- **fresh-guides** — Watchlist for fast-changing technologies: verifies advice against official docs
 - **git-branch-naming** — Enforces branch naming conventions (prefix/kebab-case)
 - **kb-grooming** — Documentation health analysis: structural checks, semantic compliance, GitHub issues
 - **plantuml** — Keeps PlantUML diagram URLs in sync; provides ASCII rendering in terminal

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/
 |--------|-------------|
 | [**ai-fortune**](plugins/ai-fortune/README.md) | Analyze your AI usage patterns, run a career interview, and get a personalized career direction report |
 | [**context**](plugins/context/README.md) | Show everything loaded into your session — CLAUDE.md files, memory, hooks — with a per-source token breakdown |
+| [**fresh-guides**](plugins/fresh-guides/README.md) | Watchlist for fast-changing technologies — verify advice against official docs before responding |
 | [**git-branch-naming**](plugins/git-branch-naming/README.md) | Enforce branch naming conventions automatically; warns before push if the name or staged content doesn't match |
 | [**kb-grooming**](plugins/kb-grooming/README.md) | Audit documentation health — broken links, orphan files, README compliance — then create a GitHub epic with linked issues |
 | [**plantuml**](plugins/plantuml/README.md) | Proactively add rendered diagrams to docs (image URLs auto-synced); draw ASCII diagrams inline during terminal conversations |

--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Inspect full Claude Code session context: CLAUDE.md files, auto-memory, SessionStart hook output, and skill listings",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -8,7 +8,7 @@
 `/ctx-dump` takes the complementary approach: it dumps the **verbatim context from Claude's memory** — exactly what Claude received at session start, including gitStatus and currentDate that `/ctx-show` cannot access.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [🔀 ctx-show vs ctx-dump](#ctx-show-vs-ctx-dump) · [📋 Sources](#sources) · [📊 Summary Table Columns](#summary-table-columns) · [⚡ Commands](#commands) · [📦 Installation](#installation)
+> [📦 Installation](#installation) · [⚙️ How it works](#how-it-works) · [🔀 ctx-show vs ctx-dump](#ctx-show-vs-ctx-dump) · [📋 Sources](#sources) · [📊 Summary Table Columns](#summary-table-columns) · [⚡ Commands](#commands)
 
 ## 🎬 Demo <a name="demo"></a>
 
@@ -47,6 +47,18 @@ Summary:
 - Active Playbook presets: 5 presets from playbook@tribe-coding (v0.5.5)
 - Total context load: ~11,800 tokens
 ```
+
+## 📦 Installation <a name="installation"></a>
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install context@tribe-coding
+/plugin
+```
+
+Select **context** → enable **auto-update**.
+
+**Requirements:** `bash`, `jq` (static sources are shown even without `jq`)
 
 ## 🔀 ctx-show vs ctx-dump <a name="ctx-show-vs-ctx-dump"></a>
 
@@ -110,15 +122,3 @@ Playbook presets appear as individual rows when using playbook plugin v0.3.1+.
 | `/ctx-show` | `--stdout` | Print full context content to terminal |
 | `/ctx-dump` | `--file` (default) | Write in-memory context to `/tmp/claude-context-dump-{timestamp}.md` |
 | `/ctx-dump` | `--stdout` | Print in-memory context to terminal |
-
-## 📦 Installation <a name="installation"></a>
-
-```bash
-/plugin marketplace add Tribe-Coding/claude-plugins
-/plugin install context@tribe-coding
-/plugin
-```
-
-Select **context** → enable **auto-update**.
-
-**Requirements:** `bash`, `jq` (static sources are shown even without `jq`)

--- a/plugins/fresh-guides/.claude-plugin/plugin.json
+++ b/plugins/fresh-guides/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "fresh-guides",
+  "version": "0.1.0",
+  "description": "Watchlist for fast-changing technologies: verifies advice against official docs before responding",
+  "author": { "name": "Tribe Coding" },
+  "license": "MIT",
+  "commands": ["./commands/"],
+  "skills": ["./skills/"]
+}

--- a/plugins/fresh-guides/README.md
+++ b/plugins/fresh-guides/README.md
@@ -10,19 +10,36 @@ Configure a watchlist of fast-changing technologies and Claude automatically ver
 
 ## 🎬 Demo <a name="demo"></a>
 
-Add technologies to your watchlist:
+Configure your watchlist:
 
 ```markdown
-> /fresh-guides-update add terraform https://developer.hashicorp.com/terraform/docs
+> /fresh-guides-setup
 
-Added **terraform** to watchlist with doc URL:
-https://developer.hashicorp.com/terraform/docs.
-Restart session for changes to take effect.
+Welcome! **Fresh Guides** keeps a watchlist of technologies that change
+frequently — where model training data may be outdated.
 
-> /fresh-guides-update url terraform https://github.com/hashicorp/terraform/releases
+? Which technologies should be on your watchlist?
+  terraform, aws terraform provider
 
-Added doc URL for **terraform**:
-https://github.com/hashicorp/terraform/releases.
+? Official doc URLs for **terraform**?
+  [*] https://developer.hashicorp.com/terraform/docs
+  [*] https://github.com/hashicorp/terraform/releases
+  [ ] Other (enter URL)
+
+? Official doc URLs for **aws terraform provider**?
+  [*] https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+  [*] https://github.com/hashicorp/terraform-provider-aws/releases
+  [ ] Other (enter URL)
+
+? Check mode?
+  ❯ alert-and-verify (Recommended)
+    alert-only
+
+? Config scope?
+    Global (~/.claude/fresh-guides.json)
+  ❯ **Project** (.claude-plugin/fresh-guides.json)
+
+Restart your session or run /clear for changes to take effect.
 ```
 
 Claude verifies before answering:
@@ -53,7 +70,7 @@ View your watchlist:
 | Technology | Official Docs | Version |
 |------------|--------------|---------|
 | terraform | developer.hashicorp.com/..., github.com/.../releases | latest |
-| aws-lambda | docs.aws.amazon.com/lambda/ | latest |
+| aws terraform provider | registry.terraform.io/..., github.com/.../releases | latest |
 
 **Check mode:** alert-and-verify
 ```
@@ -123,9 +140,10 @@ Project config: `.claude-plugin/fresh-guides.json` (overrides global)
       "version": "latest"
     },
     {
-      "name": "aws-lambda",
+      "name": "aws terraform provider",
       "docs": [
-        "https://docs.aws.amazon.com/lambda/"
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs",
+        "https://github.com/hashicorp/terraform-provider-aws/releases"
       ],
       "version": "latest"
     }

--- a/plugins/fresh-guides/README.md
+++ b/plugins/fresh-guides/README.md
@@ -1,0 +1,142 @@
+# Fresh Guides
+
+> [!TIP]
+> ✨ ***Don't trust the weights — check the docs.***
+
+Configure a watchlist of fast-changing technologies and Claude automatically verifies advice against official documentation before responding.
+
+> [!NOTE]
+> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🎮 Commands](#commands) · [📝 Config](#config)
+
+## 🎬 Demo <a name="demo"></a>
+
+Add technologies to your watchlist:
+
+```markdown
+> /fresh-guides-update add terraform https://developer.hashicorp.com/terraform/docs
+
+Added **terraform** to watchlist with doc URL:
+https://developer.hashicorp.com/terraform/docs.
+Restart session for changes to take effect.
+
+> /fresh-guides-update url terraform https://github.com/hashicorp/terraform/releases
+
+Added doc URL for **terraform**:
+https://github.com/hashicorp/terraform/releases.
+```
+
+Claude verifies before answering:
+
+```markdown
+> What's the syntax for terraform import block?
+
+fresh-guides: **terraform** is on your fast-changing tech watchlist.
+
+✦ Using skill: fresh-guides-verify
+
+The `import` block was introduced in Terraform v1.5. Syntax:
+
+    import {
+      to = aws_instance.example
+      id = "i-abcd1234"
+    }
+
+As of v1.7+, you can also use `for_each` inside import blocks for
+bulk imports. [Source: developer.hashicorp.com/terraform/docs, 2026-04-10]
+```
+
+View your watchlist:
+
+```markdown
+> /fresh-guides-show
+
+| Technology | Official Docs | Version |
+|------------|--------------|---------|
+| terraform | developer.hashicorp.com/..., github.com/.../releases | latest |
+| aws-lambda | docs.aws.amazon.com/lambda/ | latest |
+
+**Check mode:** alert-and-verify
+```
+
+## ⚙️ How it works <a name="how-it-works"></a>
+
+Two check modes control Claude's behavior:
+
+| Mode | Behavior |
+|------|----------|
+| **alert-and-verify** | Alert + fetch official docs + cite sources |
+| **alert-only** | Alert the user, skip automatic verification |
+
+| Trigger | What happens |
+|---------|-------------|
+| SessionStart | Injects compact watchlist + rules into context |
+| Watched tech detected | `fresh-guides-verify` skill invoked — fetches docs, compares, cites |
+| Docs confirm knowledge | Response includes "Verified against official docs" with citation |
+| Docs contradict knowledge | Explicit callout: "My training data may be outdated here" |
+| Verification fails | States "could not verify" with links for manual check |
+
+**Scope:** Verification triggers only for version-specific advice (API signatures, config syntax, defaults, deprecations). General concepts and design patterns are answered normally.
+
+**Complements [technology-explainer](../technology-explainer/README.md):** Technology-explainer controls explanation *depth* (brief vs detailed). Fresh-guides controls *accuracy verification* (check docs vs trust weights). A technology can be in both configs.
+
+## 📦 Installation <a name="installation"></a>
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install fresh-guides@tribe-coding
+/plugin
+```
+
+Select **fresh-guides** → enable **auto-update**. Then run the setup wizard:
+
+```
+/fresh-guides-setup
+```
+
+Restart your session for changes to take effect.
+
+## 🎮 Commands <a name="commands"></a>
+
+| Command | Description |
+|---------|-------------|
+| `/fresh-guides-setup` | Interactive wizard — configure watchlist, doc URLs, check mode |
+| `/fresh-guides-show` | Display current watchlist configuration |
+| `/fresh-guides-update add <name> <url>` | Add a technology with a doc URL |
+| `/fresh-guides-update remove <name>` | Remove a technology from watchlist |
+| `/fresh-guides-update url <name> <url>` | Add another URL to an existing technology |
+| `/fresh-guides-update mode <mode>` | Change check mode (alert-and-verify / alert-only) |
+
+## 📝 Config <a name="config"></a>
+
+Global config: `~/.claude/fresh-guides.json`
+Project config: `.claude-plugin/fresh-guides.json` (overrides global)
+
+```json
+{
+  "watchlist": [
+    {
+      "name": "terraform",
+      "docs": [
+        "https://developer.hashicorp.com/terraform/docs",
+        "https://github.com/hashicorp/terraform/releases"
+      ],
+      "version": "latest"
+    },
+    {
+      "name": "aws-lambda",
+      "docs": [
+        "https://docs.aws.amazon.com/lambda/"
+      ],
+      "version": "latest"
+    }
+  ],
+  "checkMode": "alert-and-verify"
+}
+```
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `watchlist[].name` | Technology identifier (matched case-insensitively) | — |
+| `watchlist[].docs` | Official doc / changelog / release note URLs | — |
+| `watchlist[].version` | Version constraint (`"latest"` for now) | `"latest"` |
+| `checkMode` | `"alert-and-verify"` or `"alert-only"` | `"alert-and-verify"` |

--- a/plugins/fresh-guides/README.md
+++ b/plugins/fresh-guides/README.md
@@ -37,7 +37,7 @@ frequently — where model training data may be outdated.
 
 ? Config scope?
     Global (~/.claude/fresh-guides.json)
-  ❯ **Project** (.claude-plugin/fresh-guides.json)
+  ❯ Project (.claude-plugin/fresh-guides.json)
 
 Restart your session or run /clear for changes to take effect.
 ```
@@ -47,32 +47,24 @@ Claude verifies before answering:
 ```markdown
 > What's the syntax for terraform import block?
 
-fresh-guides: **terraform** is on your fast-changing tech watchlist.
-
 ✦ Using skill: fresh-guides-verify
 
-The `import` block was introduced in Terraform v1.5. Syntax:
+● Bash(terraform version)
+  Terraform v1.6.6
+
+The `import` block is supported in your version (v1.6.6, added in v1.5).
+[Source: developer.hashicorp.com/terraform/language/v1.6.x/import]
+
+Syntax:
 
     import {
       to = aws_instance.example
       id = "i-abcd1234"
     }
 
-As of v1.7+, you can also use `for_each` inside import blocks for
-bulk imports. [Source: developer.hashicorp.com/terraform/docs, 2026-04-10]
-```
-
-View your watchlist:
-
-```markdown
-> /fresh-guides-show
-
-| Technology | Official Docs | Version |
-|------------|--------------|---------|
-| terraform | developer.hashicorp.com/..., github.com/.../releases | latest |
-| aws terraform provider | registry.terraform.io/..., github.com/.../releases | latest |
-
-**Check mode:** alert-and-verify
+**Note:** `for_each` inside import blocks requires v1.7+. Your v1.6.6
+does not support it — you'll need to write a separate `import` block
+per resource. [Source: developer.hashicorp.com/terraform/language/v1.7.x/import]
 ```
 
 ## 📦 Installation <a name="installation"></a>
@@ -93,19 +85,13 @@ Restart your session for changes to take effect.
 
 ## ⚙️ How it works <a name="how-it-works"></a>
 
-Two check modes control Claude's behavior:
-
-| Mode | Behavior |
-|------|----------|
-| **alert-and-verify** | Alert + fetch official docs + cite sources |
-| **alert-only** | Alert the user, skip automatic verification |
-
 | Trigger | What happens |
 |---------|-------------|
-| SessionStart | Injects compact watchlist + rules into context |
-| Watched tech detected | `fresh-guides-verify` skill invoked — fetches docs, compares, cites |
-| Docs confirm knowledge | Response includes "Verified against official docs" with citation |
-| Docs contradict knowledge | Explicit callout: "My training data may be outdated here" |
+| SessionStart | Injects compact watchlist into context |
+| Watched tech detected | `fresh-guides-verify` skill invoked |
+| Version detection | Checks project files and runtime for current version |
+| Doc verification | Fetches version-specific official docs via WebFetch/WebSearch |
+| Version mismatch | Warns about features unavailable in user's version |
 | Verification fails | States "could not verify" with links for manual check |
 
 **Scope:** Verification triggers only for version-specific advice (API signatures, config syntax, defaults, deprecations). General concepts and design patterns are answered normally.
@@ -116,12 +102,11 @@ Two check modes control Claude's behavior:
 
 | Command | Description |
 |---------|-------------|
-| `/fresh-guides-setup` | Interactive wizard — configure watchlist, doc URLs, check mode |
+| `/fresh-guides-setup` | Interactive wizard — configure watchlist and doc URLs |
 | `/fresh-guides-show` | Display current watchlist configuration |
 | `/fresh-guides-update add <name> <url>` | Add a technology with a doc URL |
 | `/fresh-guides-update remove <name>` | Remove a technology from watchlist |
 | `/fresh-guides-update url <name> <url>` | Add another URL to an existing technology |
-| `/fresh-guides-update mode <mode>` | Change check mode (alert-and-verify / alert-only) |
 
 ## 📝 Config <a name="config"></a>
 
@@ -136,25 +121,20 @@ Project config: `.claude-plugin/fresh-guides.json` (overrides global)
       "docs": [
         "https://developer.hashicorp.com/terraform/docs",
         "https://github.com/hashicorp/terraform/releases"
-      ],
-      "version": "latest"
+      ]
     },
     {
       "name": "aws terraform provider",
       "docs": [
         "https://registry.terraform.io/providers/hashicorp/aws/latest/docs",
         "https://github.com/hashicorp/terraform-provider-aws/releases"
-      ],
-      "version": "latest"
+      ]
     }
-  ],
-  "checkMode": "alert-and-verify"
+  ]
 }
 ```
 
 | Field | Description | Default |
 |-------|-------------|---------|
-| `watchlist[].name` | Technology identifier (matched case-insensitively) | — |
+| `watchlist[].name` | Technology identifier (matched case-insensitive) | — |
 | `watchlist[].docs` | Official doc / changelog / release note URLs | — |
-| `watchlist[].version` | Version constraint (`"latest"` for now) | `"latest"` |
-| `checkMode` | `"alert-and-verify"` or `"alert-only"` | `"alert-and-verify"` |

--- a/plugins/fresh-guides/README.md
+++ b/plugins/fresh-guides/README.md
@@ -6,7 +6,7 @@
 Configure a watchlist of fast-changing technologies and Claude automatically verifies advice against official documentation before responding.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🎮 Commands](#commands) · [📝 Config](#config)
+> [📦 Installation](#installation) · [⚙️ How it works](#how-it-works) · [🎮 Commands](#commands) · [📝 Config](#config)
 
 ## 🎬 Demo <a name="demo"></a>
 
@@ -58,6 +58,22 @@ View your watchlist:
 **Check mode:** alert-and-verify
 ```
 
+## 📦 Installation <a name="installation"></a>
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install fresh-guides@tribe-coding
+/plugin
+```
+
+Select **fresh-guides** → enable **auto-update**. Then run the setup wizard:
+
+```
+/fresh-guides-setup
+```
+
+Restart your session for changes to take effect.
+
 ## ⚙️ How it works <a name="how-it-works"></a>
 
 Two check modes control Claude's behavior:
@@ -78,22 +94,6 @@ Two check modes control Claude's behavior:
 **Scope:** Verification triggers only for version-specific advice (API signatures, config syntax, defaults, deprecations). General concepts and design patterns are answered normally.
 
 **Complements [technology-explainer](../technology-explainer/README.md):** Technology-explainer controls explanation *depth* (brief vs detailed). Fresh-guides controls *accuracy verification* (check docs vs trust weights). A technology can be in both configs.
-
-## 📦 Installation <a name="installation"></a>
-
-```bash
-/plugin marketplace add Tribe-Coding/claude-plugins
-/plugin install fresh-guides@tribe-coding
-/plugin
-```
-
-Select **fresh-guides** → enable **auto-update**. Then run the setup wizard:
-
-```
-/fresh-guides-setup
-```
-
-Restart your session for changes to take effect.
 
 ## 🎮 Commands <a name="commands"></a>
 

--- a/plugins/fresh-guides/commands/fresh-guides-setup/SKILL.md
+++ b/plugins/fresh-guides/commands/fresh-guides-setup/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: fresh-guides-setup
+description: >
+  Interactive setup wizard for fast-changing technology watchlist. Creates or updates
+  ~/.claude/fresh-guides.json or .claude-plugin/fresh-guides.json. Run this command
+  to configure which technologies require doc verification.
+  Keywords: fresh-guides setup, configure watchlist, fast-changing technology, doc verification.
+---
+
+# Fresh Guides Setup
+
+Configure which technologies Claude should verify against official docs before giving advice.
+
+## Steps
+
+### 1. Educational intro
+
+Explain to the user:
+
+> **Fresh Guides** keeps a watchlist of technologies that change frequently — where model training data may be outdated. When you ask about a watched technology, Claude will:
+> 1. Alert you that this tech is on the watchlist
+> 2. Fetch the latest official docs to verify its answer
+> 3. Cite sources with URLs and dates
+
+Give examples: AWS services (new features every week), Terraform providers (breaking changes between versions), Kubernetes (deprecation cycles), CI/CD tools (frequent major releases).
+
+### 2. Show existing config
+
+Read `~/.claude/fresh-guides.json` and `.claude-plugin/fresh-guides.json` (if in a project). If either exists, display the current watchlist as a table:
+
+| Technology | Official Docs | Version |
+|------------|--------------|---------|
+| terraform | developer.hashicorp.com/terraform/docs | latest |
+| aws-lambda | docs.aws.amazon.com/lambda/ | latest |
+
+If neither exists, say "No watchlist configured yet — let's create one."
+
+### 3. Ask for technologies
+
+Use `AskUserQuestion` with a free-text option. Ask:
+
+> "Which technologies should be on your watchlist? These are tools/services where you want Claude to always check official docs before answering."
+
+Suggest categories: cloud providers (AWS, GCP, Azure), IaC tools (Terraform, Pulumi), container orchestration (Kubernetes, ECS), CI/CD platforms, rapidly-evolving frameworks.
+
+### 4. For each technology, ask for doc URLs
+
+For each technology the user listed, use `AskUserQuestion` to collect official documentation URLs. Suggest sensible defaults based on the technology name:
+
+- terraform → `https://developer.hashicorp.com/terraform/docs`, `https://github.com/hashicorp/terraform/releases`
+- aws-* → `https://docs.aws.amazon.com/<service>/`
+- kubernetes → `https://kubernetes.io/docs/`, `https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/`
+
+Accept multiple URLs per technology (docs, release notes, changelog).
+
+### 5. Ask for check mode
+
+Use `AskUserQuestion`:
+- **alert-and-verify** (Recommended) — Claude alerts AND fetches official docs to verify
+- **alert-only** — Claude alerts but does not automatically fetch docs
+
+### 6. Ask for config scope
+
+Use `AskUserQuestion`:
+- **Global** (`~/.claude/fresh-guides.json`) — applies to all projects
+- **Project** (`.claude-plugin/fresh-guides.json`) — applies only to this project
+
+If the user chooses project scope, check that `.claude-plugin/` directory exists (create if needed).
+
+### 7. Write config and confirm
+
+Write the config file with the collected data. Display a summary:
+
+```
+Watchlist saved to ~/.claude/fresh-guides.json
+
+| Technology | Docs | Version |
+|------------|------|---------|
+| terraform  | developer.hashicorp.com/..., github.com/... | latest |
+
+Check mode: alert-and-verify
+
+Restart your session or run /clear for changes to take effect.
+```

--- a/plugins/fresh-guides/commands/fresh-guides-setup/SKILL.md
+++ b/plugins/fresh-guides/commands/fresh-guides-setup/SKILL.md
@@ -18,9 +18,9 @@ Configure which technologies Claude should verify against official docs before g
 Explain to the user:
 
 > **Fresh Guides** keeps a watchlist of technologies that change frequently — where model training data may be outdated. When you ask about a watched technology, Claude will:
-> 1. Alert you that this tech is on the watchlist
-> 2. Fetch the latest official docs to verify its answer
-> 3. Cite sources with URLs and dates
+> 1. Detect which version you're running
+> 2. Fetch the official docs for that version to verify its answer
+> 3. Cite sources and warn about version-specific limitations
 
 Give examples: AWS services (new features every week), Terraform providers (breaking changes between versions), Kubernetes (deprecation cycles), CI/CD tools (frequent major releases).
 
@@ -28,10 +28,9 @@ Give examples: AWS services (new features every week), Terraform providers (brea
 
 Read `~/.claude/fresh-guides.json` and `.claude-plugin/fresh-guides.json` (if in a project). If either exists, display the current watchlist as a table:
 
-| Technology | Official Docs | Version |
-|------------|--------------|---------|
-| terraform | developer.hashicorp.com/terraform/docs | latest |
-| aws-lambda | docs.aws.amazon.com/lambda/ | latest |
+| Technology | Official Docs |
+|------------|--------------|
+| terraform | developer.hashicorp.com/terraform/docs |
 
 If neither exists, say "No watchlist configured yet — let's create one."
 
@@ -43,23 +42,23 @@ Use `AskUserQuestion` with a free-text option. Ask:
 
 Suggest categories: cloud providers (AWS, GCP, Azure), IaC tools (Terraform, Pulumi), container orchestration (Kubernetes, ECS), CI/CD platforms, rapidly-evolving frameworks.
 
-### 4. For each technology, ask for doc URLs
+### 4. For each technology, discover and propose doc URLs
 
-For each technology the user listed, use `AskUserQuestion` to collect official documentation URLs. Suggest sensible defaults based on the technology name:
+For each technology the user listed:
 
-- terraform → `https://developer.hashicorp.com/terraform/docs`, `https://github.com/hashicorp/terraform/releases`
-- aws-* → `https://docs.aws.amazon.com/<service>/`
-- kubernetes → `https://kubernetes.io/docs/`, `https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/`
+1. **Generate candidate URLs** based on the technology name. Use well-known patterns:
+   - terraform → `https://developer.hashicorp.com/terraform/docs`, `https://github.com/hashicorp/terraform/releases`
+   - aws terraform provider → `https://registry.terraform.io/providers/hashicorp/aws/latest/docs`, `https://github.com/hashicorp/terraform-provider-aws/releases`
+   - kubernetes → `https://kubernetes.io/docs/`, `https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/`
+   - For other technologies, construct likely official doc URLs
 
-Accept multiple URLs per technology (docs, release notes, changelog).
+2. **Probe each candidate** with `WebFetch` to verify it resolves successfully. Only include URLs that actually work.
 
-### 5. Ask for check mode
+3. **Present as checkboxes** via `AskUserQuestion`: list the working URLs as `[*]` pre-selected options, plus an `[ ] Other (enter URL)` option for the user to add custom URLs.
 
-Use `AskUserQuestion`:
-- **alert-and-verify** (Recommended) — Claude alerts AND fetches official docs to verify
-- **alert-only** — Claude alerts but does not automatically fetch docs
+4. If no candidate URLs resolve, ask the user to provide URLs manually.
 
-### 6. Ask for config scope
+### 5. Ask for config scope
 
 Use `AskUserQuestion`:
 - **Global** (`~/.claude/fresh-guides.json`) — applies to all projects
@@ -67,18 +66,17 @@ Use `AskUserQuestion`:
 
 If the user chooses project scope, check that `.claude-plugin/` directory exists (create if needed).
 
-### 7. Write config and confirm
+### 6. Write config and confirm
 
-Write the config file with the collected data. Display a summary:
+Write the config file with the collected data. Display a summary table with all configured technologies and their doc URLs:
+
+| Technology | Official Docs |
+|------------|--------------|
+| terraform | developer.hashicorp.com/terraform/docs, github.com/.../releases |
+| aws terraform provider | registry.terraform.io/..., github.com/.../releases |
+
+Then confirm:
 
 ```
-Watchlist saved to ~/.claude/fresh-guides.json
-
-| Technology | Docs | Version |
-|------------|------|---------|
-| terraform  | developer.hashicorp.com/..., github.com/... | latest |
-
-Check mode: alert-and-verify
-
 Restart your session or run /clear for changes to take effect.
 ```

--- a/plugins/fresh-guides/commands/fresh-guides-show/SKILL.md
+++ b/plugins/fresh-guides/commands/fresh-guides-show/SKILL.md
@@ -2,7 +2,7 @@
 name: fresh-guides-show
 description: >
   Display current fresh-guides watchlist configuration.
-  Shows all watched technologies, their doc URLs, versions, and check mode.
+  Shows all watched technologies and their doc URLs.
   Keywords: show watchlist, fresh-guides config, current technologies.
 ---
 
@@ -26,20 +26,17 @@ Format the output as a table:
 
 **Scope: Global** (`~/.claude/fresh-guides.json`)
 
-| Technology | Official Docs | Version |
-|------------|--------------|---------|
-| terraform | developer.hashicorp.com/terraform/docs, github.com/.../releases | latest |
-| aws-lambda | docs.aws.amazon.com/lambda/ | latest |
-
-**Check mode:** alert-and-verify
+| Technology | Official Docs |
+|------------|--------------|
+| terraform | developer.hashicorp.com/terraform/docs, github.com/.../releases |
 
 If project config also exists:
 
 **Scope: Project** (`.claude-plugin/fresh-guides.json`)
 
-| Technology | Official Docs | Version |
-|------------|--------------|---------|
-| aws-cdk | docs.aws.amazon.com/cdk/ | latest |
+| Technology | Official Docs |
+|------------|--------------|
+| aws terraform provider | registry.terraform.io/..., github.com/.../releases |
 
 **Note:** Project entries override global entries with the same name.
 
@@ -49,5 +46,4 @@ Mention available commands:
 - `/fresh-guides-update add <name> <url>` — add a technology with a doc URL
 - `/fresh-guides-update remove <name>` — remove a technology from watchlist
 - `/fresh-guides-update url <name> <url>` — add another URL to an existing technology
-- `/fresh-guides-update mode <alert-and-verify|alert-only>` — change check mode
 - `/fresh-guides-setup` — reconfigure from scratch

--- a/plugins/fresh-guides/commands/fresh-guides-show/SKILL.md
+++ b/plugins/fresh-guides/commands/fresh-guides-show/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: fresh-guides-show
+description: >
+  Display current fresh-guides watchlist configuration.
+  Shows all watched technologies, their doc URLs, versions, and check mode.
+  Keywords: show watchlist, fresh-guides config, current technologies.
+---
+
+# Fresh Guides Show
+
+Display the current fast-changing technology watchlist.
+
+## Steps
+
+### 1. Read config
+
+Read both `~/.claude/fresh-guides.json` (global) and `.claude-plugin/fresh-guides.json` (project).
+
+If neither file exists, display: "No watchlist configured. Run `/fresh-guides-setup` to create one."
+
+### 2. Display configuration
+
+If both configs exist, show them separately with labels. Otherwise show the one that exists.
+
+Format the output as a table:
+
+**Scope: Global** (`~/.claude/fresh-guides.json`)
+
+| Technology | Official Docs | Version |
+|------------|--------------|---------|
+| terraform | developer.hashicorp.com/terraform/docs, github.com/.../releases | latest |
+| aws-lambda | docs.aws.amazon.com/lambda/ | latest |
+
+**Check mode:** alert-and-verify
+
+If project config also exists:
+
+**Scope: Project** (`.claude-plugin/fresh-guides.json`)
+
+| Technology | Official Docs | Version |
+|------------|--------------|---------|
+| aws-cdk | docs.aws.amazon.com/cdk/ | latest |
+
+**Note:** Project entries override global entries with the same name.
+
+### 3. Suggest next steps
+
+Mention available commands:
+- `/fresh-guides-update add <name> <url>` — add a technology with a doc URL
+- `/fresh-guides-update remove <name>` — remove a technology from watchlist
+- `/fresh-guides-update url <name> <url>` — add another URL to an existing technology
+- `/fresh-guides-update mode <alert-and-verify|alert-only>` — change check mode
+- `/fresh-guides-setup` — reconfigure from scratch

--- a/plugins/fresh-guides/commands/fresh-guides-update/SKILL.md
+++ b/plugins/fresh-guides/commands/fresh-guides-update/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: fresh-guides-update
+description: >
+  Quick-update the fresh-guides watchlist. Usage:
+  /fresh-guides-update add <name> <url> — add a technology,
+  /fresh-guides-update remove <name> — remove a technology,
+  /fresh-guides-update url <name> <url> — add URL to existing technology,
+  /fresh-guides-update mode <mode> — change check mode.
+  Keywords: update watchlist, add technology, remove technology, change mode.
+---
+
+# Fresh Guides Update
+
+Quickly update a single aspect of the fresh-guides watchlist.
+
+## Config Resolution
+
+Determine which config file to update:
+- If `.claude-plugin/fresh-guides.json` exists → update project config
+- Else if `~/.claude/fresh-guides.json` exists → update global config
+- Else → create global config from template, then apply update
+
+## Supported Operations
+
+### Add technology
+
+**Usage:** `/fresh-guides-update add <name> <url>`
+
+**Steps:**
+1. Read config file.
+2. Check if `<name>` already exists in watchlist (case-insensitive). If so, add the URL to its `docs` array instead.
+3. If new, append `{ "name": "<name>", "docs": ["<url>"], "version": "latest" }` to watchlist.
+4. Write the updated config.
+5. Confirm: "Added **<name>** to watchlist with doc URL: <url>. Restart session for changes to take effect."
+
+### Remove technology
+
+**Usage:** `/fresh-guides-update remove <name>`
+
+**Steps:**
+1. Read config file.
+2. Remove the entry matching `<name>` (case-insensitive) from watchlist.
+3. Write the updated config.
+4. Confirm: "Removed **<name>** from watchlist."
+5. If not found: "**<name>** is not on the watchlist."
+
+### Add URL to existing technology
+
+**Usage:** `/fresh-guides-update url <name> <url>`
+
+**Steps:**
+1. Read config file.
+2. Find the entry matching `<name>` (case-insensitive).
+3. Append `<url>` to its `docs` array (skip if already present).
+4. Write the updated config.
+5. Confirm: "Added doc URL for **<name>**: <url>."
+6. If not found: "**<name>** is not on the watchlist. Use `/fresh-guides-update add <name> <url>` to add it."
+
+### Change check mode
+
+**Usage:** `/fresh-guides-update mode <alert-and-verify|alert-only>`
+
+**Steps:**
+1. Read config file.
+2. Set `checkMode` to the specified value.
+3. Write the updated config.
+4. Confirm: "Check mode set to **<mode>**."
+
+## Error Handling
+
+- Invalid mode → show valid options: `alert-and-verify`, `alert-only`
+- No arguments → show usage examples for all operations
+- Config file missing → create from template, then apply update

--- a/plugins/fresh-guides/commands/fresh-guides-update/SKILL.md
+++ b/plugins/fresh-guides/commands/fresh-guides-update/SKILL.md
@@ -4,9 +4,8 @@ description: >
   Quick-update the fresh-guides watchlist. Usage:
   /fresh-guides-update add <name> <url> — add a technology,
   /fresh-guides-update remove <name> — remove a technology,
-  /fresh-guides-update url <name> <url> — add URL to existing technology,
-  /fresh-guides-update mode <mode> — change check mode.
-  Keywords: update watchlist, add technology, remove technology, change mode.
+  /fresh-guides-update url <name> <url> — add URL to existing technology.
+  Keywords: update watchlist, add technology, remove technology.
 ---
 
 # Fresh Guides Update
@@ -29,7 +28,7 @@ Determine which config file to update:
 **Steps:**
 1. Read config file.
 2. Check if `<name>` already exists in watchlist (case-insensitive). If so, add the URL to its `docs` array instead.
-3. If new, append `{ "name": "<name>", "docs": ["<url>"], "version": "latest" }` to watchlist.
+3. If new, append `{ "name": "<name>", "docs": ["<url>"] }` to watchlist.
 4. Write the updated config.
 5. Confirm: "Added **<name>** to watchlist with doc URL: <url>. Restart session for changes to take effect."
 
@@ -56,18 +55,7 @@ Determine which config file to update:
 5. Confirm: "Added doc URL for **<name>**: <url>."
 6. If not found: "**<name>** is not on the watchlist. Use `/fresh-guides-update add <name> <url>` to add it."
 
-### Change check mode
-
-**Usage:** `/fresh-guides-update mode <alert-and-verify|alert-only>`
-
-**Steps:**
-1. Read config file.
-2. Set `checkMode` to the specified value.
-3. Write the updated config.
-4. Confirm: "Check mode set to **<mode>**."
-
 ## Error Handling
 
-- Invalid mode → show valid options: `alert-and-verify`, `alert-only`
 - No arguments → show usage examples for all operations
 - Config file missing → create from template, then apply update

--- a/plugins/fresh-guides/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/fresh-guides/docs/ACCEPTANCE_TESTS.md
@@ -1,0 +1,327 @@
+# Fresh Guides Acceptance Tests
+
+## Purpose
+
+The fresh-guides plugin verifies advice against official docs for fast-changing technologies. These tests verify config reading, watchlist merging, SessionStart output formatting, silent exits, and skill invocation.
+
+## Test Execution Order
+
+1. Static checks (automated)
+2. Script unit tests (automated)
+3. SessionStart integration (manual — requires fresh session)
+4. Skill invocation tests (manual — requires fresh session)
+
+## Automation Status
+
+- Fully automated: Tests 1-2
+- Manual only: Tests 3-5 (require fresh Claude Code session)
+
+---
+
+## 1. Static Checks
+
+**Objective:** Validate plugin structure and file formats.
+
+**Automation:** Yes
+
+**Steps:**
+
+```bash
+PLUGIN="/Users/artem/devel/claude-plugins/plugins/fresh-guides"
+
+# plugin.json is valid JSON with required fields
+jq -e '.name, .version, .commands, .skills' "$PLUGIN/.claude-plugin/plugin.json"
+
+# hooks.json is valid JSON with SessionStart hook
+jq -e '.hooks.SessionStart' "$PLUGIN/hooks/hooks.json"
+
+# Template is valid JSON with required structure
+jq -e '.watchlist, .checkMode' "$PLUGIN/templates/fresh-guides.json"
+
+# SKILL.md files have YAML frontmatter
+for f in "$PLUGIN"/commands/*/SKILL.md "$PLUGIN"/skills/*/SKILL.md; do
+  head -1 "$f" | grep -q '^---' && echo "OK frontmatter: $f" || echo "FAIL frontmatter: $f"
+done
+
+# inject-rules.sh is executable
+[[ -x "$PLUGIN/scripts/inject-rules.sh" ]] && echo "OK inject-rules.sh is executable" || echo "FAIL inject-rules.sh is not executable"
+```
+
+**Expected result:**
+- All JSON files parse successfully
+- All SKILL.md files have frontmatter
+- inject-rules.sh is executable
+
+---
+
+## 2. Script Unit Tests — inject-rules.sh
+
+**Objective:** Verify config reading, watchlist merging, output format, and silent exit.
+
+**Automation:** Yes
+
+**Steps:**
+
+```bash
+SCRIPT="/Users/artem/devel/claude-plugins/plugins/fresh-guides/scripts/inject-rules.sh"
+PLUGIN="/Users/artem/devel/claude-plugins/plugins/fresh-guides"
+
+# Test 2.1: Full config with watchlist entries
+FAKE_HOME="/tmp/fg-test-1"
+mkdir -p "$FAKE_HOME/.claude"
+cat > "$FAKE_HOME/.claude/fresh-guides.json" <<'JSON'
+{
+  "watchlist": [
+    {
+      "name": "terraform",
+      "docs": ["https://developer.hashicorp.com/terraform/docs", "https://github.com/hashicorp/terraform/releases"],
+      "version": "latest"
+    },
+    {
+      "name": "aws-lambda",
+      "docs": ["https://docs.aws.amazon.com/lambda/"],
+      "version": "latest"
+    }
+  ],
+  "checkMode": "alert-and-verify"
+}
+JSON
+output=$(env HOME="$FAKE_HOME" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
+echo "$output" | grep -q '## Fresh Guides' && echo "OK 2.1: Header present" || echo "FAIL 2.1: Header missing"
+echo "$output" | grep -q 'terraform' && echo "OK 2.1: Terraform entry" || echo "FAIL 2.1: Terraform missing"
+echo "$output" | grep -q 'aws-lambda' && echo "OK 2.1: AWS Lambda entry" || echo "FAIL 2.1: AWS Lambda missing"
+echo "$output" | grep -q 'fresh-guides-verify' && echo "OK 2.1: Skill pointer" || echo "FAIL 2.1: Skill pointer missing"
+echo "$output" | grep -q '<!-- Source: Plugin fresh-guides@tribe-coding' && echo "OK 2.1: Source marker" || echo "FAIL 2.1: Source marker missing"
+echo "$output" | grep -q 'Cite' && echo "OK 2.1: Cite instruction" || echo "FAIL 2.1: Cite instruction missing"
+
+# Test 2.2: Silent exit with no config
+output=$(env HOME=/tmp/nonexistent CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
+[[ -z "$output" ]] && echo "OK 2.2: Silent exit (no config)" || echo "FAIL 2.2: Unexpected output: $output"
+
+# Test 2.3: Silent exit with empty watchlist
+FAKE_HOME2="/tmp/fg-test-3"
+mkdir -p "$FAKE_HOME2/.claude"
+cat > "$FAKE_HOME2/.claude/fresh-guides.json" <<'JSON'
+{
+  "watchlist": [],
+  "checkMode": "alert-and-verify"
+}
+JSON
+output=$(env HOME="$FAKE_HOME2" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
+[[ -z "$output" ]] && echo "OK 2.3: Silent exit (empty watchlist)" || echo "FAIL 2.3: Unexpected output: $output"
+
+# Test 2.4: alert-only mode
+FAKE_HOME3="/tmp/fg-test-4"
+mkdir -p "$FAKE_HOME3/.claude"
+cat > "$FAKE_HOME3/.claude/fresh-guides.json" <<'JSON'
+{
+  "watchlist": [
+    {
+      "name": "kubernetes",
+      "docs": ["https://kubernetes.io/docs/"],
+      "version": "latest"
+    }
+  ],
+  "checkMode": "alert-only"
+}
+JSON
+output=$(env HOME="$FAKE_HOME3" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
+echo "$output" | grep -q 'kubernetes' && echo "OK 2.4: K8s entry" || echo "FAIL 2.4: K8s missing"
+echo "$output" | grep -q 'verify before relying' && echo "OK 2.4: Alert-only mode" || echo "FAIL 2.4: Alert-only missing"
+echo "$output" | grep -qv 'fresh-guides-verify' && echo "OK 2.4: No verify skill pointer" || echo "FAIL 2.4: Unexpected verify pointer"
+
+# Test 2.5: Project config overrides global
+FAKE_HOME4="/tmp/fg-test-5"
+FAKE_PROJECT="/tmp/fg-test-5-proj"
+mkdir -p "$FAKE_HOME4/.claude" "$FAKE_PROJECT/.claude-plugin"
+cat > "$FAKE_HOME4/.claude/fresh-guides.json" <<'JSON'
+{
+  "watchlist": [
+    {
+      "name": "terraform",
+      "docs": ["https://global.example.com"],
+      "version": "latest"
+    },
+    {
+      "name": "ansible",
+      "docs": ["https://docs.ansible.com"],
+      "version": "latest"
+    }
+  ],
+  "checkMode": "alert-and-verify"
+}
+JSON
+cat > "$FAKE_PROJECT/.claude-plugin/fresh-guides.json" <<'JSON'
+{
+  "watchlist": [
+    {
+      "name": "terraform",
+      "docs": ["https://project.example.com"],
+      "version": "latest"
+    }
+  ],
+  "checkMode": "alert-and-verify"
+}
+JSON
+output=$(env HOME="$FAKE_HOME4" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="$FAKE_PROJECT" bash "$SCRIPT")
+echo "$output" | grep -q 'project.example.com' && echo "OK 2.5: Project terraform overrides global" || echo "FAIL 2.5: Project override failed"
+echo "$output" | grep -q 'ansible' && echo "OK 2.5: Global-only ansible preserved" || echo "FAIL 2.5: Global ansible lost"
+echo "$output" | grep -qv 'global.example.com' && echo "OK 2.5: Global terraform URL not present" || echo "FAIL 2.5: Global terraform URL leaked"
+
+# Test 2.6: Source marker includes version
+output=$(env HOME="$FAKE_HOME" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
+echo "$output" | grep -q 'v0.1.0' && echo "OK 2.6: Version in source marker" || echo "FAIL 2.6: Version missing"
+
+# Cleanup
+rm -rf /tmp/fg-test-1 /tmp/fg-test-3 /tmp/fg-test-4 /tmp/fg-test-5 /tmp/fg-test-5-proj
+```
+
+**Expected result:**
+- 2.1: Full output with header, entries, skill pointer, source marker, cite instruction
+- 2.2: Zero output when no config exists
+- 2.3: Zero output when watchlist is empty
+- 2.4: Alert-only mode shows alert text, no verify skill pointer
+- 2.5: Project entries override global entries with same name; global-only entries preserved
+- 2.6: Version number present in source marker
+
+---
+
+## 3. SessionStart Integration
+
+**Objective:** Verify that watchlist rules are injected into Claude Code session context.
+
+**Automation:** Manual only (requires fresh session)
+
+### Manual Test Procedure
+
+**Step 1:** Create a test config:
+```bash
+mkdir -p ~/.claude
+cat > ~/.claude/fresh-guides.json <<'JSON'
+{
+  "watchlist": [
+    {
+      "name": "terraform",
+      "docs": ["https://developer.hashicorp.com/terraform/docs", "https://github.com/hashicorp/terraform/releases"],
+      "version": "latest"
+    }
+  ],
+  "checkMode": "alert-and-verify"
+}
+JSON
+```
+
+**Step 2:** Start a fresh Claude Code session.
+
+**Step 3:** Ask Claude: "What's the syntax for terraform import block?"
+
+**Expected:**
+- Claude alerts: "fresh-guides: terraform is on your fast-changing tech watchlist."
+- Claude invokes `fresh-guides-verify` skill
+- Claude fetches official Terraform docs
+- Response includes inline citation with URL and date
+
+**Step 4:** Ask Claude a general question: "What is infrastructure as code?"
+
+**Expected:** No fresh-guides alert (general concept, not version-specific).
+
+**Step 5:** Clean up:
+```bash
+rm ~/.claude/fresh-guides.json
+```
+
+---
+
+## 4. Skill Invocation Tests
+
+**Objective:** Verify `/fresh-guides-setup`, `/fresh-guides-show`, and `/fresh-guides-update` work correctly.
+
+**Automation:** Manual only (requires Claude Code session)
+
+### Test 4.1: /fresh-guides-setup
+
+**Step 1:** In a Claude Code session, run `/fresh-guides-setup`
+
+**Expected:**
+- Explains what fresh-guides does
+- Asks for technologies to watch
+- For each technology, asks for doc URLs (with sensible suggestions)
+- Asks for check mode
+- Asks for config scope (global vs project)
+- Writes config file
+- Shows confirmation summary
+
+### Test 4.2: /fresh-guides-show
+
+**Step 1:** After setup, run `/fresh-guides-show`
+
+**Expected:**
+- Displays watchlist as a table with technology, docs, version
+- Shows check mode
+- Lists available update commands
+
+### Test 4.3: /fresh-guides-update
+
+**Step 1:** Run `/fresh-guides-update add kubernetes https://kubernetes.io/docs/`
+
+**Expected:**
+- Kubernetes added to watchlist
+- Confirmation message shown
+
+**Step 2:** Run `/fresh-guides-update url terraform https://github.com/hashicorp/terraform/releases`
+
+**Expected:**
+- URL added to terraform's docs array
+- Confirmation message shown
+
+**Step 3:** Run `/fresh-guides-update mode alert-only`
+
+**Expected:**
+- Check mode changed to alert-only
+- Confirmation message shown
+
+**Step 4:** Run `/fresh-guides-update remove kubernetes`
+
+**Expected:**
+- Kubernetes removed from watchlist
+- Confirmation message shown
+
+---
+
+## 5. Verification Behavior
+
+**Objective:** Verify that the `fresh-guides-verify` skill correctly fetches and cites official docs.
+
+**Automation:** Manual only (requires fresh session with WebFetch access)
+
+### Test 5.1: Docs confirm training data
+
+**Step 1:** Configure terraform on watchlist, ask about a well-established Terraform feature.
+
+**Expected:** Claude verifies and says "Verified against official docs" with citation.
+
+### Test 5.2: Docs contradict or extend training data
+
+**Step 1:** Ask about a very recent Terraform feature or changed behavior.
+
+**Expected:** Claude notes the discrepancy: "My training data may be outdated here. According to official docs as of [date]: ..."
+
+### Test 5.3: Verification fails
+
+**Step 1:** Configure a technology with an invalid doc URL, ask a version-specific question.
+
+**Expected:** Claude explicitly states: "I could not verify this against official docs. My answer is based on training data." Lists configured URLs for manual check.
+
+---
+
+## Regression Testing Guide
+
+Run tests 1-2 automatically before every release:
+```bash
+# Run all automated tests (copy and paste the bash blocks from sections 1-2)
+```
+
+Run tests 3-5 manually:
+- After any change to `inject-rules.sh`
+- After changing hooks.json
+- After modifying SKILL.md files

--- a/plugins/fresh-guides/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/fresh-guides/docs/ACCEPTANCE_TESTS.md
@@ -36,7 +36,7 @@ jq -e '.name, .version, .commands, .skills' "$PLUGIN/.claude-plugin/plugin.json"
 jq -e '.hooks.SessionStart' "$PLUGIN/hooks/hooks.json"
 
 # Template is valid JSON with required structure
-jq -e '.watchlist, .checkMode' "$PLUGIN/templates/fresh-guides.json"
+jq -e '.watchlist' "$PLUGIN/templates/fresh-guides.json"
 
 # SKILL.md files have YAML frontmatter
 for f in "$PLUGIN"/commands/*/SKILL.md "$PLUGIN"/skills/*/SKILL.md; do
@@ -74,25 +74,21 @@ cat > "$FAKE_HOME/.claude/fresh-guides.json" <<'JSON'
   "watchlist": [
     {
       "name": "terraform",
-      "docs": ["https://developer.hashicorp.com/terraform/docs", "https://github.com/hashicorp/terraform/releases"],
-      "version": "latest"
+      "docs": ["https://developer.hashicorp.com/terraform/docs", "https://github.com/hashicorp/terraform/releases"]
     },
     {
-      "name": "aws-lambda",
-      "docs": ["https://docs.aws.amazon.com/lambda/"],
-      "version": "latest"
+      "name": "aws terraform provider",
+      "docs": ["https://registry.terraform.io/providers/hashicorp/aws/latest/docs"]
     }
-  ],
-  "checkMode": "alert-and-verify"
+  ]
 }
 JSON
 output=$(env HOME="$FAKE_HOME" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
 echo "$output" | grep -q '## Fresh Guides' && echo "OK 2.1: Header present" || echo "FAIL 2.1: Header missing"
 echo "$output" | grep -q 'terraform' && echo "OK 2.1: Terraform entry" || echo "FAIL 2.1: Terraform missing"
-echo "$output" | grep -q 'aws-lambda' && echo "OK 2.1: AWS Lambda entry" || echo "FAIL 2.1: AWS Lambda missing"
+echo "$output" | grep -q 'aws terraform provider' && echo "OK 2.1: AWS provider entry" || echo "FAIL 2.1: AWS provider missing"
 echo "$output" | grep -q 'fresh-guides-verify' && echo "OK 2.1: Skill pointer" || echo "FAIL 2.1: Skill pointer missing"
 echo "$output" | grep -q '<!-- Source: Plugin fresh-guides@tribe-coding' && echo "OK 2.1: Source marker" || echo "FAIL 2.1: Source marker missing"
-echo "$output" | grep -q 'Cite' && echo "OK 2.1: Cite instruction" || echo "FAIL 2.1: Cite instruction missing"
 
 # Test 2.2: Silent exit with no config
 output=$(env HOME=/tmp/nonexistent CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
@@ -103,52 +99,28 @@ FAKE_HOME2="/tmp/fg-test-3"
 mkdir -p "$FAKE_HOME2/.claude"
 cat > "$FAKE_HOME2/.claude/fresh-guides.json" <<'JSON'
 {
-  "watchlist": [],
-  "checkMode": "alert-and-verify"
+  "watchlist": []
 }
 JSON
 output=$(env HOME="$FAKE_HOME2" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
 [[ -z "$output" ]] && echo "OK 2.3: Silent exit (empty watchlist)" || echo "FAIL 2.3: Unexpected output: $output"
 
-# Test 2.4: alert-only mode
+# Test 2.4: Project config overrides global
 FAKE_HOME3="/tmp/fg-test-4"
-mkdir -p "$FAKE_HOME3/.claude"
+FAKE_PROJECT="/tmp/fg-test-4-proj"
+mkdir -p "$FAKE_HOME3/.claude" "$FAKE_PROJECT/.claude-plugin"
 cat > "$FAKE_HOME3/.claude/fresh-guides.json" <<'JSON'
 {
   "watchlist": [
     {
-      "name": "kubernetes",
-      "docs": ["https://kubernetes.io/docs/"],
-      "version": "latest"
-    }
-  ],
-  "checkMode": "alert-only"
-}
-JSON
-output=$(env HOME="$FAKE_HOME3" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
-echo "$output" | grep -q 'kubernetes' && echo "OK 2.4: K8s entry" || echo "FAIL 2.4: K8s missing"
-echo "$output" | grep -q 'verify before relying' && echo "OK 2.4: Alert-only mode" || echo "FAIL 2.4: Alert-only missing"
-echo "$output" | grep -qv 'fresh-guides-verify' && echo "OK 2.4: No verify skill pointer" || echo "FAIL 2.4: Unexpected verify pointer"
-
-# Test 2.5: Project config overrides global
-FAKE_HOME4="/tmp/fg-test-5"
-FAKE_PROJECT="/tmp/fg-test-5-proj"
-mkdir -p "$FAKE_HOME4/.claude" "$FAKE_PROJECT/.claude-plugin"
-cat > "$FAKE_HOME4/.claude/fresh-guides.json" <<'JSON'
-{
-  "watchlist": [
-    {
       "name": "terraform",
-      "docs": ["https://global.example.com"],
-      "version": "latest"
+      "docs": ["https://global.example.com"]
     },
     {
       "name": "ansible",
-      "docs": ["https://docs.ansible.com"],
-      "version": "latest"
+      "docs": ["https://docs.ansible.com"]
     }
-  ],
-  "checkMode": "alert-and-verify"
+  ]
 }
 JSON
 cat > "$FAKE_PROJECT/.claude-plugin/fresh-guides.json" <<'JSON'
@@ -156,33 +128,30 @@ cat > "$FAKE_PROJECT/.claude-plugin/fresh-guides.json" <<'JSON'
   "watchlist": [
     {
       "name": "terraform",
-      "docs": ["https://project.example.com"],
-      "version": "latest"
+      "docs": ["https://project.example.com"]
     }
-  ],
-  "checkMode": "alert-and-verify"
+  ]
 }
 JSON
-output=$(env HOME="$FAKE_HOME4" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="$FAKE_PROJECT" bash "$SCRIPT")
-echo "$output" | grep -q 'project.example.com' && echo "OK 2.5: Project terraform overrides global" || echo "FAIL 2.5: Project override failed"
-echo "$output" | grep -q 'ansible' && echo "OK 2.5: Global-only ansible preserved" || echo "FAIL 2.5: Global ansible lost"
-echo "$output" | grep -qv 'global.example.com' && echo "OK 2.5: Global terraform URL not present" || echo "FAIL 2.5: Global terraform URL leaked"
+output=$(env HOME="$FAKE_HOME3" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="$FAKE_PROJECT" bash "$SCRIPT")
+echo "$output" | grep -q 'project.example.com' && echo "OK 2.4: Project terraform overrides global" || echo "FAIL 2.4: Project override failed"
+echo "$output" | grep -q 'ansible' && echo "OK 2.4: Global-only ansible preserved" || echo "FAIL 2.4: Global ansible lost"
+echo "$output" | grep -qv 'global.example.com' && echo "OK 2.4: Global terraform URL not present" || echo "FAIL 2.4: Global terraform URL leaked"
 
-# Test 2.6: Source marker includes version
+# Test 2.5: Source marker includes version
 output=$(env HOME="$FAKE_HOME" CLAUDE_PLUGIN_ROOT="$PLUGIN" CLAUDE_PROJECT_DIR="/tmp/nonexistent" bash "$SCRIPT")
-echo "$output" | grep -q 'v0.1.0' && echo "OK 2.6: Version in source marker" || echo "FAIL 2.6: Version missing"
+echo "$output" | grep -q 'v0.1.0' && echo "OK 2.5: Version in source marker" || echo "FAIL 2.5: Version missing"
 
 # Cleanup
-rm -rf /tmp/fg-test-1 /tmp/fg-test-3 /tmp/fg-test-4 /tmp/fg-test-5 /tmp/fg-test-5-proj
+rm -rf /tmp/fg-test-1 /tmp/fg-test-3 /tmp/fg-test-4 /tmp/fg-test-4-proj
 ```
 
 **Expected result:**
-- 2.1: Full output with header, entries, skill pointer, source marker, cite instruction
+- 2.1: Full output with header, entries, skill pointer, source marker
 - 2.2: Zero output when no config exists
 - 2.3: Zero output when watchlist is empty
-- 2.4: Alert-only mode shows alert text, no verify skill pointer
-- 2.5: Project entries override global entries with same name; global-only entries preserved
-- 2.6: Version number present in source marker
+- 2.4: Project entries override global entries with same name; global-only entries preserved
+- 2.5: Version number present in source marker
 
 ---
 
@@ -202,11 +171,9 @@ cat > ~/.claude/fresh-guides.json <<'JSON'
   "watchlist": [
     {
       "name": "terraform",
-      "docs": ["https://developer.hashicorp.com/terraform/docs", "https://github.com/hashicorp/terraform/releases"],
-      "version": "latest"
+      "docs": ["https://developer.hashicorp.com/terraform/docs", "https://github.com/hashicorp/terraform/releases"]
     }
-  ],
-  "checkMode": "alert-and-verify"
+  ]
 }
 JSON
 ```
@@ -216,14 +183,14 @@ JSON
 **Step 3:** Ask Claude: "What's the syntax for terraform import block?"
 
 **Expected:**
-- Claude alerts: "fresh-guides: terraform is on your fast-changing tech watchlist."
 - Claude invokes `fresh-guides-verify` skill
+- Claude detects terraform version from project or runtime
 - Claude fetches official Terraform docs
-- Response includes inline citation with URL and date
+- Response includes version-specific inline citations
 
 **Step 4:** Ask Claude a general question: "What is infrastructure as code?"
 
-**Expected:** No fresh-guides alert (general concept, not version-specific).
+**Expected:** No fresh-guides verification (general concept, not version-specific).
 
 **Step 5:** Clean up:
 ```bash
@@ -245,19 +212,18 @@ rm ~/.claude/fresh-guides.json
 **Expected:**
 - Explains what fresh-guides does
 - Asks for technologies to watch
-- For each technology, asks for doc URLs (with sensible suggestions)
-- Asks for check mode
+- For each technology, probes candidate doc URLs via WebFetch
+- Presents working URLs as checkboxes with pre-selected defaults + "Other" option
 - Asks for config scope (global vs project)
 - Writes config file
-- Shows confirmation summary
+- Shows summary table and restart reminder
 
 ### Test 4.2: /fresh-guides-show
 
 **Step 1:** After setup, run `/fresh-guides-show`
 
 **Expected:**
-- Displays watchlist as a table with technology, docs, version
-- Shows check mode
+- Displays watchlist as a table with technology and docs
 - Lists available update commands
 
 ### Test 4.3: /fresh-guides-update
@@ -274,13 +240,7 @@ rm ~/.claude/fresh-guides.json
 - URL added to terraform's docs array
 - Confirmation message shown
 
-**Step 3:** Run `/fresh-guides-update mode alert-only`
-
-**Expected:**
-- Check mode changed to alert-only
-- Confirmation message shown
-
-**Step 4:** Run `/fresh-guides-update remove kubernetes`
+**Step 3:** Run `/fresh-guides-update remove kubernetes`
 
 **Expected:**
 - Kubernetes removed from watchlist
@@ -290,21 +250,26 @@ rm ~/.claude/fresh-guides.json
 
 ## 5. Verification Behavior
 
-**Objective:** Verify that the `fresh-guides-verify` skill correctly fetches and cites official docs.
+**Objective:** Verify that the `fresh-guides-verify` skill correctly detects version, fetches docs, and cites sources.
 
 **Automation:** Manual only (requires fresh session with WebFetch access)
 
-### Test 5.1: Docs confirm training data
+### Test 5.1: Version detection and doc verification
 
-**Step 1:** Configure terraform on watchlist, ask about a well-established Terraform feature.
+**Step 1:** Configure terraform on watchlist, ensure terraform is installed locally.
 
-**Expected:** Claude verifies and says "Verified against official docs" with citation.
+**Step 2:** Ask about a terraform feature.
 
-### Test 5.2: Docs contradict or extend training data
+**Expected:**
+- Claude runs `terraform version` to detect current version
+- Claude fetches version-specific docs
+- Response includes version-aware advice with inline citations
 
-**Step 1:** Ask about a very recent Terraform feature or changed behavior.
+### Test 5.2: Feature not available in user's version
 
-**Expected:** Claude notes the discrepancy: "My training data may be outdated here. According to official docs as of [date]: ..."
+**Step 1:** Ask about a feature introduced in a version newer than the user's.
+
+**Expected:** Claude warns: "Requires vX.Y+. Your vA.B does not support it." and suggests workaround if available.
 
 ### Test 5.3: Verification fails
 

--- a/plugins/fresh-guides/hooks/hooks.json
+++ b/plugins/fresh-guides/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/inject-rules.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/fresh-guides/scripts/inject-rules.sh
+++ b/plugins/fresh-guides/scripts/inject-rules.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# inject-rules.sh — SessionStart hook for fresh-guides plugin
+# Reads watchlist config and outputs compact verification rules.
+# Silent exit (zero output) when no config or empty watchlist.
+
+set -euo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+VERSION=$(jq -r '.version' "$PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null || echo "?")
+
+PROJECT_CONFIG="${CLAUDE_PROJECT_DIR:-.}/.claude-plugin/fresh-guides.json"
+GLOBAL_CONFIG="$HOME/.claude/fresh-guides.json"
+
+# Determine which config(s) to use
+PROJECT_WATCHLIST=""
+GLOBAL_WATCHLIST=""
+CHECK_MODE="alert-and-verify"
+
+if [[ -f "$PROJECT_CONFIG" ]]; then
+  PROJECT_WATCHLIST=$(jq -r '.watchlist // [] | length' "$PROJECT_CONFIG" 2>/dev/null || echo "0")
+  CHECK_MODE=$(jq -r '.checkMode // "alert-and-verify"' "$PROJECT_CONFIG" 2>/dev/null || echo "alert-and-verify")
+fi
+
+if [[ -f "$GLOBAL_CONFIG" ]]; then
+  GLOBAL_WATCHLIST=$(jq -r '.watchlist // [] | length' "$GLOBAL_CONFIG" 2>/dev/null || echo "0")
+  if [[ "$CHECK_MODE" == "alert-and-verify" && -z "$PROJECT_WATCHLIST" ]]; then
+    CHECK_MODE=$(jq -r '.checkMode // "alert-and-verify"' "$GLOBAL_CONFIG" 2>/dev/null || echo "alert-and-verify")
+  fi
+fi
+
+# Silent exit if no config
+if [[ ! -f "$PROJECT_CONFIG" && ! -f "$GLOBAL_CONFIG" ]]; then
+  exit 0
+fi
+
+# Merge watchlists: project entries override global entries with same name
+MERGED=$(jq -n '
+  def merge_lists(global; project):
+    (global // []) as $g |
+    (project // []) as $p |
+    ($p | map(.name) | map(ascii_downcase)) as $pnames |
+    [$g[] | select((.name | ascii_downcase) as $n | $pnames | index($n) | not)] + $p;
+
+  input as $global |
+  input as $project |
+  merge_lists($global.watchlist; $project.watchlist)
+' <(if [[ -f "$GLOBAL_CONFIG" ]]; then cat "$GLOBAL_CONFIG"; else echo '{"watchlist":[]}'; fi) \
+  <(if [[ -f "$PROJECT_CONFIG" ]]; then cat "$PROJECT_CONFIG"; else echo '{"watchlist":[]}'; fi) 2>/dev/null || echo '[]')
+
+# Count entries
+COUNT=$(echo "$MERGED" | jq 'length' 2>/dev/null || echo "0")
+
+# Silent exit if empty watchlist
+if [[ "$COUNT" == "0" ]]; then
+  exit 0
+fi
+
+# Emit compact output (≤300 tokens)
+printf '<!-- Source: Plugin fresh-guides@tribe-coding (v%s) -->\n' "$VERSION"
+printf '## Fresh Guides — Fast-Changing Technology Watchlist\n\n'
+printf 'These technologies change frequently — model training data may be outdated.\n'
+printf 'When the conversation involves any of them AND advice is version-specific:\n'
+
+if [[ "$CHECK_MODE" == "alert-and-verify" ]]; then
+  printf '1. **Alert**: "fresh-guides: <name> is on your fast-changing tech watchlist."\n'
+  printf '2. **Verify** by invoking the `fresh-guides-verify` skill BEFORE giving version-specific advice.\n'
+  printf '3. **Cite** the source URL and date when providing verified information.\n\n'
+else
+  printf '1. **Alert**: "fresh-guides: <name> is on your fast-changing tech watchlist — verify before relying on my answer."\n\n'
+fi
+
+printf '**Watchlist:**\n'
+
+# Format each entry: name → docs (version)
+echo "$MERGED" | jq -r '
+  .[:10] | .[] |
+  "- \(.name) → \(.docs | join(", ")) (\(.version // "latest"))"
+' 2>/dev/null
+
+OVERFLOW=$((COUNT - 10))
+if [[ "$OVERFLOW" -gt 0 ]]; then
+  printf '- ...and %d more\n' "$OVERFLOW"
+fi
+
+if [[ "$CHECK_MODE" == "alert-and-verify" ]]; then
+  printf '\nWhen you need to verify → invoke `fresh-guides-verify` skill.\n'
+fi
+printf 'Run `/fresh-guides-setup` to configure, `/fresh-guides-show` to view, `/fresh-guides-update` to modify.\n'

--- a/plugins/fresh-guides/scripts/inject-rules.sh
+++ b/plugins/fresh-guides/scripts/inject-rules.sh
@@ -11,23 +11,6 @@ VERSION=$(jq -r '.version' "$PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null
 PROJECT_CONFIG="${CLAUDE_PROJECT_DIR:-.}/.claude-plugin/fresh-guides.json"
 GLOBAL_CONFIG="$HOME/.claude/fresh-guides.json"
 
-# Determine which config(s) to use
-PROJECT_WATCHLIST=""
-GLOBAL_WATCHLIST=""
-CHECK_MODE="alert-and-verify"
-
-if [[ -f "$PROJECT_CONFIG" ]]; then
-  PROJECT_WATCHLIST=$(jq -r '.watchlist // [] | length' "$PROJECT_CONFIG" 2>/dev/null || echo "0")
-  CHECK_MODE=$(jq -r '.checkMode // "alert-and-verify"' "$PROJECT_CONFIG" 2>/dev/null || echo "alert-and-verify")
-fi
-
-if [[ -f "$GLOBAL_CONFIG" ]]; then
-  GLOBAL_WATCHLIST=$(jq -r '.watchlist // [] | length' "$GLOBAL_CONFIG" 2>/dev/null || echo "0")
-  if [[ "$CHECK_MODE" == "alert-and-verify" && -z "$PROJECT_WATCHLIST" ]]; then
-    CHECK_MODE=$(jq -r '.checkMode // "alert-and-verify"' "$GLOBAL_CONFIG" 2>/dev/null || echo "alert-and-verify")
-  fi
-fi
-
 # Silent exit if no config
 if [[ ! -f "$PROJECT_CONFIG" && ! -f "$GLOBAL_CONFIG" ]]; then
   exit 0
@@ -59,22 +42,15 @@ fi
 printf '<!-- Source: Plugin fresh-guides@tribe-coding (v%s) -->\n' "$VERSION"
 printf '## Fresh Guides — Fast-Changing Technology Watchlist\n\n'
 printf 'These technologies change frequently — model training data may be outdated.\n'
-printf 'When the conversation involves any of them AND advice is version-specific:\n'
-
-if [[ "$CHECK_MODE" == "alert-and-verify" ]]; then
-  printf '1. **Alert**: "fresh-guides: <name> is on your fast-changing tech watchlist."\n'
-  printf '2. **Verify** by invoking the `fresh-guides-verify` skill BEFORE giving version-specific advice.\n'
-  printf '3. **Cite** the source URL and date when providing verified information.\n\n'
-else
-  printf '1. **Alert**: "fresh-guides: <name> is on your fast-changing tech watchlist — verify before relying on my answer."\n\n'
-fi
+printf 'When the conversation involves any of them AND advice is version-specific,\n'
+printf 'invoke the `fresh-guides-verify` skill BEFORE giving advice.\n\n'
 
 printf '**Watchlist:**\n'
 
 # Format each entry: name → docs (version)
 echo "$MERGED" | jq -r '
   .[:10] | .[] |
-  "- \(.name) → \(.docs | join(", ")) (\(.version // "latest"))"
+  "- \(.name) → \(.docs | join(", "))"
 ' 2>/dev/null
 
 OVERFLOW=$((COUNT - 10))
@@ -82,7 +58,4 @@ if [[ "$OVERFLOW" -gt 0 ]]; then
   printf '- ...and %d more\n' "$OVERFLOW"
 fi
 
-if [[ "$CHECK_MODE" == "alert-and-verify" ]]; then
-  printf '\nWhen you need to verify → invoke `fresh-guides-verify` skill.\n'
-fi
-printf 'Run `/fresh-guides-setup` to configure, `/fresh-guides-show` to view, `/fresh-guides-update` to modify.\n'
+printf '\nRun `/fresh-guides-setup` to configure, `/fresh-guides-show` to view, `/fresh-guides-update` to modify.\n'

--- a/plugins/fresh-guides/skills/fresh-guides-verify/SKILL.md
+++ b/plugins/fresh-guides/skills/fresh-guides-verify/SKILL.md
@@ -2,9 +2,9 @@
 name: fresh-guides-verify
 description: >
   Invoked automatically when discussing a technology on the fresh-guides watchlist.
-  Provides verification procedure: fetch official docs, compare with training data,
-  cite sources. Do NOT give version-specific advice for watched technologies
-  without consulting this skill first.
+  Provides verification procedure: detect version, fetch official docs for that version,
+  compare with training data, cite sources. Do NOT give version-specific advice for
+  watched technologies without consulting this skill first.
   Keywords: fresh-guides verify, check docs, fast-changing technology, outdated knowledge, version check.
 ---
 
@@ -19,7 +19,6 @@ A technology on the user's fresh-guides watchlist was detected in the conversati
 Find the matching entry in the watchlist (injected by SessionStart). Note:
 - The technology `name` from the watchlist
 - The configured `docs` URLs
-- The `version` constraint (usually "latest")
 
 ### 2. Determine the current version
 
@@ -44,34 +43,41 @@ Identify the specific claim, API, behavior, config syntax, or default that could
 Use `WebFetch` on the configured doc URLs to find information about the specific topic:
 
 1. Try the most specific doc URL first (e.g., API reference > general docs)
-2. If the page is too large or doesn't contain the answer, use `WebSearch` with a targeted query:
-   `"<technology> <specific feature/API> official documentation <current year>"`
-3. For release notes / changelogs, search for the specific version or recent changes
+2. When the official docs have versioned URLs (e.g., `/v1.6.x/`, `/latest/`), target the URL for the user's specific version — not "latest"
+3. If the page is too large or doesn't contain the answer, use `WebSearch` with a targeted query:
+   `"<technology> <version> <specific feature/API> official documentation"`
+4. For release notes / changelogs, search for the specific version or recent changes
 
 **Fallback chain:** configured docs URL → WebSearch official docs → WebSearch general → state "could not verify"
 
-### 5. Compare and respond
+### 5. Compare with user's version and respond
 
-Based on what you found:
+After verification, explicitly compare the feature/behavior with the user's version:
+
+- **Feature available in user's version:** State it clearly: "Supported in your version (vX.Y.Z, added in vA.B)."
+- **Feature NOT available in user's version:** Warn explicitly: "Requires vA.B+. Your vX.Y.Z does not support it." Suggest a workaround if one exists for their version.
+- **Behavior changed between versions:** Note what differs: "In your vX.Y.Z, the default is A. In vA.B+ it changed to B."
+
+Based on what you found from docs:
 
 **Docs confirm your knowledge:**
-> Verified against official docs ([source](url), fetched YYYY-MM-DD).
+> Include the answer with inline citation.
 
 **Docs contradict your knowledge:**
-> **Note:** My training data may be outdated here. According to the official docs as of YYYY-MM-DD: [corrected information]. Source: [url]
+> **Note:** My training data may be outdated here. According to the official docs: [corrected information]. [Source: url]
 
 **Could not verify:**
-> **Note:** I could not verify this against official docs. My answer is based on training data (cutoff: [date]). Please double-check at: [configured doc URLs]
+> **Note:** I could not verify this against official docs. My answer is based on training data. Please double-check at: [configured doc URLs]
 
 ### 6. Citation format
 
 Always include inline citations when providing verified information:
 
 ```
-[Source: domain.com/path, YYYY-MM-DD]
+[Source: domain.com/path/to/versioned/page]
 ```
 
-Place the citation after the specific claim it supports, not at the end of the entire response.
+Place the citation after the specific claim it supports, not at the end of the entire response. Use version-specific URLs when the documentation site supports them.
 
 ## Important
 

--- a/plugins/fresh-guides/skills/fresh-guides-verify/SKILL.md
+++ b/plugins/fresh-guides/skills/fresh-guides-verify/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: fresh-guides-verify
+description: >
+  Invoked automatically when discussing a technology on the fresh-guides watchlist.
+  Provides verification procedure: fetch official docs, compare with training data,
+  cite sources. Do NOT give version-specific advice for watched technologies
+  without consulting this skill first.
+  Keywords: fresh-guides verify, check docs, fast-changing technology, outdated knowledge, version check.
+---
+
+# Fresh Guides — Verification Procedure
+
+A technology on the user's fresh-guides watchlist was detected in the conversation. Follow this procedure BEFORE giving version-specific advice.
+
+## Steps
+
+### 1. Identify the matched technology
+
+Find the matching entry in the watchlist (injected by SessionStart). Note:
+- The technology `name` from the watchlist
+- The configured `docs` URLs
+- The `version` constraint (usually "latest")
+
+### 2. Determine the current version
+
+Before giving any advice, establish which version of the technology is in use:
+
+1. **Check the project** — look for version pins in lockfiles, config files, or dependency manifests (e.g., `terraform { required_version }`, `package.json`, `go.mod`, `.tool-versions`, Dockerfile `FROM` tags, provider version constraints).
+2. **Check runtime** — if the tool is available locally, run its version command (e.g., `terraform version`, `kubectl version --client`, `aws --version`).
+3. **If neither works** — ask the user: "Which version of **<technology>** are you using?" Do NOT assume "latest" — the user may be on an older version with different behavior.
+
+All subsequent verification MUST target the specific version identified in this step.
+
+### 3. Determine what needs verification
+
+Identify the specific claim, API, behavior, config syntax, or default that could have changed since training cutoff. Not everything needs verification:
+
+**Verify:** API signatures, default values, config syntax, deprecations, new features, pricing, limits, CLI flags, provider arguments, service quotas.
+
+**Skip verification:** General concepts, design patterns, architectural principles, well-established fundamentals that don't change across versions.
+
+### 4. Fetch official documentation
+
+Use `WebFetch` on the configured doc URLs to find information about the specific topic:
+
+1. Try the most specific doc URL first (e.g., API reference > general docs)
+2. If the page is too large or doesn't contain the answer, use `WebSearch` with a targeted query:
+   `"<technology> <specific feature/API> official documentation <current year>"`
+3. For release notes / changelogs, search for the specific version or recent changes
+
+**Fallback chain:** configured docs URL → WebSearch official docs → WebSearch general → state "could not verify"
+
+### 5. Compare and respond
+
+Based on what you found:
+
+**Docs confirm your knowledge:**
+> Verified against official docs ([source](url), fetched YYYY-MM-DD).
+
+**Docs contradict your knowledge:**
+> **Note:** My training data may be outdated here. According to the official docs as of YYYY-MM-DD: [corrected information]. Source: [url]
+
+**Could not verify:**
+> **Note:** I could not verify this against official docs. My answer is based on training data (cutoff: [date]). Please double-check at: [configured doc URLs]
+
+### 6. Citation format
+
+Always include inline citations when providing verified information:
+
+```
+[Source: domain.com/path, YYYY-MM-DD]
+```
+
+Place the citation after the specific claim it supports, not at the end of the entire response.
+
+## Important
+
+- NEVER silently use training data for version-specific advice on watched technologies
+- NEVER skip verification because "I'm fairly confident" — the whole point is that confidence can be misplaced for fast-changing tech
+- If WebFetch/WebSearch fails, say so explicitly — do not fall back to training data silently
+- Keep verification efficient — fetch only what's needed, don't read entire documentation sites

--- a/plugins/fresh-guides/templates/fresh-guides.json
+++ b/plugins/fresh-guides/templates/fresh-guides.json
@@ -1,0 +1,4 @@
+{
+  "watchlist": [],
+  "checkMode": "alert-and-verify"
+}

--- a/plugins/fresh-guides/templates/fresh-guides.json
+++ b/plugins/fresh-guides/templates/fresh-guides.json
@@ -1,4 +1,3 @@
 {
-  "watchlist": [],
-  "checkMode": "alert-and-verify"
+  "watchlist": []
 }

--- a/plugins/git-branch-naming/.claude-plugin/plugin.json
+++ b/plugins/git-branch-naming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-branch-naming",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Git branch naming convention enforcement: validates names, warns on content mismatch before push",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/git-branch-naming/README.md
+++ b/plugins/git-branch-naming/README.md
@@ -6,7 +6,7 @@
 A Claude Code plugin that enforces git branch naming conventions. Validates branch names before creation, warns when staged/pushed files don't match the branch type, and protects against direct pushes to main branches.
 
 > [!NOTE]
-> [💡 Why](#why-this-plugin-exists) · [🎬 Usage Examples](#usage-examples) · [📐 Format](#branch-name-format) · [📦 Installation](#installation) · [⚙️ Configuration](#configuration) · [👥 Team Setup](#team-setup-workflow) · [🔍 Mismatch](#content-mismatch) · [🪝 Pre-push](#pre-push-hook) · [🏗️ Architecture](#architecture) · [💰 Token Cost](#token-cost) · [🧪 Testing](#testing) · [📚 References](#references)
+> [💡 Why](#why-this-plugin-exists) · [🎬 Usage Examples](#usage-examples) · [📦 Installation](#installation) · [📐 Format](#branch-name-format) · [⚙️ Configuration](#configuration) · [👥 Team Setup](#team-setup-workflow) · [🔍 Mismatch](#content-mismatch) · [🪝 Pre-push](#pre-push-hook) · [🏗️ Architecture](#architecture) · [💰 Token Cost](#token-cost) · [🧪 Testing](#testing) · [📚 References](#references)
 
 ## ✅ What It Does <a name="what-it-does"></a>
 
@@ -122,22 +122,6 @@ This is usually done via a pull request instead of a direct push. Are you sure?
 
 Your team uses JIRA and wants strict enforcement. One dev runs `/git-branch-naming:setup`, commits `.claude-plugin/git-branch-naming.json`, and from that point every teammate's Claude Code session enforces the same rules — no onboarding docs required.
 
-## 📐 Branch Name Format <a name="branch-name-format"></a>
-
-```
-<prefix>/<kebab-case-description>
-```
-
-Valid prefixes: `feature`, `bugfix`, `hotfix`, `release`, `docs`, `test`, `chore`, `refactor`
-
-Examples:
-- ✅ `feature/user-auth`
-- ✅ `bugfix/fix-login-redirect`
-- ✅ `docs/update-readme`
-- ❌ `my-feature` — missing prefix
-- ❌ `Feature/UserAuth` — wrong case
-- ❌ `feature/user_auth` — underscore not allowed
-
 ## 📦 Installation <a name="installation"></a>
 
 ```bash
@@ -157,6 +141,22 @@ Then run the setup wizard to configure your branch naming conventions:
 This creates `.claude-plugin/git-branch-naming.json` with your project's conventions. Commit it to git to share with your team.
 
 **Requirements:** bash 3.2+, git, jq (scripts fall back to defaults if jq is unavailable)
+
+## 📐 Branch Name Format <a name="branch-name-format"></a>
+
+```
+<prefix>/<kebab-case-description>
+```
+
+Valid prefixes: `feature`, `bugfix`, `hotfix`, `release`, `docs`, `test`, `chore`, `refactor`
+
+Examples:
+- ✅ `feature/user-auth`
+- ✅ `bugfix/fix-login-redirect`
+- ✅ `docs/update-readme`
+- ❌ `my-feature` — missing prefix
+- ❌ `Feature/UserAuth` — wrong case
+- ❌ `feature/user_auth` — underscore not allowed
 
 ## ⚙️ Configuration <a name="configuration"></a>
 

--- a/plugins/kb-grooming/.claude-plugin/plugin.json
+++ b/plugins/kb-grooming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-grooming",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Documentation health analysis: structural checks, semantic compliance, and GitHub issue creation",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/kb-grooming/README.md
+++ b/plugins/kb-grooming/README.md
@@ -6,7 +6,7 @@
 Documentation health analysis for Claude Code projects. Scans all markdown files for structural problems and semantic compliance, then creates a GitHub epic with linked issues for each finding group.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [⚡ Commands](#commands) · [📦 Installation](#installation) · [⚙️ Setup](#setup) · [📝 Config](#config) · [🔗 Dependencies](#dependencies)
+> [📦 Installation](#installation) · [⚙️ How it works](#how-it-works) · [⚡ Commands](#commands) · [⚙️ Setup](#setup) · [📝 Config](#config) · [🔗 Dependencies](#dependencies)
 
 ## 🎬 Demo <a name="demo"></a>
 
@@ -42,6 +42,12 @@ Created issues:
 
 If you decline issue creation, the full report is saved to `docs/audit/kb-grooming-report-2026-02-28.md`.
 
+## 📦 Installation <a name="installation"></a>
+
+```bash
+/plugin install kb-grooming@tribe-coding
+```
+
 ## ⚙️ How it works <a name="how-it-works"></a>
 
 ```
@@ -73,12 +79,6 @@ If you decline issue creation, the full report is saved to `docs/audit/kb-groomi
 |---------|-------------|
 | `/kb-groom` | Run full documentation health analysis |
 | `/kb-grooming-setup` | Interactive configuration wizard |
-
-## 📦 Installation <a name="installation"></a>
-
-```bash
-/plugin install kb-grooming@tribe-coding
-```
 
 ## ⚙️ Setup <a name="setup"></a>
 

--- a/plugins/playbook/.claude-plugin/plugin.json
+++ b/plugins/playbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Curated presets of coding guidelines injected into sessions on demand",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/playbook/presets/readme.md
+++ b/plugins/playbook/presets/readme.md
@@ -13,6 +13,7 @@ MANDATORY: README.md is the project's landing page. First 5 lines MUST answer "w
 - After header block (motto + intro paragraph) → add a nav line as `> [!NOTE]` GitHub Alert. **NEVER include the first H2 section** — it is always visible above the fold. This is a hard rule: do not add it "for completeness", do not add it when there are few sections, do not add it for any reason. Do NOT include GitHub community files in nav (see Navigation Line reference section) but DO reference them in a section at the bottom. Include all other H2 sections. Use ` · ` as separator. No "Scroll to:" prefix. Add explicit `<a name="...">` anchor to each emoji heading: `## ⚙️ How it works <a name="how-it-works"></a>`. Then nav links use the explicit anchor: `[⚙️ How it works](#how-it-works)`
 - Use emoji in headings (🚀 📦 ⚡ ⚙️) unless user explicitly forbids it
 - For tools/CLIs/plugins → lead with a concrete demo (real input → real output), NOT a feature list
+- Installation MUST be the first section after Demo (or after the first introductory section if no Demo). Never bury it behind How it works, Commands, or other sections — the reader who liked the demo wants to install next
 - Installation: official method only — no workarounds; merge Quick Start + Installation into one section
 - Every install/usage instruction MUST include a copy-pasteable command block — no placeholder-only steps
 - When a README section exceeds 20 lines → extract to `docs/<topic>.md` and replace with a one-line summary + link

--- a/plugins/technology-explainer/.claude-plugin/plugin.json
+++ b/plugins/technology-explainer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "technology-explainer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Adapts explanation depth based on user proficiency per technology: expert, intermediate, or learning",
   "author": { "name": "Tribe Coding" },
   "license": "MIT",

--- a/plugins/technology-explainer/README.md
+++ b/plugins/technology-explainer/README.md
@@ -6,7 +6,7 @@
 Configure your proficiency level per technology and Claude automatically adjusts its explanation depth: expert gets terse answers, learning gets theory and examples.
 
 > [!NOTE]
-> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🎮 Commands](#commands) · [📝 Config](#config)
+> [📦 Installation](#installation) · [⚙️ How it works](#how-it-works) · [🎮 Commands](#commands) · [📝 Config](#config)
 
 ## 🎬 Demo <a name="demo"></a>
 
@@ -85,6 +85,22 @@ persistent rules. `PostToolUse` hooks can match specific tools via the
 `matcher` field (e.g., `Edit`, `Write`) — leave it empty to match all tools.
 ```
 
+## 📦 Installation <a name="installation"></a>
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install technology-explainer@tribe-coding
+/plugin
+```
+
+Select **technology-explainer** → enable **auto-update**. Then run the setup wizard:
+
+```
+/technology-explainer-setup
+```
+
+Restart your session for changes to take effect.
+
 ## ⚙️ How it works <a name="how-it-works"></a>
 
 Three proficiency levels control Claude's explanation depth:
@@ -104,22 +120,6 @@ Three proficiency levels control Claude's explanation depth:
 | Unlisted technology | Asks for proficiency level, saves choice, then explains |
 
 **Scope:** Rules apply ONLY to conversational explanations in the terminal. Code comments, docstrings, and project documentation follow project conventions.
-
-## 📦 Installation <a name="installation"></a>
-
-```bash
-/plugin marketplace add Tribe-Coding/claude-plugins
-/plugin install technology-explainer@tribe-coding
-/plugin
-```
-
-Select **technology-explainer** → enable **auto-update**. Then run the setup wizard:
-
-```
-/technology-explainer-setup
-```
-
-Restart your session for changes to take effect.
 
 ## 🎮 Commands <a name="commands"></a>
 


### PR DESCRIPTION
## Summary

- New **fresh-guides** plugin (v0.1.0) — watchlist for fast-changing technologies that verifies advice against official docs before responding
- SessionStart hook injects compact watchlist + verification rules into context
- Auto-invoked `fresh-guides-verify` skill: detects current version (project files → runtime → ask user), fetches version-specific official docs via WebFetch/WebSearch, cites sources, warns about version-incompatible features
- Setup wizard probes candidate doc URLs via WebFetch before proposing as checkboxes
- Commands: `/fresh-guides-setup`, `/fresh-guides-show`, `/fresh-guides-update` (add/remove/url)
- Config merging: project `.claude-plugin/fresh-guides.json` overrides global `~/.claude/fresh-guides.json`
- Registered in marketplace, CLAUDE.md, and root README
- Moved Installation section right after Demo across 5 existing plugin READMEs (kb-grooming, context, git-branch-naming, technology-explainer) + added rule to playbook readme preset
- Version bumps: kb-grooming v0.1.6, context v0.9.1, git-branch-naming v0.3.7, technology-explainer v0.2.2, playbook v0.10.6

Closes #309

## Test plan

- [x] Static checks pass (plugin.json, hooks.json, template, SKILL.md frontmatter, script executable)
- [x] Script unit tests pass (full config, silent exits, project-overrides-global merge, version marker, no alert line)
- [ ] Manual: SessionStart integration (fresh session with watchlist config)
- [ ] Manual: `/fresh-guides-setup` wizard flow with URL probing
- [ ] Manual: `/fresh-guides-show` and `/fresh-guides-update` commands
- [ ] Manual: `fresh-guides-verify` skill — version detection, doc fetch, version-specific citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)