### PR TITLE
docs: add cross-links between fresh-guides and technology-explainer

### DIFF
--- a/plugins/fresh-guides/README.md
+++ b/plugins/fresh-guides/README.md
@@ -5,6 +5,8 @@
 
 Configure a watchlist of fast-changing technologies and Claude automatically verifies advice against official documentation before responding.
 
+Pair with [`technology-explainer`](../technology-explainer/README.md) plugin for full coverage: `fresh-guides` controls *how reliably* Claude answers (checking official docs), `technology-explainer` controls *how much* it explains (depth based on your proficiency).
+
 > [!NOTE]
 > [📦 Installation](#installation) · [⚙️ How it works](#how-it-works) · [🎮 Commands](#commands) · [📝 Config](#config)
 
@@ -96,7 +98,6 @@ Restart your session for changes to take effect.
 
 **Scope:** Verification triggers only for version-specific advice (API signatures, config syntax, defaults, deprecations). General concepts and design patterns are answered normally.
 
-**Complements [technology-explainer](../technology-explainer/README.md):** Technology-explainer controls explanation *depth* (brief vs detailed). Fresh-guides controls *accuracy verification* (check docs vs trust weights). A technology can be in both configs.
 
 ## 🎮 Commands <a name="commands"></a>
 

--- a/plugins/technology-explainer/README.md
+++ b/plugins/technology-explainer/README.md
@@ -5,6 +5,8 @@
 
 Configure your proficiency level per technology and Claude automatically adjusts its explanation depth: expert gets terse answers, learning gets theory and examples.
 
+Pair with [`fresh-guides`](../fresh-guides/README.md) plugin for full coverage: `technology-explainer` controls *how much* Claude explains (depth), `fresh-guides` controls *how reliably* — by verifying against official docs before answering about fast-changing technologies.
+
 > [!NOTE]
 > [📦 Installation](#installation) · [⚙️ How it works](#how-it-works) · [🎮 Commands](#commands) · [📝 Config](#config)
 


### PR DESCRIPTION
## Summary

- Add "Pair with..." cross-links in the intro section of both plugin READMEs
- `technology-explainer` → links to `fresh-guides` (accuracy verification)
- `fresh-guides` → links to `technology-explainer` (explanation depth)

## Test plan

- [x] Links resolve correctly (relative paths between sibling plugin dirs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)