### PR TITLE
mermaid: teach semantic styling, shape vocabulary, accessibility (v0.2.0)

### DIFF
--- a/plugins/mermaid/.claude-plugin/plugin.json
+++ b/plugins/mermaid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mermaid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Mermaid diagram automation: proactive diagrams in markdown, syntax validation, diagram type guide",
   "author": {
     "name": "Tribe Coding"

--- a/plugins/mermaid/CHANGELOG.md
+++ b/plugins/mermaid/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.0 — 2026-04-15
+
+- Skill guide now teaches semantic styling: shape vocabulary (cylinder = storage, hexagon = orchestrator, stadium = actor, etc.), `linkStyle` color palette (blue = data, orange = control, green = storage, purple = feedback), and a default `classDef` set (storage, external, critical, deprecated).
+- Added recommended `%%{init}%%` layout block for flowcharts over ~8 nodes (curve, nodeSpacing, rankSpacing, htmlLabels).
+- Accessibility: `accTitle` and `accDescr` directives are now required for every supported diagram type.
+- Added `click` handler example for linking nodes to source files / external docs.
+- Flowchart example rewritten to demonstrate the full styling pattern; minimal example retained for quick READMEs.
+
 ## 0.1.0 — 2026-04-15
 
 - Initial release.

--- a/plugins/mermaid/scripts/inject-rules.sh
+++ b/plugins/mermaid/scripts/inject-rules.sh
@@ -19,8 +19,10 @@ Proactive usage:
 
 Diagram conventions:
 - Every diagram MUST include a title where the type supports it: `title: ...` for sequence, class, state; `title ...` for gantt; first-line comment `%% Title: ...` otherwise. Self-documenting diagrams only.
-- Supported types in v0.1.0 guide: flowchart, sequence, state, class, ER, gantt. For other Mermaid types (pie, journey, mindmap, timeline, etc.), consult upstream docs at https://mermaid.js.org.
-- **ALWAYS invoke the `mermaid-diagram-guide` skill BEFORE creating any Mermaid diagram** to choose the correct diagram type. This is MANDATORY — do not skip this step even if you think you know which type to use.
+- Every diagram MUST include `accTitle: ...` and `accDescr: ...` where supported (flowchart, sequence, class, state, ER) — screen readers rely on these.
+- For flowcharts, use shapes *semantically* (cylinder = storage, hexagon = orchestrator, stadium = actor, rhombus = decision) and apply `linkStyle` colors for meaning (blue = data, orange = control, green = storage, purple = feedback). Define reusable `classDef` entries instead of styling nodes inline.
+- Supported types in guide: flowchart, sequence, state, class, ER, gantt. For other Mermaid types (pie, journey, mindmap, timeline, architecture-beta), consult upstream docs at https://mermaid.js.org.
+- **ALWAYS invoke the `mermaid-diagram-guide` skill BEFORE creating any Mermaid diagram** to choose the correct diagram type AND review the Styling & Semantics section. This is MANDATORY — do not skip this step even if you think you know which type to use.
 
 Validation:
 - The PostToolUse hook validates every `mermaid` block after Write/Edit on `.md` files by POSTing to Kroki (https://kroki.io). Syntax errors are surfaced to stderr (non-blocking).

--- a/plugins/mermaid/skills/mermaid-diagram-guide/SKILL.md
+++ b/plugins/mermaid/skills/mermaid-diagram-guide/SKILL.md
@@ -22,7 +22,7 @@ Use this guide to choose the right Mermaid diagram type for documentation. When 
 - **PlantUML** (separate plugin): complex UML (timing, deployment, nwdiag, wireframes/Salt), nested components, fine-grained styling, in-terminal ASCII rendering.
 - When in doubt for simple docs → Mermaid. When you need UML rigor → PlantUML.
 
-## Diagram Types (v0.1.0)
+## Diagram Types
 
 | Type | When to use | When to suggest | Syntax |
 |------|-------------|-----------------|--------|
@@ -48,23 +48,126 @@ Use this guide to choose the right Mermaid diagram type for documentation. When 
 2. **No image link.** Unlike PlantUML, Mermaid renders natively in GitHub/Obsidian/IDE. Do NOT add an image URL after the code block.
 3. **Fenced block.** Always ` ```mermaid `, never bare ` ``` ` or alternative fences.
 4. **Keep it simple.** If the diagram needs > 20 nodes or heavy styling, consider splitting it or switching to PlantUML.
+5. **Accessibility.** Add `accTitle: ...` and `accDescr: ...` directives for every diagram that supports them (flowchart, sequence, class, state, ER) — screen readers use these.
+
+## Styling & Semantics
+
+A monochrome, rectangle-only diagram is usually worse than no diagram. Use shapes and colors *semantically* — meaning that an informed reader can infer a node's role from its appearance.
+
+### Shape vocabulary (flowchart)
+
+| Shape | Syntax | Meaning |
+|-------|--------|---------|
+| Rectangle | `A[Name]` | Default — generic step or component |
+| Rounded | `A(Name)` | Process or action |
+| Stadium | `A([Name])` | Actor or external user |
+| Cylinder | `A[(Name)]` | Persistent storage (DB, file store, cache) |
+| Hexagon | `A{{Name}}` | Orchestrator, router, decision coordinator |
+| Rhombus | `A{Name?}` | Decision / conditional branch |
+| Subroutine | `A[[Name]]` | Call into another flow/module |
+| Parallelogram | `A[/Name/]` | Input or output artifact |
+| Trapezoid | `A[\Name\]` | Manual/human step |
+
+### Link semantics (flowchart)
+
+Apply `linkStyle` to convey intent. Index `linkStyle` entries are zero-based in order of appearance.
+
+| Color | Use for |
+|-------|---------|
+| Blue `#2563eb` | Primary data flow (request, payload, event stream) |
+| Orange `#ea580c` | Control / command (trigger, invocation, signal) |
+| Green `#16a34a` | Storage read/write (persistence ops) |
+| Purple `#9333ea` | Feedback / loop-back (retry, backpressure, callback) |
+| Gray dashed | Optional, async, or error path |
+
+Use `linkStyle default stroke:#64748b,stroke-width:1.5px` as a baseline, then override specific edges.
+
+### Node classes (`classDef`)
+
+Define named classes once, apply to any set of nodes. Use these four defaults unless the diagram needs more:
+
+```
+classDef storage fill:#ecfdf5,stroke:#16a34a,color:#064e3b;
+classDef external fill:#fef3c7,stroke:#d97706,color:#78350f;
+classDef critical fill:#fee2e2,stroke:#dc2626,color:#7f1d1d;
+classDef deprecated fill:#f1f5f9,stroke:#94a3b8,color:#475569,stroke-dasharray: 5 5;
+class DB,Cache storage;
+class StripeAPI external;
+class AuthGate critical;
+class LegacyCron deprecated;
+```
+
+### Layout and spacing
+
+Prepend an `%%{init}%%` block to control layout without hand-tuning. Use these defaults for anything over ~8 nodes:
+
+```
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':70,'rankSpacing':100,'htmlLabels':true}}}%%
+```
+
+- `curve: 'basis'` — smooth orthogonal routing (alternatives: `'linear'`, `'step'`)
+- `nodeSpacing` / `rankSpacing` — horizontal/vertical breathing room
+- `htmlLabels: true` — enables `<br/>` in labels for multi-line text
+
+### Interactivity (when relevant)
+
+Mermaid supports `click` handlers — useful in docs where a node maps to a source file or external resource:
+
+```
+click AuthService "https://github.com/acme/repo/blob/main/auth/service.py" "Auth service source"
+```
+
+Don't overdo it — every `click` adds noise. Use only when the link is genuinely the reader's next question.
 
 ## Quick Examples
 
-### Flowchart
+### Flowchart (with full styling)
+
+A production-quality flowchart uses shapes, link semantics, `classDef`, `accTitle`, and `%%{init}%%` together. This example shows the full pattern — adapt, don't copy verbatim.
+
 ```mermaid
-%% Title: Login decision flow
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':70,'rankSpacing':100}}}%%
 flowchart TD
+    accTitle: Login request flow
+    accDescr: Browser submits credentials; auth service checks the user database and returns a token on success or a 401 on failure.
+
+    User([User]) -->|POST /login| Web(Web App)
+    Web --> Auth{{Auth Service}}
+    Auth -->|lookup| DB[(User DB)]
+    DB -->|row| Auth
+    Auth -->|valid?| Decide{Credentials valid?}
+    Decide -->|Yes| Token[/JWT token/]
+    Decide -->|No| Deny[Return 401]
+    Token --> Cookie[Set cookie]
+
+    classDef storage fill:#ecfdf5,stroke:#16a34a,color:#064e3b;
+    classDef critical fill:#fee2e2,stroke:#dc2626,color:#7f1d1d;
+    class DB storage;
+    class Deny critical;
+
+    linkStyle default stroke:#64748b,stroke-width:1.5px
+    linkStyle 0,1 stroke:#2563eb,stroke-width:2px
+    linkStyle 2,3 stroke:#16a34a,stroke-width:2px
+```
+
+### Flowchart (minimal)
+
+For a quick decision in a README, skip the theming:
+
+```mermaid
+flowchart TD
+    accTitle: Login decision
     A[Login request] --> B{Credentials valid?}
     B -->|Yes| C[Issue token]
     B -->|No| D[Return 401]
-    C --> E[Set cookie]
 ```
 
 ### Sequence
 ```mermaid
 sequenceDiagram
     title: Login Request Flow
+    accTitle: Login Request Flow
+    accDescr: User posts credentials, web app forwards to API, API queries database, token is returned and cookie is set.
     actor User
     participant Web
     participant API


### PR DESCRIPTION
## Summary
- Claude will now produce Mermaid flowcharts with semantic shapes (cylinder = storage, hexagon = orchestrator, stadium = actor) and colored arrows (blue = data, orange = control, green = storage, purple = feedback) instead of monochrome rectangles.
- Every diagram gains \`accTitle\` / \`accDescr\` for screen readers — zero visual cost, big accessibility win.
- Readers can tell at a glance which nodes are databases, external services, or critical failure paths without reading labels.

## Why
Current first-draft diagrams are correct but visually flat. A rectangle-to-rectangle flowchart forces readers to parse every label to understand what each node is. Reviewing [fireworks-tech-graph](https://github.com/yizhiyanhua-ai/fireworks-tech-graph) surfaced a clear pattern: publish a small semantic vocabulary (shape + color) and reader comprehension jumps.

This is phase 1 of the follow-up tracked in #314 — styling only, no new diagram types and no code/hook changes.

Depends on #313 (v0.1.0). Base branch is set to \`feature/mermaid-plugin\` so this doesn't conflict; once #313 merges, this rebases cleanly onto main.

## Changes
- \`skills/mermaid-diagram-guide/SKILL.md\`: new **Styling & Semantics** section (shape table, linkStyle palette, classDef defaults, \`%%{init}%%\` layout block, \`click\` handler example). Accessibility added to Required Conventions.
- Flowchart example rewritten to demonstrate the full styling pattern. A second minimal example added for quick README use.
- Sequence example updated with \`accTitle\` / \`accDescr\`.
- \`scripts/inject-rules.sh\`: SessionStart rules now mention accessibility requirements, shape/color semantics, and point to the Styling section.
- Version bump 0.1.0 → 0.2.0; CHANGELOG entry.

## Test plan
- [x] All new Mermaid examples (styled flowchart, minimal flowchart, updated sequence) validate via Kroki — exit 0
- [x] \`inject-rules.sh\` output contains the new accessibility and styling guidance
- [x] \`plugin.json\` valid JSON, version 0.2.0
- [ ] Install locally, confirm styled flowchart renders correctly on GitHub (shapes distinct, arrow colors applied)
- [ ] Ask Claude to draw a system diagram in a fresh session; verify it invokes the skill and applies \`classDef\` + \`linkStyle\`

Tracks #314 (phase 1).