### PR TITLE
Add Mermaid diagram plugin for native-rendering markdown docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,6 +4,11 @@
   "owner": { "name": "Tribe Coding" },
   "plugins": [
     {
+      "name": "mermaid",
+      "source": "./plugins/mermaid",
+      "description": "Mermaid diagram automation: proactive diagrams in markdown, Kroki-backed syntax validation, pre-commit check"
+    },
+    {
       "name": "plantuml",
       "source": "./plugins/plantuml",
       "description": "PlantUML diagram automation: auto-sync URLs in markdown, pre-commit validation, CI checks"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ A marketplace of reusable Claude Code plugins (`Tribe Coding`). Each plugin live
 - **fresh-guides** — Watchlist for fast-changing technologies: verifies advice against official docs
 - **git-branch-naming** — Enforces branch naming conventions (prefix/kebab-case)
 - **kb-grooming** — Documentation health analysis: structural checks, semantic compliance, GitHub issues
+- **mermaid** — Proactive Mermaid diagrams in markdown; Kroki-backed syntax validation on save
 - **plantuml** — Keeps PlantUML diagram URLs in sync; provides ASCII rendering in terminal
 - **playbook** — Injects curated coding guideline presets into sessions
 - **retroscope** — Generates retrospective reports summarizing sessions

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/
 | [**fresh-guides**](plugins/fresh-guides/README.md) | Watchlist for fast-changing technologies — verify advice against official docs before responding |
 | [**git-branch-naming**](plugins/git-branch-naming/README.md) | Enforce branch naming conventions automatically; warns before push if the name or staged content doesn't match |
 | [**kb-grooming**](plugins/kb-grooming/README.md) | Audit documentation health — broken links, orphan files, README compliance — then create a GitHub epic with linked issues |
+| [**mermaid**](plugins/mermaid/README.md) | Proactively add Mermaid diagrams to markdown (native rendering in GitHub/Obsidian); syntax-validated on save via Kroki |
 | [**plantuml**](plugins/plantuml/README.md) | Proactively add rendered diagrams to docs (image URLs auto-synced); draw ASCII diagrams inline during terminal conversations |
 | [**playbook**](plugins/playbook/README.md) | Inject team coding conventions into every session — git workflow, documentation standards, platform quirks |
 | [**retroscope**](plugins/retroscope/README.md) | Capture what happened each session and generate structured daily retrospective reports |

--- a/plugins/mermaid/.claude-plugin/plugin.json
+++ b/plugins/mermaid/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "mermaid",
+  "version": "0.1.0",
+  "description": "Mermaid diagram automation: proactive diagrams in markdown, syntax validation, diagram type guide",
+  "author": {
+    "name": "Tribe Coding"
+  },
+  "license": "MIT",
+  "commands": [
+    "./commands/"
+  ],
+  "skills": [
+    "./skills/"
+  ]
+}

--- a/plugins/mermaid/CHANGELOG.md
+++ b/plugins/mermaid/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0 — 2026-04-15
+
+- Initial release.
+- SessionStart hook injects Mermaid base rules.
+- PostToolUse hook validates Mermaid blocks in `.md` files via Kroki after Write/Edit.
+- Pre-commit hook installed in projects to block commits with invalid Mermaid syntax (marker-delimited, non-destructive).
+- `mermaid-diagram-guide` skill covering 6 common types: flowchart, sequence, state, class, ER, gantt.
+- `/mermaid-validate` command for on-demand repo-wide validation.
+- `/mermaid-uninstall` command to remove the pre-commit section.
+- Self-hosted Kroki supported via `MERMAID_KROKI_URL` env var.

--- a/plugins/mermaid/README.md
+++ b/plugins/mermaid/README.md
@@ -1,0 +1,95 @@
+# Mermaid
+
+> [!TIP]
+> ✨ ***Native markdown diagrams, validated on save — Claude picks the type, draws, and catches syntax errors.***
+
+With this plugin, Claude proactively adds [Mermaid](https://mermaid.js.org) diagrams to your markdown docs. They render natively in GitHub, Obsidian, VS Code, and most modern viewers — no image URL, no round-trip. Every edit is validated against Kroki so syntax errors surface immediately.
+
+> [!NOTE]
+> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🗑️ Uninstall](#uninstall) · [📚 Reference](#reference)
+
+## 🎬 Demo <a name="demo"></a>
+
+A developer asks Claude to document the login flow. Claude picks a sequence diagram, writes it inline, and the validator confirms the block parses.
+
+```markdown
+> Document the login flow for the auth service.
+
+✦ Using skill: mermaid-diagram-guide
+
+I'll create docs/auth.md. Four actors and a request/response pattern — sequence diagram.
+
+● Write(docs/auth.md)
+  ┌────────────────────────────────────────────────────────┐
+  │ # Auth Service                                         │
+  │                                                        │
+  │ ## Login Request Flow                                  │
+  │                                                        │
+  │ ```mermaid                                             │
+  │ sequenceDiagram                                        │
+  │     title: Login Request Flow                          │
+  │     actor User                                         │
+  │     participant Web                                    │
+  │     participant API                                    │
+  │     participant DB                                     │
+  │     User->>Web: POST /login                            │
+  │     Web->>API: forward credentials                     │
+  │     API->>DB: SELECT user WHERE email = ?              │
+  │     DB-->>API: user row                                │
+  │     API-->>Web: 200 + token                            │
+  │     Web-->>User: redirect + cookie                     │
+  │ ```                                                    │
+  └────────────────────────────────────────────────────────┘
+
+⏺ Done — docs/auth.md created. Block validated by Kroki. GitHub/Obsidian will render it inline.
+```
+
+## ⚙️ How it works <a name="how-it-works"></a>
+
+A Mermaid diagram is a single fenced ` ```mermaid ` block. Unlike PlantUML, there is no separate image URL — the target viewer renders the source directly.
+
+| Trigger | What happens |
+|---------|-------------|
+| SessionStart | Injects diagram formatting rules and the mermaid-vs-plantuml decision guide |
+| PostToolUse (Write/Edit on `.md`) | Validates every `mermaid` block by POSTing to Kroki; reports syntax errors to stderr |
+| SessionStart (in a git repo) | Installs a pre-commit hook section that blocks commits with invalid mermaid syntax |
+| Before creating any diagram | `mermaid-diagram-guide` skill invoked automatically — picks the right type from 6 common options |
+
+### When to pick Mermaid vs PlantUML
+
+- **Mermaid**: GitHub/Obsidian-bound docs, simple flowcharts, quick sequences, lightweight ERD, project gantts. Default for most `.md` documentation.
+- **PlantUML**: complex UML (timing, deployment, nwdiag, Salt wireframes), nested components, fine styling, in-terminal ASCII rendering.
+
+## 📦 Installation <a name="installation"></a>
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install mermaid@tribe-coding
+/plugin
+```
+
+Select **mermaid** → enable **auto-update**. Restart your session — done.
+
+**Requirements:** Python 3.x (stdlib only) and network access to `https://kroki.io`. To run offline or avoid rate limits, set `MERMAID_KROKI_URL` to a self-hosted instance:
+
+```bash
+docker run -d -p 8000:8000 yuzutech/kroki
+export MERMAID_KROKI_URL=http://localhost:8000
+```
+
+## 🗑️ Uninstall <a name="uninstall"></a>
+
+The plugin installs a pre-commit hook section that validates Mermaid syntax before each commit. To remove it from a project:
+
+```
+/mermaid-uninstall
+```
+
+This removes only the mermaid section from your pre-commit hook. Other hook sections (eslint, prettier, plantuml, etc.) are preserved. If the mermaid section was the only content, the hook file is deleted entirely.
+
+## 📚 Reference <a name="reference"></a>
+
+- [`CHANGELOG.md`](CHANGELOG.md) — version history
+- [`docs/ACCEPTANCE_TESTS.md`](docs/ACCEPTANCE_TESTS.md) — test suite
+- [Mermaid syntax reference](https://mermaid.js.org) — upstream docs
+- [Kroki](https://kroki.io) — the validation backend

--- a/plugins/mermaid/commands/mermaid-uninstall/SKILL.md
+++ b/plugins/mermaid/commands/mermaid-uninstall/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: mermaid-uninstall
+description: >
+  Remove the Mermaid pre-commit validation hook from the current project.
+  Removes only the mermaid marker-delimited section, preserving other hook content.
+---
+
+# Mermaid Uninstall
+
+Remove the Mermaid pre-commit hook section from the current project's git hooks.
+
+## Instructions
+
+1. Run the uninstall script:
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/uninstall-hook.sh"
+   ```
+   `CLAUDE_PLUGIN_ROOT` is set automatically by Claude Code when running plugin commands.
+
+2. Report the result to the user:
+   - If the mermaid section was the only content, the hook file is deleted entirely.
+   - If other hook sections exist, only the mermaid section is removed and the rest is preserved.
+   - If no mermaid section was found, inform the user that nothing needed to be removed.

--- a/plugins/mermaid/commands/mermaid-validate/SKILL.md
+++ b/plugins/mermaid/commands/mermaid-validate/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: mermaid-validate
+description: >
+  Validate the syntax of all Mermaid diagrams in markdown files across the project
+  by submitting each block to Kroki. Reports syntax errors with file and line.
+compatibility: Requires Python 3.x and network access to Kroki (https://kroki.io by default).
+---
+
+# Mermaid Validate
+
+Validate syntax of all Mermaid diagram blocks in markdown files.
+
+## Instructions
+
+1. Find all `.md` files in the project that contain Mermaid code blocks:
+   ```bash
+   grep -rl '```mermaid' . --include='*.md'
+   ```
+
+2. Run the validator on all found files:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/validate-mermaid.py" <files>
+   ```
+   `CLAUDE_PLUGIN_ROOT` is set automatically by Claude Code when running plugin commands.
+
+3. Report results to the user:
+   - If all diagrams are valid: confirm success with file and block count.
+   - If syntax errors found: list each issue with file, line, and error message from Kroki.
+   - If network was unreachable: mention validation was skipped (fail-soft).
+
+4. If the user wants offline or faster validation, suggest setting `MERMAID_KROKI_URL` to a self-hosted Kroki instance (`docker run -d -p 8000:8000 yuzutech/kroki`).

--- a/plugins/mermaid/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/mermaid/docs/ACCEPTANCE_TESTS.md
@@ -1,0 +1,93 @@
+# Mermaid Plugin — Acceptance Tests
+
+Each test describes setup, expected behavior, and how to verify.
+
+## 1. Manifest validity
+
+**Setup:** fresh checkout.
+**Run:**
+```bash
+cat plugins/mermaid/.claude-plugin/plugin.json | jq .
+```
+**Expect:** valid JSON with `name`, `version`, `commands`, `skills` fields.
+
+## 2. Marketplace registration
+
+**Run:**
+```bash
+jq '.plugins[] | select(.name == "mermaid")' .claude-plugin/marketplace.json
+```
+**Expect:** non-empty object.
+
+## 3. SessionStart rules injection
+
+**Run:**
+```bash
+bash plugins/mermaid/scripts/inject-rules.sh
+```
+**Expect:** stdout contains "Mermaid Diagrams in Markdown — Base Rules" and "ALWAYS invoke the `mermaid-diagram-guide` skill".
+
+## 4. Validator — valid block
+
+**Setup:** `/tmp/ok.md` containing:
+```
+\`\`\`mermaid
+flowchart TD
+    A --> B
+\`\`\`
+```
+**Run:**
+```bash
+python3 plugins/mermaid/scripts/validate-mermaid.py /tmp/ok.md
+```
+**Expect:** exit 0, no stderr.
+
+## 5. Validator — invalid block
+
+**Setup:** `/tmp/bad.md` containing a mermaid block with `A --->>>> B`.
+**Run:** same command, path `/tmp/bad.md`.
+**Expect:** exit 1, stderr contains `mermaid block #1 invalid:` with a Kroki error message.
+
+## 6. Validator — no blocks
+
+**Setup:** `/tmp/plain.md` with plain text, no mermaid fences.
+**Expect:** exit 0, no stderr.
+
+## 7. Validator — non-markdown file
+
+**Run:**
+```bash
+echo '{"tool_input":{"file_path":"/tmp/foo.py"}}' | bash plugins/mermaid/scripts/validate-on-edit.sh
+```
+**Expect:** no Kroki call, silent exit 0.
+
+## 8. Validator — network offline (fail-soft)
+
+**Setup:** `MERMAID_KROKI_URL=http://127.0.0.1:1` and a file containing a mermaid block.
+**Expect:** exit 0, stderr warns "Kroki unreachable".
+
+## 9. Pre-commit install/uninstall
+
+**Setup:** a scratch git repo.
+**Run:** `bash plugins/mermaid/scripts/setup-project.sh`
+**Expect:** `.githooks/pre-commit` exists with `# >>> tribe-coding/mermaid >>>` markers; `core.hooksPath = .githooks`.
+**Run:** `bash plugins/mermaid/scripts/uninstall-hook.sh`
+**Expect:** markers removed, other hook content preserved (or file deleted if it was the only content).
+
+## 10. Pre-commit blocks invalid commits
+
+**Setup:** scratch repo with plugin's pre-commit installed; stage a `.md` with an invalid mermaid block.
+**Run:** `git commit -m test`
+**Expect:** commit rejected with "Commit blocked: Mermaid diagrams have syntax errors".
+
+## 11. Live plugin — rules in session
+
+**Setup:** install plugin locally via `/plugin marketplace add` + `/plugin install mermaid@tribe-coding`.
+**Run:** in a new session, `/context:ctx-show`.
+**Expect:** base rules visible; `mermaid-diagram-guide` skill listed.
+
+## 12. Live plugin — proactive diagram
+
+**Setup:** installed plugin, new session.
+**Prompt:** "Document the login flow in `docs/auth.md`".
+**Expect:** Claude invokes `mermaid-diagram-guide`, writes a `mermaid` block (no image URL), and PostToolUse validation reports no errors.

--- a/plugins/mermaid/hooks/hooks.json
+++ b/plugins/mermaid/hooks/hooks.json
@@ -1,0 +1,32 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/validate-on-edit.sh\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/inject-rules.sh\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-project.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/mermaid/scripts/inject-rules.sh
+++ b/plugins/mermaid/scripts/inject-rules.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# SessionStart hook: inject Mermaid formatting rules into Claude's context.
+# The full diagram type catalog is available on-demand via the mermaid-diagram-guide skill.
+
+cat <<'RULES'
+## Mermaid Diagrams in Markdown — Base Rules
+
+Mermaid diagrams render natively in GitHub, Obsidian, VS Code, and most modern markdown viewers. No image URL is needed — just a fenced `mermaid` code block.
+
+Format:
+- A fenced ```mermaid code block with the diagram source. Nothing else.
+- Do NOT add an image link after the block (unlike PlantUML).
+
+Proactive usage:
+- When creating/updating `.md` docs, proactively add Mermaid diagrams for flowcharts, sequences, state machines, class relationships, ER schemas, and gantt timelines.
+- Prefer Mermaid for: GitHub/Obsidian-bound docs, simple flowcharts, quick sequences, lightweight ERD. Default choice for most `.md` documentation.
+- Prefer PlantUML (if installed) for: complex UML (timing, deployment, nwdiag, wireframes), component diagrams with nested packages, diagrams requiring specific styling control.
+- Terminal rendering is NOT supported. For in-terminal diagrams, use the PlantUML plugin (ASCII rendering). With Mermaid, write to `.md` and direct the user to view in GitHub/Obsidian/IDE.
+
+Diagram conventions:
+- Every diagram MUST include a title where the type supports it: `title: ...` for sequence, class, state; `title ...` for gantt; first-line comment `%% Title: ...` otherwise. Self-documenting diagrams only.
+- Supported types in v0.1.0 guide: flowchart, sequence, state, class, ER, gantt. For other Mermaid types (pie, journey, mindmap, timeline, etc.), consult upstream docs at https://mermaid.js.org.
+- **ALWAYS invoke the `mermaid-diagram-guide` skill BEFORE creating any Mermaid diagram** to choose the correct diagram type. This is MANDATORY — do not skip this step even if you think you know which type to use.
+
+Validation:
+- The PostToolUse hook validates every `mermaid` block after Write/Edit on `.md` files by POSTing to Kroki (https://kroki.io). Syntax errors are surfaced to stderr (non-blocking).
+- Set `MERMAID_KROKI_URL` to point at a self-hosted Kroki instance if public kroki.io is unavailable or rate-limited.
+- On network failure, validation is skipped silently (fail-soft).
+RULES

--- a/plugins/mermaid/scripts/setup-project.sh
+++ b/plugins/mermaid/scripts/setup-project.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SessionStart hook: install Mermaid pre-commit validation in the current project.
+# Non-destructive — uses marker-based injection to coexist with existing hooks.
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+# Only run in git repos
+if ! git -C "$PROJECT_DIR" rev-parse --git-dir > /dev/null 2>&1; then
+  exit 0
+fi
+
+TEMPLATE="$PLUGIN_ROOT/templates/pre-commit"
+
+if [ ! -f "$TEMPLATE" ]; then
+  exit 0
+fi
+
+# Determine hooks directory: respect existing core.hooksPath, default to .githooks
+HOOKS_DIR=$(git -C "$PROJECT_DIR" config --local core.hooksPath 2>/dev/null)
+if [ -z "$HOOKS_DIR" ]; then
+  HOOKS_DIR=".githooks"
+  git -C "$PROJECT_DIR" config core.hooksPath "$HOOKS_DIR"
+fi
+
+# Resolve relative hooks dir against project root
+case "$HOOKS_DIR" in
+  /*) HOOK_FILE="$HOOKS_DIR/pre-commit" ;;
+  *)  HOOK_FILE="$PROJECT_DIR/$HOOKS_DIR/pre-commit" ;;
+esac
+
+mkdir -p "$(dirname "$HOOK_FILE")"
+
+MARKER_BEGIN="# >>> tribe-coding/mermaid >>>"
+MARKER_END="# <<< tribe-coding/mermaid <<<"
+SECTION=$(cat "$TEMPLATE")
+
+if [ -f "$HOOK_FILE" ]; then
+  if grep -qF "$MARKER_BEGIN" "$HOOK_FILE"; then
+    BEFORE_LINE=$(grep -nF "$MARKER_BEGIN" "$HOOK_FILE" | head -1 | cut -d: -f1)
+    AFTER_LINE=$(grep -nF "$MARKER_END" "$HOOK_FILE" | head -1 | cut -d: -f1)
+    TOTAL=$(wc -l < "$HOOK_FILE")
+
+    {
+      if [ "$BEFORE_LINE" -gt 1 ]; then
+        head -n "$(( BEFORE_LINE - 1 ))" "$HOOK_FILE"
+      fi
+      printf '%s\n' "$SECTION"
+      if [ "$AFTER_LINE" -lt "$TOTAL" ]; then
+        tail -n "$(( TOTAL - AFTER_LINE ))" "$HOOK_FILE"
+      fi
+    } > "$HOOK_FILE.tmp"
+    mv "$HOOK_FILE.tmp" "$HOOK_FILE"
+  else
+    printf '\n%s\n' "$SECTION" >> "$HOOK_FILE"
+  fi
+else
+  {
+    printf '#!/bin/bash\n\n'
+    printf '%s\n' "$SECTION"
+  } > "$HOOK_FILE"
+fi
+
+chmod +x "$HOOK_FILE"
+
+exit 0

--- a/plugins/mermaid/scripts/uninstall-hook.sh
+++ b/plugins/mermaid/scripts/uninstall-hook.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Remove the mermaid pre-commit hook section from the current project.
+# Uses marker-based detection to only remove the mermaid section,
+# preserving other hook content.
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+if ! git -C "$PROJECT_DIR" rev-parse --git-dir > /dev/null 2>&1; then
+  echo "Not a git repository. Nothing to uninstall."
+  exit 1
+fi
+
+HOOKS_DIR=$(git -C "$PROJECT_DIR" config --local core.hooksPath 2>/dev/null)
+if [ -z "$HOOKS_DIR" ]; then
+  HOOKS_DIR=".githooks"
+fi
+
+case "$HOOKS_DIR" in
+  /*) HOOK_FILE="$HOOKS_DIR/pre-commit" ;;
+  *)  HOOK_FILE="$PROJECT_DIR/$HOOKS_DIR/pre-commit" ;;
+esac
+
+if [ ! -f "$HOOK_FILE" ]; then
+  echo "No pre-commit hook found at $HOOK_FILE. Nothing to uninstall."
+  exit 0
+fi
+
+MARKER_BEGIN="# >>> tribe-coding/mermaid >>>"
+MARKER_END="# <<< tribe-coding/mermaid <<<"
+
+if ! grep -qF "$MARKER_BEGIN" "$HOOK_FILE"; then
+  echo "No mermaid section found in $HOOK_FILE. Nothing to uninstall."
+  exit 0
+fi
+
+BEFORE_LINE=$(grep -nF "$MARKER_BEGIN" "$HOOK_FILE" | head -1 | cut -d: -f1)
+AFTER_LINE=$(grep -nF "$MARKER_END" "$HOOK_FILE" | head -1 | cut -d: -f1)
+TOTAL=$(wc -l < "$HOOK_FILE")
+
+{
+  if [ "$BEFORE_LINE" -gt 1 ]; then
+    head -n "$(( BEFORE_LINE - 1 ))" "$HOOK_FILE"
+  fi
+  if [ "$AFTER_LINE" -lt "$TOTAL" ]; then
+    tail -n "$(( TOTAL - AFTER_LINE ))" "$HOOK_FILE"
+  fi
+} > "$HOOK_FILE.tmp"
+
+if ! grep -qvE '^(#!/|[[:space:]]*$)' "$HOOK_FILE.tmp" 2>/dev/null; then
+  rm -f "$HOOK_FILE" "$HOOK_FILE.tmp"
+  echo "Removed $HOOK_FILE (no other hook sections remaining)."
+else
+  mv "$HOOK_FILE.tmp" "$HOOK_FILE"
+  chmod +x "$HOOK_FILE"
+  echo "Removed mermaid section from $HOOK_FILE. Other hook sections preserved."
+fi
+
+exit 0

--- a/plugins/mermaid/scripts/validate-mermaid.py
+++ b/plugins/mermaid/scripts/validate-mermaid.py
@@ -107,7 +107,8 @@ def validate_block(source: str) -> tuple[bool, str]:
             try:
                 body = e.read().decode("utf-8", errors="replace").strip()
             except Exception:
-                pass
+                # Body read/decode is best-effort — we still have e.code to report.
+                body = ""
             return False, _extract_error(body) or f"HTTP {e.code}"
         except urllib.error.URLError as e:
             if isinstance(e.reason, ssl.SSLError):

--- a/plugins/mermaid/scripts/validate-mermaid.py
+++ b/plugins/mermaid/scripts/validate-mermaid.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Validate Mermaid diagram blocks in markdown files against Kroki.
+
+Usage:
+    validate-mermaid.py <file.md> [<file.md> ...]
+
+Behavior:
+- Extracts every ```mermaid ... ``` block from each file.
+- POSTs each block to Kroki (default https://kroki.io/mermaid/svg).
+- 200 = valid, 400 = parse error (message printed to stderr).
+- Network/timeout errors are fail-soft: warning to stderr, exit 0.
+- Exit code: 0 if all blocks valid or network unreachable; 1 if any block has a parse error.
+  (The PostToolUse wrapper always exits 0 — non-blocking. The pre-commit path uses this exit code.)
+
+Env:
+    MERMAID_KROKI_URL — override default Kroki base URL (e.g. http://localhost:8000).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+KROKI_URL = os.environ.get("MERMAID_KROKI_URL", "https://kroki.io").rstrip("/")
+ENDPOINT = f"{KROKI_URL}/mermaid/svg"
+TIMEOUT = 5.0
+
+BLOCK_RE = re.compile(r"^```mermaid\s*\n(.*?)\n```", re.DOTALL | re.MULTILINE)
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    """Build an SSL context that works across environments.
+
+    Try, in order: certifi (if installed), common system CA bundles, the
+    default context. As a last resort — if all above fail to verify — fall
+    back to an unverified context. We only read the HTTP status from the
+    response, not content, so this is acceptable for a best-effort validator.
+    """
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        pass
+    for cafile in (
+        "/etc/ssl/cert.pem",
+        "/etc/ssl/certs/ca-certificates.crt",
+        "/usr/local/etc/openssl/cert.pem",
+        "/opt/homebrew/etc/ca-certificates/cert.pem",
+    ):
+        if os.path.exists(cafile):
+            try:
+                return ssl.create_default_context(cafile=cafile)
+            except ssl.SSLError:
+                continue
+    return ssl.create_default_context()
+
+
+_SSL_CTX = _build_ssl_context()
+_SSL_CTX_UNVERIFIED = ssl._create_unverified_context()
+
+
+_TSPAN_RE = re.compile(r"<tspan[^>]*>(.*?)</tspan>", re.DOTALL)
+
+
+def _extract_error(body: str) -> str:
+    """Kroki returns an SVG with <tspan> lines on 400. Extract the error lines
+    and join them into a single short message. Fall back to raw body otherwise.
+    """
+    if not body:
+        return ""
+    if body.lstrip().startswith("<") and "<tspan" in body:
+        lines = [m.group(1).strip() for m in _TSPAN_RE.finditer(body)]
+        lines = [ln for ln in lines if ln and not ln.startswith("at ")]
+        if lines:
+            return " | ".join(lines)
+    return body.splitlines()[0][:300] if body else ""
+
+
+def validate_block(source: str) -> tuple[bool, str]:
+    """Return (ok, message). ok=True on 200, ok=False on 400 with error body.
+
+    On network error, returns (True, "<network-skip>") — fail-soft: we don't know
+    if the diagram is valid, so we don't block.
+    """
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=source.encode("utf-8"),
+        headers={
+            "Content-Type": "text/plain",
+            "User-Agent": "tribe-coding-mermaid-plugin/0.1 (+https://github.com/Tribe-Coding/claude-plugins)",
+            "Accept": "image/svg+xml",
+        },
+        method="POST",
+    )
+    for ctx in (_SSL_CTX, _SSL_CTX_UNVERIFIED):
+        try:
+            with urllib.request.urlopen(req, timeout=TIMEOUT, context=ctx) as resp:
+                if resp.status == 200:
+                    return True, ""
+                return False, f"Kroki returned HTTP {resp.status}"
+        except urllib.error.HTTPError as e:
+            body = ""
+            try:
+                body = e.read().decode("utf-8", errors="replace").strip()
+            except Exception:
+                pass
+            return False, _extract_error(body) or f"HTTP {e.code}"
+        except urllib.error.URLError as e:
+            if isinstance(e.reason, ssl.SSLError):
+                continue  # retry with unverified context
+            return True, f"<network-skip: {e}>"
+        except (TimeoutError, OSError) as e:
+            return True, f"<network-skip: {e}>"
+    return True, "<network-skip: SSL verification failed with all contexts>"
+
+
+def line_of_offset(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def check_file(path: str) -> int:
+    """Return count of invalid blocks in this file."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"{path}: cannot read ({e})", file=sys.stderr)
+        return 0
+
+    invalid = 0
+    network_skipped = False
+
+    for i, match in enumerate(BLOCK_RE.finditer(content), start=1):
+        source = match.group(1)
+        line = line_of_offset(content, match.start())
+        ok, msg = validate_block(source)
+        if ok and msg.startswith("<network-skip"):
+            if not network_skipped:
+                print(
+                    f"{path}: mermaid validation skipped (Kroki unreachable: {msg})",
+                    file=sys.stderr,
+                )
+                network_skipped = True
+            continue
+        if not ok:
+            print(
+                f"{path}:{line}: mermaid block #{i} invalid: {msg}",
+                file=sys.stderr,
+            )
+            invalid += 1
+
+    return invalid
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: validate-mermaid.py <file.md> [<file.md> ...]", file=sys.stderr)
+        return 0
+
+    total_invalid = 0
+    for path in argv[1:]:
+        total_invalid += check_file(path)
+
+    return 1 if total_invalid > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/plugins/mermaid/scripts/validate-on-edit.sh
+++ b/plugins/mermaid/scripts/validate-on-edit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Claude Code PostToolUse hook: validate Mermaid blocks after editing .md files.
+# Reads tool input from stdin, checks if the file is .md, and runs the validator.
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ "$FILE_PATH" == *.md ]]; then
+  python3 "$PLUGIN_ROOT/scripts/validate-mermaid.py" "$FILE_PATH" 2>&1
+fi
+
+exit 0

--- a/plugins/mermaid/skills/mermaid-diagram-guide/SKILL.md
+++ b/plugins/mermaid/skills/mermaid-diagram-guide/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: mermaid-diagram-guide
+description: >
+  Invoked automatically before creating Mermaid diagrams to select the correct type.
+  Covers 6 common types: flowchart, sequence, state, class, ER, gantt.
+  Do NOT create Mermaid without consulting this guide.
+  Keywords: mermaid, diagram type, which diagram, flowchart, sequence diagram, ER diagram, gantt.
+---
+
+# Mermaid Diagram Type Guide
+
+Use this guide to choose the right Mermaid diagram type for documentation. When creating or updating `.md` files, proactively suggest and use the appropriate diagram type.
+
+**IMPORTANT:** Every diagram MUST include a title where the syntax supports it:
+- `sequenceDiagram` / `classDiagram` / `stateDiagram-v2` / `erDiagram`: use `title: ...` frontmatter block (see syntax column)
+- `gantt`: `title ...` directive
+- `flowchart`: prepend a `%% Title: ...` comment on line 1
+
+## Mermaid vs PlantUML — which to pick
+
+- **Mermaid** (this plugin): GitHub/Obsidian/VS Code docs, simple flowcharts, quick sequences, lightweight ERD, project gantts. Renders natively — no image URL needed.
+- **PlantUML** (separate plugin): complex UML (timing, deployment, nwdiag, wireframes/Salt), nested components, fine-grained styling, in-terminal ASCII rendering.
+- When in doubt for simple docs → Mermaid. When you need UML rigor → PlantUML.
+
+## Diagram Types (v0.1.0)
+
+| Type | When to use | When to suggest | Syntax |
+|------|-------------|-----------------|--------|
+| **Flowchart** | Decision trees, branching logic, algorithm flow, CI/CD pipelines, process flow | Any "how does this work step by step" doc; decision logs; script/pipeline flow | `flowchart TD` / `LR` with `A --> B`, `A -->|label| B`, `{Decision}`, `[[Subroutine]]` |
+| **Sequence** | Interactions between services, API request/response, message passing, auth flows | Spec files describing inter-service communication; new API endpoints; event flows | `sequenceDiagram` with `A->>B: msg`, `B-->>A: reply`, `activate`/`deactivate`, `alt`/`loop` |
+| **State** | State machines, object lifecycles, session/connection states, workflow statuses | Code with state transitions; specs describing distinct behavioral states; workflow engines | `stateDiagram-v2` with `[*] --> Active`, `Active --> Idle`, nested states |
+| **Class** | Class hierarchies, interfaces, data models (Pydantic/dataclasses), entity structure | Adding new model classes; refactoring hierarchies; storage/query object docs | `classDiagram` with `class Name { +field: Type; +method() }`, `A <|-- B`, `A --> B` |
+| **ER** | Database schemas, table relationships with cardinality (1:1, 1:N, M:N) | Any database storage design; schema docs; migration planning | `erDiagram` with `USER \|\|--o{ ORDER : places`, attribute blocks |
+| **Gantt** | Project timelines, phase planning, task dependencies, milestones | Roadmap docs; sprint/phase planning; release schedules | `gantt` with `title ...`, `dateFormat YYYY-MM-DD`, `section`, `task :id, YYYY-MM-DD, Nd` |
+
+## Quick Selection Guide
+
+- **"Who sends what to whom?"** → Sequence
+- **"What's the algorithm/decision flow?"** → Flowchart
+- **"What states can this be in?"** → State
+- **"What do the classes look like?"** → Class
+- **"What's in the database?"** → ER
+- **"What's the project timeline?"** → Gantt
+
+## Required Conventions
+
+1. **Title first.** Every diagram must have a title. Self-documenting diagrams only.
+2. **No image link.** Unlike PlantUML, Mermaid renders natively in GitHub/Obsidian/IDE. Do NOT add an image URL after the code block.
+3. **Fenced block.** Always ` ```mermaid `, never bare ` ``` ` or alternative fences.
+4. **Keep it simple.** If the diagram needs > 20 nodes or heavy styling, consider splitting it or switching to PlantUML.
+
+## Quick Examples
+
+### Flowchart
+```mermaid
+%% Title: Login decision flow
+flowchart TD
+    A[Login request] --> B{Credentials valid?}
+    B -->|Yes| C[Issue token]
+    B -->|No| D[Return 401]
+    C --> E[Set cookie]
+```
+
+### Sequence
+```mermaid
+sequenceDiagram
+    title: Login Request Flow
+    actor User
+    participant Web
+    participant API
+    participant DB
+    User->>Web: POST /login
+    Web->>API: forward credentials
+    API->>DB: SELECT user
+    DB-->>API: user row
+    API-->>Web: 200 + token
+    Web-->>User: redirect + cookie
+```
+
+### State
+```mermaid
+stateDiagram-v2
+    title: Connection lifecycle
+    [*] --> Connecting
+    Connecting --> Connected: success
+    Connecting --> Failed: timeout
+    Connected --> Closed: user close
+    Failed --> [*]
+    Closed --> [*]
+```
+
+### ER
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "ordered in"
+    USER {
+      uuid id PK
+      string email
+    }
+    ORDER {
+      uuid id PK
+      uuid user_id FK
+      timestamp created_at
+    }
+```
+
+### Gantt
+```mermaid
+gantt
+    title Q2 roadmap
+    dateFormat YYYY-MM-DD
+    section Backend
+    Auth rewrite      :a1, 2026-04-01, 14d
+    Rate limiting     :after a1, 7d
+    section Frontend
+    Settings page     :2026-04-10, 10d
+```
+
+### Class
+```mermaid
+classDiagram
+    title: Payment domain
+    class Payment {
+      +UUID id
+      +Money amount
+      +charge()
+      +refund()
+    }
+    class StripePayment {
+      +String stripeId
+      +charge()
+    }
+    Payment <|-- StripePayment
+```

--- a/plugins/mermaid/templates/pre-commit
+++ b/plugins/mermaid/templates/pre-commit
@@ -1,0 +1,27 @@
+# >>> tribe-coding/mermaid >>>
+# Mermaid syntax validation — installed by mermaid Claude Code plugin.
+# Do not edit between markers; managed automatically by setup-project.sh.
+MERMAID_STAGED_MD=$(git diff --cached --name-only --diff-filter=ACM -- '*.md')
+
+if [ -n "$MERMAID_STAGED_MD" ]; then
+    MERMAID_VALIDATOR=""
+    for candidate in \
+        "$HOME/.claude/plugins/cache/tribe-coding/mermaid/scripts/validate-mermaid.py" \
+        "$HOME/.claude/plugins/marketplaces/tribe-coding/plugins/mermaid/scripts/validate-mermaid.py" \
+        "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/validate-mermaid.py"; do
+        if [ -f "$candidate" ]; then
+            MERMAID_VALIDATOR="$candidate"
+            break
+        fi
+    done
+
+    if [ -n "$MERMAID_VALIDATOR" ]; then
+        if ! python3 "$MERMAID_VALIDATOR" $MERMAID_STAGED_MD; then
+            echo ""
+            echo "Commit blocked: Mermaid diagrams have syntax errors."
+            echo "  Fix the errors reported above, or set MERMAID_KROKI_URL if Kroki is unreachable."
+            exit 1
+        fi
+    fi
+fi
+# <<< tribe-coding/mermaid <<<


### PR DESCRIPTION
## Summary
- Claude now proactively adds [Mermaid](https://mermaid.js.org) diagrams to markdown docs — no image URL, no hosting, renders natively in GitHub/Obsidian/VS Code.
- Every `.md` edit is syntax-validated against Kroki; errors surface immediately instead of showing up as red error boxes on GitHub.
- Ships a pre-commit hook that blocks commits with broken Mermaid, a 6-type diagram guide skill, and `/mermaid-validate` + `/mermaid-uninstall` commands.

## Why
PlantUML is already solid for complex UML and terminal ASCII rendering, but it's overkill when you just want a quick flowchart or sequence in a README. For docs that live on GitHub or in Obsidian, Mermaid is the natural fit — the viewer renders the source directly, so there's no encoding round-trip and no image to keep in sync.

The plugins are complementary, not overlapping:
- **Mermaid** → simple flowcharts, quick sequences, lightweight ERD, gantt, anything GitHub/Obsidian-bound
- **PlantUML** → complex UML, deployment/timing/nwdiag, Salt wireframes, terminal ASCII

Validation matters because broken Mermaid renders as a loud red error box on GitHub. Catching it on save (and at commit time) keeps that out of main.

## Changes
- New plugin at `plugins/mermaid/` mirroring the `plantuml/` structure: manifest, hooks, scripts, skill guide, commands, templates, docs, README, CHANGELOG.
- SessionStart hook injects base rules + mandatory skill reference; runs `setup-project.sh` to install the pre-commit section (marker-delimited, non-destructive).
- PostToolUse hook on Write/Edit for `.md` runs `validate-mermaid.py`, which POSTs each block to Kroki (`https://kroki.io` by default; override with `MERMAID_KROKI_URL` for self-hosted). Fail-soft on network errors; extracts clean error text from Kroki's SVG 400 response.
- SSL handling: tries certifi → common system CA bundles → default context → unverified fallback, so it works across macOS python.org, Homebrew, and Linux installs.
- Registered in `.claude-plugin/marketplace.json`, root `README.md` plugins table, and root `CLAUDE.md` plugins list (alphabetical).

## Test plan
- [x] `jq . plugins/mermaid/.claude-plugin/plugin.json` — valid manifest
- [x] Validator on valid block → exit 0, silent
- [x] Validator on invalid block → exit 1, clean extracted Kroki error
- [x] Validator on non-`.md` via wrapper → silent exit 0
- [x] Install / uninstall pre-commit cycle in scratch git repo → marker-delimited, cleanly removed
- [ ] Install locally via `/plugin marketplace add` + `/plugin install mermaid@tribe-coding`; confirm base rules in `/context:ctx-show`
- [ ] New session: "Document X in docs/foo.md" → Claude invokes `mermaid-diagram-guide`, writes a valid `mermaid` block, PostToolUse reports no errors
- [ ] Manually break the block, re-save → validator surfaces syntax error to stderr
- [ ] Stage an invalid diagram + `git commit` → blocked by pre-commit