### PR TITLE
feat(plan-review): add plan-and-review plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,6 +14,11 @@
       "description": "PlantUML diagram automation: auto-sync URLs in markdown, pre-commit validation, CI checks"
     },
     {
+      "name": "plan-review",
+      "source": "./plugins/plan-review",
+      "description": "Plan-and-review pattern: a fresh-context subagent critiques a plan-mode plan for gaps and blind spots before any code is written"
+    },
+    {
       "name": "statusline",
       "source": "./plugins/statusline",
       "description": "Custom Claude Code statusline with API rate limits, context window, git info"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ A marketplace of reusable Claude Code plugins (`Tribe Coding`). Each plugin live
 - **git-branch-naming** — Enforces branch naming conventions (prefix/kebab-case)
 - **kb-grooming** — Documentation health analysis: structural checks, semantic compliance, GitHub issues
 - **mermaid** — Proactive Mermaid diagrams in markdown; Kroki-backed syntax validation on save
+- **plan-review** — Fresh-context subagent critiques a plan-mode plan for gaps and blind spots before code is written
 - **plantuml** — Keeps PlantUML diagram URLs in sync; provides ASCII rendering in terminal
 - **playbook** — Injects curated coding guideline presets into sessions
 - **retroscope** — Generates retrospective reports summarizing sessions

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A curated collection of plugins for [Claude Code](https://docs.anthropic.com/en/
 | [**git-branch-naming**](plugins/git-branch-naming/README.md) | Enforce branch naming conventions automatically; warns before push if the name or staged content doesn't match |
 | [**kb-grooming**](plugins/kb-grooming/README.md) | Audit documentation health — broken links, orphan files, README compliance — then create a GitHub epic with linked issues |
 | [**mermaid**](plugins/mermaid/README.md) | Proactively add Mermaid diagrams to markdown (native rendering in GitHub/Obsidian); syntax-validated on save via Kroki |
+| [**plan-review**](plugins/plan-review/README.md) | After plan mode produces a plan, a fresh-context subagent critiques it for gaps, blind spots, and ordering issues before any code is written |
 | [**plantuml**](plugins/plantuml/README.md) | Proactively add rendered diagrams to docs (image URLs auto-synced); draw ASCII diagrams inline during terminal conversations |
 | [**playbook**](plugins/playbook/README.md) | Inject team coding conventions into every session — git workflow, documentation standards, platform quirks |
 | [**retroscope**](plugins/retroscope/README.md) | Capture what happened each session and generate structured daily retrospective reports |

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "plan-review",
+  "version": "0.1.0",
+  "description": "Plan-and-review pattern: after plan mode produces a plan, a fresh-context subagent critiques it for gaps, blind spots, and ordering issues before any code is written",
+  "author": {
+    "name": "Tribe Coding"
+  },
+  "license": "MIT",
+  "commands": [
+    "./commands/"
+  ],
+  "skills": [
+    "./skills/"
+  ]
+}

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -1,0 +1,72 @@
+# plan-review
+
+> [!TIP]
+> ✨ ***Never implement an unreviewed plan — a fresh-context agent critiques it for blind spots before any code is written.***
+
+The plan-and-review pattern for Claude Code. After plan mode produces an implementation plan, a second agent with **fresh context** critiques it — surfacing gaps, blind spots, ordering problems, and missing edge cases that the planning agent cannot see because it authored the plan. Catches intent-level errors before tokens are burned generating broken code.
+
+> [!NOTE]
+> [⚙️ How it works](#how-it-works) · [📦 Installation](#installation) · [🛠️ Skills](#skills) · [📚 Reference](#reference)
+
+## 🎬 Demo <a name="demo"></a>
+
+```markdown
+You: [accepts a plan from plan mode]
+
+Claude: Want a fresh-context review of this plan first?
+
+You: yes
+
+Claude: Spawned a fresh-context reviewer. Findings:
+
+| Priority | Finding                                          | Suggestion                                              |
+|----------|--------------------------------------------------|---------------------------------------------------------|
+| CRITICAL | Migration step has no rollback path              | Add step 4b: wrap migration in a transaction with down  |
+| HIGH     | Step 3 assumes the cache is warm — never stated  | Add explicit cache-warm or cold-start handling to step 3|
+| MEDIUM   | No test named for the new error branch           | Name the test in step 6: test_auth_expired_token        |
+
+Verdict: REVISE (major)
+
+Revised plan applied. Here is the updated plan — review before I implement.
+```
+
+## ⚙️ How it works <a name="how-it-works"></a>
+
+| Trigger | What happens |
+|---------|-------------|
+| SessionStart | Injects plan-review rules — Claude offers a review after every accepted plan |
+| After `ExitPlanMode` | Claude proactively offers a fresh-context review before writing code |
+| `/review-plan` | Manually review a plan — including one pasted from another session or a document |
+
+The reviewer is a **fresh-context subagent** spawned via the `Task` tool. It receives only the plan text — never the planning conversation — so it does not inherit the planning agent's assumptions. It returns prioritized findings (CRITICAL / HIGH / MEDIUM / LOW), each with a concrete suggested change, plus a verdict.
+
+**Why fresh context:** the agent that wrote a plan cannot reliably review it — its context is anchored to the reasoning that produced the plan. A clean-context reviewer re-derives judgment from the artifact alone. Asking for a suggestion for *every* finding (not just the top few) forces the list to be exhausted.
+
+## 📦 Installation <a name="installation"></a>
+
+```bash
+/plugin marketplace add Tribe-Coding/claude-plugins
+/plugin install plan-review@tribe-coding
+```
+
+Select **plan-review** in `/plugin` → enable **auto-update**. Restart your session — done. No configuration required.
+
+## 🛠️ Skills <a name="skills"></a>
+
+| Skill | Type | Purpose |
+|-------|------|---------|
+| `review-plan` | Command | Manually trigger a fresh-context plan review (`/review-plan`) |
+| `plan-review-guide` | Skill | The review protocol — subagent prompt, prioritized findings, iteration |
+
+## 📚 Reference <a name="reference"></a>
+
+The review protocol runs in four steps:
+
+1. **Isolate the plan** — extract the plan artifact only; the planning chat is never passed on.
+2. **Spawn the reviewer** — a fresh-context `Task` subagent critiques the plan with a skeptical-reviewer prompt.
+3. **Apply the review** — show the findings table, revise the plan with the suggestions, present the revised plan.
+4. **Optional second pass** — re-review the revised plan for large or high-risk work; stop when no CRITICAL/HIGH findings remain.
+
+A `RECONSIDER APPROACH` verdict halts implementation — Claude surfaces it and asks how to proceed.
+
+The pattern originates from the plan-and-review workflow described by Matt Cary (Cloudflare) and Adam Stacoviak on The Changelog: have one model plan, hand the plan to a second model invocation with fresh context, ask it to list gaps and blind spots with priorities, and get a concrete suggestion for each before writing any code.

--- a/plugins/plan-review/commands/review-plan/SKILL.md
+++ b/plugins/plan-review/commands/review-plan/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: review-plan
+description: >
+  Manually trigger a fresh-context review of an implementation plan.
+  Use after exiting plan mode, or to review a plan pasted from another session or document.
+  Critiques the plan for gaps, blind spots, and ordering issues, then iterates it before any code.
+  Keywords: review plan, review-plan, critique plan, plan review, check my plan.
+---
+
+# Review Plan
+
+Run a fresh-context review of an implementation plan.
+
+## Steps
+
+### 1. Locate the plan
+
+- If a plan was just produced in this session (via plan mode / `ExitPlanMode`) → use that plan text.
+- If the user passed a plan as an argument or pasted one → use that.
+- If no plan is available → ask the user to paste the plan to review.
+
+### 2. Run the review protocol
+
+Invoke the `plan-review-guide` skill and follow its protocol exactly:
+
+- Isolate the plan artifact — pass only the plan text to the reviewer, never the planning chat.
+- Spawn a fresh-context `Task` subagent with the review prompt from the guide.
+- The review must produce prioritized findings with a concrete suggestion for **every** finding.
+
+### 3. Apply and present
+
+- Show the findings table verbatim.
+- Revise the plan with the suggestions (CRITICAL/HIGH always; MEDIUM/LOW unless the user opts out).
+- Present the revised plan and the verdict.
+- On a `RECONSIDER APPROACH` verdict → stop and ask the user how to proceed; do not implement.
+
+Implement only after the revised plan is accepted.

--- a/plugins/plan-review/docs/ACCEPTANCE_TESTS.md
+++ b/plugins/plan-review/docs/ACCEPTANCE_TESTS.md
@@ -1,0 +1,126 @@
+# Plan-Review Plugin Acceptance Tests
+
+## Purpose
+
+The plan-review plugin makes Claude run a fresh-context review of an implementation plan before writing code. These tests verify that required files are valid, the SessionStart hook injects rules correctly, and the proactive review behavior triggers as expected.
+
+## Test Execution Order
+
+1. Static checks (automated)
+2. Script unit tests — inject-rules.sh (automated)
+3. Behavioral tests — SessionStart rules (manual, fresh session)
+4. End-to-end — full plan-review workflow (manual)
+
+## Automation Status
+
+- ✅ Fully automated: Tests 1–2
+- ⚠️ Manual only: Tests 3–4 (require a fresh session and real plan mode usage)
+
+---
+
+## Test Categories
+
+### 1. Static Checks
+
+**Objective:** Verify file structure, YAML frontmatter, and JSON schema validity.
+
+**Automation:** ✅
+
+```bash
+PLUGIN="$(git rev-parse --show-toplevel)/plugins/plan-review"
+
+# 1.1 Check all required files exist
+for f in \
+  ".claude-plugin/plugin.json" \
+  "hooks/hooks.json" \
+  "scripts/inject-rules.sh" \
+  "commands/review-plan/SKILL.md" \
+  "skills/plan-review-guide/SKILL.md" \
+  "docs/ACCEPTANCE_TESTS.md" \
+  "README.md"; do
+  test -f "$PLUGIN/$f" && echo "✅ $f" || echo "❌ MISSING: $f"
+done
+
+# 1.2 Validate JSON files
+for f in ".claude-plugin/plugin.json" "hooks/hooks.json"; do
+  jq empty "$PLUGIN/$f" 2>/dev/null && echo "✅ JSON valid: $f" || echo "❌ Invalid JSON: $f"
+done
+
+# 1.3 inject-rules.sh is executable
+test -x "$PLUGIN/scripts/inject-rules.sh" && echo "✅ inject-rules.sh executable" || echo "❌ not executable"
+
+# 1.4 SKILL.md files have YAML frontmatter with name + description
+for f in "commands/review-plan/SKILL.md" "skills/plan-review-guide/SKILL.md"; do
+  head -1 "$PLUGIN/$f" | grep -q '^---$' \
+    && grep -q '^name:' "$PLUGIN/$f" \
+    && grep -q '^description:' "$PLUGIN/$f" \
+    && echo "✅ frontmatter OK: $f" || echo "❌ frontmatter missing: $f"
+done
+
+# 1.5 No duplicate skill name across commands/ and skills/
+CMD_NAME=$(grep '^name:' "$PLUGIN/commands/review-plan/SKILL.md" | head -1)
+SKILL_NAME=$(grep '^name:' "$PLUGIN/skills/plan-review-guide/SKILL.md" | head -1)
+[ "$CMD_NAME" != "$SKILL_NAME" ] && echo "✅ skill names distinct" || echo "❌ duplicate name: $CMD_NAME"
+```
+
+**Expected:** all lines print `✅`.
+
+---
+
+### 2. Script Unit Tests — inject-rules.sh
+
+**Objective:** Verify the SessionStart hook outputs the expected rules block.
+
+**Automation:** ✅
+
+```bash
+PLUGIN="$(git rev-parse --show-toplevel)/plugins/plan-review"
+OUT=$(bash "$PLUGIN/scripts/inject-rules.sh")
+
+# 2.1 Outputs the rules header
+echo "$OUT" | grep -q "Plan Review — Base Rules" && echo "✅ header present" || echo "❌ header missing"
+
+# 2.2 References the ExitPlanMode trigger
+echo "$OUT" | grep -q "ExitPlanMode" && echo "✅ trigger present" || echo "❌ trigger missing"
+
+# 2.3 Mandates the plan-review-guide skill
+echo "$OUT" | grep -q "plan-review-guide" && echo "✅ skill invocation present" || echo "❌ skill invocation missing"
+
+# 2.4 Exit code is 0 (never blocks session start)
+bash "$PLUGIN/scripts/inject-rules.sh" >/dev/null 2>&1 && echo "✅ exit 0" || echo "❌ non-zero exit"
+```
+
+**Expected:** all lines print `✅`.
+
+---
+
+### 3. Behavioral Tests — SessionStart Rules
+
+**Objective:** Verify the rules inject into a real session.
+
+**Automation:** ⚠️ Manual — requires a fresh session.
+
+| # | Step | Expected |
+|---|------|----------|
+| 3.1 | Install the plugin, start a fresh session | No errors at startup |
+| 3.2 | Run `/context` | "Plan Review — Base Rules" appears in the SessionStart hook output |
+| 3.3 | Confirm skill listing | `review-plan` and `plan-review-guide` both appear, with no duplicate names |
+
+---
+
+### 4. End-to-End — Full Plan-Review Workflow
+
+**Objective:** Verify the proactive review fires and the protocol runs correctly.
+
+**Automation:** ⚠️ Manual — requires real plan mode usage.
+
+| # | Step | Expected |
+|---|------|----------|
+| 4.1 | Enter plan mode, ask for a non-trivial plan, accept it | Claude offers a fresh-context review before writing code |
+| 4.2 | Accept the review offer | Claude invokes `plan-review-guide`, spawns a `Task` subagent |
+| 4.3 | Inspect the subagent invocation | Subagent receives only the plan text — not the planning conversation |
+| 4.4 | Review the output | Findings are prioritized (CRITICAL/HIGH/MEDIUM/LOW); every finding has a concrete suggestion; output ends with a verdict |
+| 4.5 | Continue | Claude presents a revised plan before implementing |
+| 4.6 | Decline the review offer in a second run | Claude proceeds to implementation without nagging |
+| 4.7 | Run `/review-plan` with a pasted external plan | Review runs on the pasted plan |
+| 4.8 | Force a `RECONSIDER APPROACH` verdict (review a deliberately flawed plan) | Claude halts, surfaces the verdict, asks how to proceed — does not implement |

--- a/plugins/plan-review/hooks/hooks.json
+++ b/plugins/plan-review/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/inject-rules.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/plan-review/scripts/inject-rules.sh
+++ b/plugins/plan-review/scripts/inject-rules.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SessionStart hook: inject plan-review rules into Claude's context.
+# Makes Claude proactively offer a fresh-context review after plan mode
+# produces an implementation plan, before any code is written.
+# Silent on errors — never block session start.
+
+cat <<'RULES'
+## Plan Review — Base Rules
+
+MANDATORY: A plan produced in plan mode is reviewed by a fresh-context subagent before any code is written.
+
+- After `ExitPlanMode` is accepted (a plan was produced) → offer a fresh-context plan review BEFORE writing code: "Want a fresh-context review of this plan first?"
+- When the user accepts → invoke the `plan-review-guide` skill and follow its protocol exactly. NEVER review the plan yourself in the same context — your context is biased by having authored the plan.
+- When the user declines → proceed to implementation without nagging.
+- The reviewer subagent receives ONLY the plan text — never the planning conversation, rationale, or chat history. Independence is the point.
+- The review MUST produce, for the plan: (1) gaps, blind spots, and unclear points, (2) each finding tagged with a priority, (3) a concrete suggested change for EVERY finding — not just the top few.
+- After the review returns → revise the plan with the findings, show the user the revised plan, then implement.
+- Run `/review-plan` to review a plan manually — including a plan pasted from outside this session.
+- **ALWAYS invoke the `plan-review-guide` skill BEFORE running any plan review** to load the full review protocol and subagent prompt. This is MANDATORY — do not skip this step.
+RULES

--- a/plugins/plan-review/skills/plan-review-guide/SKILL.md
+++ b/plugins/plan-review/skills/plan-review-guide/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: plan-review-guide
+description: >
+  Invoked automatically before running a plan review to load the review protocol and subagent prompt.
+  Spawns a fresh-context subagent that critiques an implementation plan for gaps, blind spots, ordering
+  issues, and unclear points, prioritizes each finding, and suggests a concrete change for every one.
+  Do NOT review a plan in the planning context — it is biased by having authored the plan.
+  Keywords: plan review, review plan, plan mode, fresh context critique, blind spots, plan gaps.
+---
+
+# Plan Review Protocol
+
+Critique an implementation plan with a **fresh-context subagent** before any code is written. The
+value is independence: the reviewer has not seen the planning conversation, so it does not inherit
+its assumptions. This is the plan-and-review pattern — review surfaces intent-level errors *before*
+tokens are burned generating broken code.
+
+## When to run
+
+- A plan was just accepted via `ExitPlanMode` and the user agreed to a review.
+- The user ran `/review-plan` (the plan may be pasted from outside this session).
+
+If no plan is in context, ask the user to paste the plan to review.
+
+## Step 1 — Isolate the plan artifact
+
+Extract the plan text **only**. Do not pass the planning conversation, your rationale, file contents
+you explored, or chat history. The subagent must judge the plan on its own merits. If the plan
+references files, list their paths so the reviewer can read them itself with fresh eyes.
+
+## Step 2 — Spawn the reviewer subagent
+
+Use the `Task` tool. Default `subagent_type: Plan` (read-only, can inspect the codebase); use
+`general-purpose` if the plan needs broader tool access. Inherit the model — same model, fresh
+context is what matters. Pass this prompt, with `<PLAN>` replaced by the plan text:
+
+```
+You are reviewing an implementation plan written by another agent. You did NOT write it and have
+no stake in it. Be a skeptical senior reviewer. Read any files the plan references before judging.
+
+Find every gap, blind spot, unclear point, ordering problem, missing edge case, untested
+assumption, and unhandled failure mode in the plan below.
+
+For EVERY finding, output a row:
+  - Priority: CRITICAL (plan fails or causes damage) | HIGH (likely rework) | MEDIUM (quality
+    gap) | LOW (polish)
+  - Finding: what is wrong, missing, or ambiguous — one sentence.
+  - Suggestion: a concrete, specific change to the plan that resolves it. Not "consider X" —
+    state what the revised plan should say.
+
+Rules:
+- Produce a suggestion for EVERY finding. Do not stop after the top few. Exhaust the list.
+- If a step is ambiguous, say what it should specify, not just that it is vague.
+- If the plan is sound in some area, say so briefly — do not invent problems.
+- End with a one-line verdict: SHIP AS-IS | REVISE (minor) | REVISE (major) | RECONSIDER APPROACH.
+
+<PLAN>
+```
+
+## Step 3 — Apply the review
+
+When the subagent returns:
+
+1. Show the user the findings table verbatim — priority, finding, suggestion.
+2. Revise the plan: apply CRITICAL and HIGH suggestions; apply MEDIUM/LOW unless the user opts out.
+3. Present the **revised plan** and the verdict.
+4. If the verdict is `RECONSIDER APPROACH` → do not implement. Surface this prominently and ask the
+   user how to proceed.
+
+## Step 4 — Optional second pass
+
+For large or high-risk plans, offer one more round: feed the *revised* plan back through Step 2.
+Stop when a pass returns no CRITICAL or HIGH findings — do not loop indefinitely.
+
+Only after the plan is revised and accepted: proceed to implementation.
+
+## Anti-patterns
+
+- Reviewing the plan yourself in the planning context — you authored it, your judgment is biased.
+- Passing the planning chat history to the subagent — it then inherits the same blind spots.
+- Accepting only the top 2-3 findings — the per-finding suggestion step exists to exhaust the list.
+- Looping reviews forever — two passes is the practical ceiling.


### PR DESCRIPTION
## What

New `plan-review` plugin implementing the plan-and-review pattern: after plan mode produces an implementation plan, a **fresh-context subagent** critiques it for gaps, blind spots, ordering issues, and missing edge cases — before any code is written.

The pattern comes from the Matt Cary (Cloudflare) / Adam Stacoviak episode of The Changelog. Matt called it the single highest-leverage workflow change he's made: have one model plan, hand the plan to a second model invocation with fresh context, and have it surface intent-level errors before tokens are spent generating broken code.

## User-facing impact

Developers using plan mode get a second, unbiased pass over their plan automatically. The agent that wrote a plan cannot reliably review it — its context is anchored to the reasoning that produced it. A clean-context reviewer re-derives judgment from the plan artifact alone. Errors that would otherwise surface mid-implementation (or after) now surface before any code is written.

## How it works

| Component | Behavior |
|-----------|----------|
| SessionStart hook | Injects a proactive rule — Claude offers a fresh-context review after every accepted plan |
| `plan-review-guide` skill | The review protocol — spawns a `Task` subagent that receives **only the plan text** (not the planning conversation), returns prioritized findings (CRITICAL/HIGH/MEDIUM/LOW) each with a concrete suggested change, plus a verdict |
| `/review-plan` command | Manual review of any plan, including plans pasted from outside the session |

Three design points from the source episode are baked in:

1. **Fresh context, not the planning chat** — the subagent prompt forbids passing the planning conversation; independence is the point.
2. **Auto-prompt after planning** — the hook makes the review proactive, since the discipline matters most when tired.
3. **A suggestion for *every* finding** — the prompt explicitly says "do not stop after the top few; exhaust the list." This is the non-obvious step the episode flags: without it, only the top 2-3 issues get addressed.

A `RECONSIDER APPROACH` verdict halts implementation.

## Files

- New plugin under `plugins/plan-review/` — manifest (v0.1.0), hook, script, skill, command, README, `docs/ACCEPTANCE_TESTS.md`
- Registered in `.claude-plugin/marketplace.json`
- Root `README.md` and `CLAUDE.md` plugin lists updated (alphabetical)

## Testing

- ✅ Automated acceptance tests pass: static checks (file structure, JSON validity, distinct skill names, no dedup violation), `inject-rules.sh` output, marketplace registration
- ⚠️ Manual tests (Tests 3-4 in `ACCEPTANCE_TESTS.md`) require a fresh session and real plan mode usage — not run yet